### PR TITLE
Add parkour ascend

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -125,6 +125,13 @@ public final class Settings {
     public final Setting<Boolean> allowJumpAt256 = new Setting<>(false);
 
     /**
+     * This should be monetized it's so good
+     * <p>
+     * Defaults to true, but only actually takes effect if allowParkour is also true
+     */
+    public final Setting<Boolean> allowParkourAscend = new Setting<>(true);
+
+    /**
      * Allow descending diagonally
      * <p>
      * Safer than allowParkour yet still slightly unsafe, can make contact with unchecked adjacent blocks, so it's unsafe in the nether.

--- a/src/main/java/baritone/pathing/calc/AbstractNodeCostSearch.java
+++ b/src/main/java/baritone/pathing/calc/AbstractNodeCostSearch.java
@@ -127,7 +127,7 @@ public abstract class AbstractNodeCostSearch implements IPathFinder, Helper {
                 return new PathCalculationResult(PathCalculationResult.Type.SUCCESS_SEGMENT, path);
             }
         } catch (Exception e) {
-            Helper.HELPER.logDebug("Pathing exception: " + e);
+            Helper.HELPER.logDirect("Pathing exception: " + e);
             e.printStackTrace();
             return new PathCalculationResult(PathCalculationResult.Type.EXCEPTION);
         } finally {

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -58,6 +58,7 @@ public class CalculationContext {
     public final boolean allowParkour;
     public final boolean allowParkourPlace;
     public final boolean allowJumpAt256;
+    public final boolean allowParkourAscend;
     public final boolean assumeWalkOnWater;
     public final boolean allowDiagonalDescend;
     public final boolean allowDownward;
@@ -90,6 +91,7 @@ public class CalculationContext {
         this.allowParkour = Baritone.settings().allowParkour.value;
         this.allowParkourPlace = Baritone.settings().allowParkourPlace.value;
         this.allowJumpAt256 = Baritone.settings().allowJumpAt256.value;
+        this.allowParkourAscend = Baritone.settings().allowParkourAscend.value;
         this.assumeWalkOnWater = Baritone.settings().assumeWalkOnWater.value;
         this.allowDiagonalDescend = Baritone.settings().allowDiagonalDescend.value;
         this.allowDownward = Baritone.settings().allowDownward.value;

--- a/src/main/java/baritone/pathing/movement/Moves.java
+++ b/src/main/java/baritone/pathing/movement/Moves.java
@@ -276,7 +276,7 @@ public enum Moves {
         }
     },
 
-    PARKOUR_NORTH(0, 0, -4, true, false) {
+    PARKOUR_NORTH(0, 0, -4, true, true) {
         @Override
         public Movement apply0(CalculationContext context, BetterBlockPos src) {
             return MovementParkour.cost(context, src, EnumFacing.NORTH);
@@ -288,7 +288,7 @@ public enum Moves {
         }
     },
 
-    PARKOUR_SOUTH(0, 0, +4, true, false) {
+    PARKOUR_SOUTH(0, 0, +4, true, true) {
         @Override
         public Movement apply0(CalculationContext context, BetterBlockPos src) {
             return MovementParkour.cost(context, src, EnumFacing.SOUTH);
@@ -300,7 +300,7 @@ public enum Moves {
         }
     },
 
-    PARKOUR_EAST(+4, 0, 0, true, false) {
+    PARKOUR_EAST(+4, 0, 0, true, true) {
         @Override
         public Movement apply0(CalculationContext context, BetterBlockPos src) {
             return MovementParkour.cost(context, src, EnumFacing.EAST);
@@ -312,7 +312,7 @@ public enum Moves {
         }
     },
 
-    PARKOUR_WEST(-4, 0, 0, true, false) {
+    PARKOUR_WEST(-4, 0, 0, true, true) {
         @Override
         public Movement apply0(CalculationContext context, BetterBlockPos src) {
             return MovementParkour.cost(context, src, EnumFacing.WEST);

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -43,18 +43,20 @@ public class MovementParkour extends Movement {
 
     private final EnumFacing direction;
     private final int dist;
+    private final boolean ascend;
 
-    private MovementParkour(IBaritone baritone, BetterBlockPos src, int dist, EnumFacing dir) {
-        super(baritone, src, src.offset(dir, dist), EMPTY, src.offset(dir, dist).down());
+    private MovementParkour(IBaritone baritone, BetterBlockPos src, int dist, EnumFacing dir, boolean ascend) {
+        super(baritone, src, src.offset(dir, dist).up(ascend ? 1 : 0), EMPTY, src.offset(dir, dist).down(ascend ? 0 : 1));
         this.direction = dir;
         this.dist = dist;
+        this.ascend = ascend;
     }
 
     public static MovementParkour cost(CalculationContext context, BetterBlockPos src, EnumFacing direction) {
         MutableMoveResult res = new MutableMoveResult();
         cost(context, src.x, src.y, src.z, direction, res);
         int dist = Math.abs(res.x - src.x) + Math.abs(res.z - src.z);
-        return new MovementParkour(context.getBaritone(), src, dist, direction);
+        return new MovementParkour(context.getBaritone(), src, dist, direction, res.y != src.y);
     }
 
     public static void cost(CalculationContext context, int x, int y, int z, EnumFacing dir, MutableMoveResult res) {
@@ -103,19 +105,35 @@ public class MovementParkour extends Movement {
             }
         }
         for (int i = 2; i <= maxJump; i++) {
-            // TODO perhaps dest.up(3) doesn't need to be fullyPassable, just canWalkThrough, possibly?
-            for (int y2 = 0; y2 < 4; y2++) {
-                if (!MovementHelper.fullyPassable(context, x + xDiff * i, y + y2, z + zDiff * i)) {
-                    return;
-                }
+            int destX = x + xDiff * i;
+            int destZ = z + zDiff * i;
+            if (!MovementHelper.fullyPassable(context, destX, y + 1, destZ)) {
+                return;
             }
-            IBlockState landingOn = context.bsi.get0(x + xDiff * i, y - 1, z + zDiff * i);
+            if (!MovementHelper.fullyPassable(context, destX, y + 2, destZ)) {
+                return;
+            }
+            if (!MovementHelper.fullyPassable(context, destX, y, destZ)) {
+                if (i <= 3 && context.allowParkourAscend && context.canSprint && MovementHelper.canWalkOn(context.bsi, destX, y, destZ) && checkOvershootSafety(context.bsi, destX + xDiff, y + 1, destZ + zDiff)) {
+                    res.x = destX;
+                    res.y = y + 1;
+                    res.z = destZ;
+                    res.cost = costFromJumpDistance(i) + context.jumpPenalty;
+                }
+                return;
+            }
+            IBlockState landingOn = context.bsi.get0(destX, y - 1, destZ);
             // farmland needs to be canwalkon otherwise farm can never work at all, but we want to specifically disallow ending a jumy on farmland haha
-            if (landingOn.getBlock() != Blocks.FARMLAND && MovementHelper.canWalkOn(context.bsi, x + xDiff * i, y - 1, z + zDiff * i, landingOn)) {
-                res.x = x + xDiff * i;
-                res.y = y;
-                res.z = z + zDiff * i;
-                res.cost = costFromJumpDistance(i) + context.jumpPenalty;
+            if (landingOn.getBlock() != Blocks.FARMLAND && MovementHelper.canWalkOn(context.bsi, destX, y - 1, destZ, landingOn)) {
+                if (checkOvershootSafety(context.bsi, destX + xDiff, y, destZ + zDiff)) {
+                    res.x = destX;
+                    res.y = y;
+                    res.z = destZ;
+                    res.cost = costFromJumpDistance(i) + context.jumpPenalty;
+                }
+                return;
+            }
+            if (!MovementHelper.fullyPassable(context, destX, y + 3, destZ)) {
                 return;
             }
         }
@@ -136,6 +154,9 @@ public class MovementParkour extends Movement {
         if (!MovementHelper.isReplacable(destX, y - 1, destZ, toReplace, context.bsi)) {
             return;
         }
+        if (!checkOvershootSafety(context.bsi, destX + xDiff, y, destZ + zDiff)) {
+            return;
+        }
         for (int i = 0; i < 5; i++) {
             int againstX = destX + HORIZONTALS_BUT_ALSO_DOWN_____SO_EVERY_DIRECTION_EXCEPT_UP[i].getXOffset();
             int againstY = y - 1 + HORIZONTALS_BUT_ALSO_DOWN_____SO_EVERY_DIRECTION_EXCEPT_UP[i].getYOffset();
@@ -151,6 +172,11 @@ public class MovementParkour extends Movement {
                 return;
             }
         }
+    }
+
+    private static boolean checkOvershootSafety(BlockStateInterface bsi, int x, int y, int z) {
+        // we're going to walk into these two blocks after the landing of the parkour anyway, so make sure they aren't avoidWalkingInto
+        return !MovementHelper.avoidWalkingInto(bsi.get0(x, y, z).getBlock()) && !MovementHelper.avoidWalkingInto(bsi.get0(x, y + 1, z).getBlock());
     }
 
     private static double costFromJumpDistance(int dist) {
@@ -211,7 +237,7 @@ public class MovementParkour extends Movement {
             logDebug("sorry");
             return state.setStatus(MovementStatus.UNREACHABLE);
         }
-        if (dist >= 4) {
+        if (dist >= 4 || ascend) {
             state.setInput(Input.SPRINT, true);
         }
         MovementHelper.moveTowards(ctx, state, dest);
@@ -231,7 +257,7 @@ public class MovementParkour extends Movement {
                     // go in the opposite order to check DOWN before all horizontals -- down is preferable because you don't have to look to the side while in midair, which could mess up the trajectory
                     state.setInput(Input.CLICK_RIGHT, true);
                 }
-                if (dist == 3) { // this is a 2 block gap, dest = src + direction * 3
+                if (dist == 3 && !ascend) { // this is a 2 block gap, dest = src + direction * 3
                     double xDiff = (src.x + 0.5) - ctx.player().posX;
                     double zDiff = (src.z + 0.5) - ctx.player().posZ;
                     double distFromStart = Math.max(Math.abs(xDiff), Math.abs(zDiff));

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -56,7 +56,7 @@ public class MovementParkour extends Movement {
         MutableMoveResult res = new MutableMoveResult();
         cost(context, src.x, src.y, src.z, direction, res);
         int dist = Math.abs(res.x - src.x) + Math.abs(res.z - src.z);
-        return new MovementParkour(context.getBaritone(), src, dist, direction, res.y != src.y);
+        return new MovementParkour(context.getBaritone(), src, dist, direction, res.y > src.y);
     }
 
     public static void cost(CalculationContext context, int x, int y, int z, EnumFacing dir, MutableMoveResult res) {
@@ -118,7 +118,7 @@ public class MovementParkour extends Movement {
                     res.x = destX;
                     res.y = y + 1;
                     res.z = destZ;
-                    res.cost = costFromJumpDistance(i) + context.jumpPenalty;
+                    res.cost = i * SPRINT_ONE_BLOCK_COST + context.jumpPenalty;
                 }
                 return;
             }
@@ -257,6 +257,7 @@ public class MovementParkour extends Movement {
                     // go in the opposite order to check DOWN before all horizontals -- down is preferable because you don't have to look to the side while in midair, which could mess up the trajectory
                     state.setInput(Input.CLICK_RIGHT, true);
                 }
+                // prevent jumping too late by checking for ascend
                 if (dist == 3 && !ascend) { // this is a 2 block gap, dest = src + direction * 3
                     double xDiff = (src.x + 0.5) - ctx.player().posX;
                     double zDiff = (src.z + 0.5) - ctx.player().posZ;


### PR DESCRIPTION
I made a promise to BluSpectrum in issue #650 that I would do what many (such as @0-x-2-2) thought to be impossible - allow Baritone to do upwards parkour jump to ascend

Since a parkour ascend and a parkour can never be possible in the same cardinal direction from the same origin, I opted to make the existing `MovementParkour dynamicY`. This purely adds new movement options, no previously valid `MovementParkour` is now invalid in favor of an ascend. As a part of this constraint, no ascend parkour place exists. This is because it's ambiguous if a parkour place or an ascend parkour place should be prioritized. For the same reason that parkour place only runs over a gap of 3, parkour place does not ascend.

BluSpectrum, I hope this helps you find happiness. 🤙 