### PR TITLE
Add alias "forward" to "thisway"

### DIFF
--- a/src/main/java/baritone/utils/ExampleBaritoneControl.java
+++ b/src/main/java/baritone/utils/ExampleBaritoneControl.java
@@ -299,7 +299,7 @@ public class ExampleBaritoneControl extends Behavior implements Helper {
             logDirect("Started mining blocks of type " + Arrays.toString(blockTypes));
             return true;
         }
-        if (msg.startsWith("thisway")) {
+        if (msg.startsWith("thisway") || msg.equals("forward")) {
             try {
                 Goal goal = GoalXZ.fromDirection(playerFeetAsVec(), player().rotationYaw, Double.parseDouble(msg.substring(7).trim()));
                 pathingBehavior.setGoal(goal);

--- a/src/main/java/baritone/utils/ExampleBaritoneControl.java
+++ b/src/main/java/baritone/utils/ExampleBaritoneControl.java
@@ -299,7 +299,7 @@ public class ExampleBaritoneControl extends Behavior implements Helper {
             logDirect("Started mining blocks of type " + Arrays.toString(blockTypes));
             return true;
         }
-        if (msg.startsWith("thisway") || msg.equals("forward")) {
+        if (msg.matches("^(thisway|forward).*")) {
             try {
                 Goal goal = GoalXZ.fromDirection(playerFeetAsVec(), player().rotationYaw, Double.parseDouble(msg.substring(7).trim()));
                 pathingBehavior.setGoal(goal);


### PR DESCRIPTION
I can't for the life of me remember the command "thisway", I'm literally opening up an old youtube video on Baritone just to remember what command the recorder used.

I'll instinctual type `forward 100` (or `.b forward 100` in Impact's case) when I want Baritone to path forwards.