### PR TITLE
add a secondary failure cutoff

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -247,7 +247,9 @@ public class Settings {
     public Setting<Integer> movementTimeoutTicks = new Setting<>(100);
 
     /**
-     * Pathing ends after this amount of time, if a path has been found
+     * Pathing ends after this amount of time, but only if a path has been found
+     * <p>
+     * If no valid path (length above the minimum) has been found, pathing continues up until the failure timeout
      */
     public Setting<Long> primaryTimeoutMS = new Setting<>(500L);
 
@@ -257,7 +259,9 @@ public class Settings {
     public Setting<Long> failureTimeoutMS = new Setting<>(2000L);
 
     /**
-     * Planning ahead while executing a segment ends after this amount of time, if a path has been found
+     * Planning ahead while executing a segment ends after this amount of time, but only if a path has been found
+     * <p>
+     * If no valid path (length above the minimum) has been found, pathing continues up until the failure timeout
      */
     public Setting<Long> planAheadPrimaryTimeoutMS = new Setting<>(4000L);
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -247,14 +247,24 @@ public class Settings {
     public Setting<Integer> movementTimeoutTicks = new Setting<>(100);
 
     /**
-     * Pathing can never take longer than this
+     * Pathing ends after this amount of time, if a path has been found
      */
-    public Setting<Long> pathTimeoutMS = new Setting<>(2000L);
+    public Setting<Long> primaryTimeoutMS = new Setting<>(500L);
 
     /**
-     * Planning ahead while executing a segment can never take longer than this
+     * Pathing can never take longer than this, even if that means failing to find any path at all
      */
-    public Setting<Long> planAheadTimeoutMS = new Setting<>(4000L);
+    public Setting<Long> failureTimeoutMS = new Setting<>(2000L);
+
+    /**
+     * Planning ahead while executing a segment ends after this amount of time, if a path has been found
+     */
+    public Setting<Long> planAheadPrimaryTimeoutMS = new Setting<>(4000L);
+
+    /**
+     * Planning ahead while executing a segment can never take longer than this, even if that means failing to find any path at all
+     */
+    public Setting<Long> planAheadFailureTimeoutMS = new Setting<>(5000L);
 
     /**
      * For debugging, consider nodes much much slower

--- a/src/api/java/baritone/api/pathing/calc/IPathFinder.java
+++ b/src/api/java/baritone/api/pathing/calc/IPathFinder.java
@@ -36,7 +36,7 @@ public interface IPathFinder {
      *
      * @return The final path
      */
-    PathCalculationResult calculate(long timeout);
+    PathCalculationResult calculate(long primaryTimeout, long failureTimeout);
 
     /**
      * Intended to be called concurrently with calculatePath from a different thread to tell if it's finished yet

--- a/src/main/java/baritone/pathing/calc/AStarPathFinder.java
+++ b/src/main/java/baritone/pathing/calc/AStarPathFinder.java
@@ -85,9 +85,6 @@ public final class AStarPathFinder extends AbstractNodeCostSearch implements Hel
             if (now - failureTimeoutTime >= 0 || (!failing && now - primaryTimeoutTime >= 0)) {
                 break;
             }
-            if (failing == bestPathSoFar().isPresent()) {
-                throw new IllegalStateException();
-            }
             if (slowPath) {
                 try {
                     Thread.sleep(Baritone.settings().slowPathTimeDelayMS.<Long>get());

--- a/src/main/java/baritone/pathing/calc/AStarPathFinder.java
+++ b/src/main/java/baritone/pathing/calc/AStarPathFinder.java
@@ -49,7 +49,7 @@ public final class AStarPathFinder extends AbstractNodeCostSearch implements Hel
     }
 
     @Override
-    protected Optional<IPath> calculate0(long timeout) {
+    protected Optional<IPath> calculate0(long primaryTimeout, long failureTimeout) {
         startNode = getNodeAtPosition(startX, startY, startZ, BetterBlockPos.longHash(startX, startY, startZ));
         startNode.cost = 0;
         startNode.combinedCost = startNode.estimatedCostToGoal;
@@ -68,10 +68,11 @@ public final class AStarPathFinder extends AbstractNodeCostSearch implements Hel
         long startTime = System.nanoTime() / 1000000L;
         boolean slowPath = Baritone.settings().slowPath.get();
         if (slowPath) {
-            logDebug("slowPath is on, path timeout will be " + Baritone.settings().slowPathTimeoutMS.<Long>get() + "ms instead of " + timeout + "ms");
+            logDebug("slowPath is on, path timeout will be " + Baritone.settings().slowPathTimeoutMS.<Long>get() + "ms instead of " + primaryTimeout + "ms");
         }
-        long timeoutTime = startTime + (slowPath ? Baritone.settings().slowPathTimeoutMS.<Long>get() : timeout);
-        //long lastPrintout = 0;
+        long primaryTimeoutTime = startTime + (slowPath ? Baritone.settings().slowPathTimeoutMS.<Long>get() : primaryTimeout);
+        long failureTimeoutTime = startTime + (slowPath ? Baritone.settings().slowPathTimeoutMS.<Long>get() : failureTimeout);
+        boolean failing = true;
         int numNodes = 0;
         int numMovementsConsidered = 0;
         int numEmptyChunk = 0;
@@ -79,7 +80,14 @@ public final class AStarPathFinder extends AbstractNodeCostSearch implements Hel
         int pathingMaxChunkBorderFetch = Baritone.settings().pathingMaxChunkBorderFetch.get(); // grab all settings beforehand so that changing settings during pathing doesn't cause a crash or unpredictable behavior
         double favorCoeff = Baritone.settings().backtrackCostFavoringCoefficient.get();
         boolean minimumImprovementRepropagation = Baritone.settings().minimumImprovementRepropagation.get();
-        while (!openSet.isEmpty() && numEmptyChunk < pathingMaxChunkBorderFetch && System.nanoTime() / 1000000L - timeoutTime < 0 && !cancelRequested) {
+        while (!openSet.isEmpty() && numEmptyChunk < pathingMaxChunkBorderFetch && !cancelRequested) {
+            long now = System.nanoTime() / 1000000L;
+            if (now - failureTimeoutTime >= 0 || (!failing && now - primaryTimeoutTime >= 0)) {
+                break;
+            }
+            if (failing == bestPathSoFar().isPresent()) {
+                throw new IllegalStateException();
+            }
             if (slowPath) {
                 try {
                     Thread.sleep(Baritone.settings().slowPathTimeDelayMS.<Long>get());
@@ -166,6 +174,9 @@ public final class AStarPathFinder extends AbstractNodeCostSearch implements Hel
                             }
                             bestHeuristicSoFar[i] = heuristic;
                             bestSoFar[i] = neighbor;
+                            if (getDistFromStartSq(neighbor) > MIN_DIST_PATH * MIN_DIST_PATH) {
+                                failing = false;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Unintentionally fixes #262 I have no idea why.

Anyway this adds a secondary cutoff. 

If you tell it to path, it will start executing after 500ms if it's found a path, but can continue calculating up to 2000ms if there is no valid (long enough) path found. Same goes for planning ahead, with 4000ms and 5000ms. This helps it get started as fast as possible, without compromising on its ability to find paths in really tricky situations that require lots of backtracking.