### PR TITLE
added things to avoid

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -172,7 +172,9 @@ public final class Settings {
             Blocks.FURNACE,
             Blocks.LIT_FURNACE,
             Blocks.CHEST,
-            Blocks.TRAPPED_CHEST
+            Blocks.TRAPPED_CHEST,
+            Blocks.STANDING_SIGN,
+            Blocks.WALL_SIGN
     )));
 
     /**


### PR DESCRIPTION
Signs should also be avoided. A lot of history can get lost

Actually, before that gets merged, let me also add, hoppes along with other containers and restone things. Like restone itself and doors eg. maybe glass also?

<!-- No UwU's or OwO's allowed -->
