### PR TITLE
[New fork, same content] Custom tunneling

### DIFF
--- a/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
+++ b/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
@@ -38,6 +38,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ReportedException;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
@@ -366,6 +367,74 @@ public class ExampleBaritoneControl implements Helper, AbstractGameEventListener
         if (msg.equals("tunnel")) {
             customGoalProcess.setGoalAndPath(new GoalStrictDirection(ctx.playerFeet(), ctx.player().getHorizontalFacing()));
             logDirect("tunneling");
+            return true;
+        }
+        if (msg.startsWith("tunnelcustom")) {
+            String suffix = msg.substring("tunnelcustom".length());
+            int a;
+            int b;
+            int c;
+            if (suffix.isEmpty()) {
+                logDirect("Need to specify depth, height and width of the tunnel. eg #tunnelcustom depth height width");
+                return true;
+            } else {
+                try {
+                    String[] spl = suffix.split(" ");
+                    if(spl.length != 4) {
+                        logDirect(Integer.toString(spl.length));
+                        logDirect("Please enter 3 values");
+                        return true;
+                    }
+                    a = Integer.parseInt(spl[1]);
+                    b = Integer.parseInt(spl[2]);
+                    c = Integer.parseInt(spl[3]);
+                } catch (NumberFormatException | ArrayIndexOutOfBoundsException | NullPointerException ex) {
+                    logDirect("One or more number arguments were invalid");
+                    return true;
+                }
+            }
+            if (c < 1) {
+                logDirect("Width must at least be 1 block");
+                return true;
+            }
+            if (b < 2) {
+                logDirect("Height must at least be 2 blocks");
+                return true;
+            }
+            //Adjustment for player location
+            a--;
+            b--;
+            c--;
+            BlockPos corner1;
+            BlockPos corner2;
+            EnumFacing enumfacing = ctx.player().getHorizontalFacing();
+            int addition = 1;
+            //Check if width is uneven to center player's location
+            if (c % 2 == 0) {
+                addition = 0;
+            }
+            switch(enumfacing) {
+                case EAST:
+                    corner1 = new BlockPos(ctx.playerFeet().x, ctx.playerFeet().y, ctx.playerFeet().z - c / 2);
+                    corner2 = new BlockPos(ctx.playerFeet().x + a, ctx.playerFeet().y + b, ctx.playerFeet().z + c / 2 + addition);
+                    break;
+                case WEST:
+                    corner1 = new BlockPos(ctx.playerFeet().x, ctx.playerFeet().y, ctx.playerFeet().z + c / 2 + addition);
+                    corner2 = new BlockPos(ctx.playerFeet().x - a, ctx.playerFeet().y + b, ctx.playerFeet().z - c / 2 );
+                    break;
+                case NORTH:
+                    corner1 = new BlockPos(ctx.playerFeet().x - c / 2, ctx.playerFeet().y, ctx.playerFeet().z);
+                    corner2 = new BlockPos(ctx.playerFeet().x + c / 2 + addition, ctx.playerFeet().y + b, ctx.playerFeet().z - a);
+                    break;
+                case SOUTH:
+                    corner1 = new BlockPos(ctx.playerFeet().x + c / 2 + addition, ctx.playerFeet().y, ctx.playerFeet().z);
+                    corner2 = new BlockPos(ctx.playerFeet().x - c / 2, ctx.playerFeet().y + b, ctx.playerFeet().z + a);
+                    break;
+                default:
+                    logDirect("How did you get here?");
+                    return true;
+            }
+            baritone.getBuilderProcess().clearArea(corner1, corner2);
             return true;
         }
         if (msg.equals("render")) {


### PR DESCRIPTION
Allows for custom tunnelling specified by given parameters.
The player location is the middle of the tunnel if possible (3 = uneven, possible: 4 = even, not possible, otherwise it'll stray to the right one block)
Example: https://dl.dropboxusercontent.com/s/yxya9u6nlyipzcy/2019-08-03_20-42-46.mp4

The current tunneling feature only supports a 2x1 area, this can support and width, height and depth in any of the 4 directions (north,east,south,west).

New PR because my whole fork was scuffed for some reason. (Also less statpadding, just for you BadDev).

Solves #319 and #474 
