### PR TITLE
Stop parseGoal from removing the last argument (when it shouldn't)

### DIFF
--- a/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
+++ b/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
@@ -50,7 +50,7 @@ import net.minecraft.world.chunk.Chunk;
 import java.nio.file.Path;
 import java.util.*;
 
-import static org.apache.commons.lang3.StringUtils.isNumeric;
+import static org.apache.commons.lang3.math.NumberUtils.isCreatable;
 
 public class ExampleBaritoneControl implements Helper, AbstractGameEventListener {
     private static final String COMMAND_PREFIX = "#";
@@ -694,7 +694,7 @@ public class ExampleBaritoneControl implements Helper, AbstractGameEventListener
             BetterBlockPos playerFeet = ctx.playerFeet();
 
             int length = params.length - 1; // length has to be smaller when a dimension parameter is added
-            if (params.length < 1 || (isNumeric(params[params.length - 1]) || params[params.length - 1].startsWith("~"))) {
+            if (params.length < 1 || (isCreatable(params[params.length - 1]) || params[params.length - 1].startsWith("~"))) {
                 length = params.length;
             }
             switch (length) {


### PR DESCRIPTION
This fixes #782. Using #goto -100 -100 for example would send you to y=-100 rather than x=-100 z=-100. 

isNumeric returns false if the input is anything other than a positive integer. This meant that parseGoal wasn't correctly parsing goals that ended in 'impure' numbers (negatives, decimals, etc.). Replacing isNumeric with isCreatable fixes this

<!-- No UwU's or OwO's allowed -->
