### PR TITLE
direct invocation

### DIFF
--- a/src/main/java/baritone/api/event/GameEventHandler.java
+++ b/src/main/java/baritone/api/event/GameEventHandler.java
@@ -49,7 +49,6 @@ import org.lwjgl.input.Keyboard;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * @author Brady
@@ -61,12 +60,20 @@ public final class GameEventHandler implements IGameEventListener, Helper {
 
     @Override
     public final void onTick(TickEvent event) {
-        dispatch(listener -> listener.onTick(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onTick(event);
+            }
+        }
     }
 
     @Override
     public final void onPlayerUpdate(PlayerUpdateEvent event) {
-        dispatch(listener -> listener.onPlayerUpdate(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onPlayerUpdate(event);
+            }
+        }
     }
 
     @Override
@@ -86,12 +93,20 @@ public final class GameEventHandler implements IGameEventListener, Helper {
             }
         }
 
-        dispatch(IGameEventListener::onProcessKeyBinds);
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onProcessKeyBinds();
+            }
+        }
     }
 
     @Override
     public final void onSendChatMessage(ChatEvent event) {
-        dispatch(listener -> listener.onSendChatMessage(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onSendChatMessage(event);
+            }
+        }
     }
 
     @Override
@@ -117,18 +132,20 @@ public final class GameEventHandler implements IGameEventListener, Helper {
         }
 
 
-        dispatch(listener -> listener.onChunkEvent(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onChunkEvent(event);
+            }
+        }
     }
 
     @Override
     public final void onRenderPass(RenderEvent event) {
-        /*
-        WorldProvider.INSTANCE.ifWorldLoaded(world -> world.forEachRegion(region -> region.forEachChunk(chunk -> {
-            drawChunkLine(region.getX() * 512 + chunk.getX() * 16, region.getZ() * 512 + chunk.getZ() * 16, event.getPartialTicks());
-        })));
-        */
-
-        dispatch(listener -> listener.onRenderPass(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onRenderPass(event);
+            }
+        }
     }
 
     @Override
@@ -148,45 +165,69 @@ public final class GameEventHandler implements IGameEventListener, Helper {
                 break;
         }
 
-        dispatch(listener -> listener.onWorldEvent(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onWorldEvent(event);
+            }
+        }
     }
 
     @Override
     public final void onSendPacket(PacketEvent event) {
-        dispatch(listener -> listener.onSendPacket(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onSendPacket(event);
+            }
+        }
     }
 
     @Override
     public final void onReceivePacket(PacketEvent event) {
-        dispatch(listener -> listener.onReceivePacket(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onReceivePacket(event);
+            }
+        }
     }
 
     @Override
     public void onPlayerRelativeMove(RelativeMoveEvent event) {
-        dispatch(listener -> listener.onPlayerRelativeMove(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onPlayerRelativeMove(event);
+            }
+        }
     }
 
     @Override
     public void onBlockInteract(BlockInteractEvent event) {
-        dispatch(listener -> listener.onBlockInteract(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onBlockInteract(event);
+            }
+        }
     }
 
     @Override
     public void onPlayerDeath() {
-        dispatch(IGameEventListener::onPlayerDeath);
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onPlayerDeath();
+            }
+        }
     }
 
     @Override
     public void onPathEvent(PathEvent event) {
-        dispatch(listener -> listener.onPathEvent(event));
+        for (IGameEventListener l : listeners) {
+            if (canDispatch(l)) {
+                l.onPathEvent(event);
+            }
+        }
     }
 
     public final void registerEventListener(IGameEventListener listener) {
         this.listeners.add(listener);
-    }
-
-    private void dispatch(Consumer<IGameEventListener> dispatchFunction) {
-        this.listeners.stream().filter(this::canDispatch).forEach(dispatchFunction);
     }
 
     private boolean canDispatch(IGameEventListener listener) {


### PR DESCRIPTION
```
for (IGameEventListener l : listeners) {
            if (canDispatch(l)) {
                l.onRenderPass(event);
            }
        }
```

average: 9153 nanoseconds

```
dispatch(listener -> listener.onRenderPass(event));
...
 private void dispatch(Consumer<IGameEventListener> dispatchFunction) {
        this.listeners.forEach(listener -> {
            if (canDispatch(listener)) {
                dispatchFunction.accept(listener);
            }
        });
    }
```

average: 11541 nanoseconds

```
dispatch(listener -> listener.onRenderPass(event));
...
    private void dispatch(Consumer<IGameEventListener> dispatchFunction) {
        this.listeners.stream().filter(this::canDispatch).forEach(dispatchFunction);
    }
```

average: 15262 nanoseconds

Tested over the first 30 seconds of frames rendered after loading a world, like so:
<img width="676" alt="screen shot 2018-09-08 at 8 17 05 pm" src="https://user-images.githubusercontent.com/3837873/45260902-4ea34280-b3a8-11e8-953e-6c18ab445842.png">

<img width="487" alt="screen shot 2018-09-08 at 8 47 11 pm" src="https://user-images.githubusercontent.com/3837873/45260904-667ac680-b3a8-11e8-8068-9e44ad31536e.png">
