### PR TITLE
Enhanced mine command

### DIFF
--- a/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
+++ b/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
@@ -524,23 +524,22 @@ public class ExampleBaritoneControl implements Helper, AbstractGameEventListener
 
             for (int i = 0; i < blockTypes.length; i++) {
                 String s = blockTypes[i];
+
+                s = BlockUtils.stringToBlockNullable(s) == null // Is it not already a block?
+                    ? aliases.get(s) != null // Check if it's an alias
+                        ? aliases.get(s) // If is an alias just set it to that
+                        : s.endsWith("s") // Else is it plural?
+                            ? aliases.get(s.substring(0, s.length() - 1)) != null // Is it a plural alias?
+                                ? aliases.get(s.substring(0, s.length() - 1)) // If it's a plural alias set it to that
+                                : s.substring(0, s.length() - 1) // If just plural set it to that
+                            : s // Otherwise, don't change it
+                    : s; // Otherwise, don't change it
+
+                blockTypes[i] = s;
+
                 if (BlockUtils.stringToBlockNullable(s) == null) {
-                    if (s.endsWith("s")) {
-                        s = s.substring(0, s.length() - 1);
-                        blockTypes[i] = s;
-                    }
-
-                    String alias = aliases.get(s);
-
-                    if (alias != null) {
-                        s = alias;
-                        blockTypes[i] = s;
-                    }
-
-                    if (BlockUtils.stringToBlockNullable(s) == null) {
-                        logDirect(s + " isn't a valid block name");
-                        return true;
-                    }
+                    logDirect(s + " isn't a valid block name");
+                    return true;
                 }
 
             }

--- a/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
+++ b/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
@@ -511,10 +511,18 @@ public class ExampleBaritoneControl implements Helper, AbstractGameEventListener
                 logDirect("Will mine " + quantity + " " + blockTypes[0]);
                 return true;
             } catch (NumberFormatException | ArrayIndexOutOfBoundsException | NullPointerException ex) {}
-            for (String s : blockTypes) {
+            for (int i = 0; i < blockTypes.length; i++) {
+                String s = blockTypes[i];
                 if (BlockUtils.stringToBlockNullable(s) == null) {
-                    logDirect(s + " isn't a valid block name");
-                    return true;
+                    if (s.endsWith("s")) {
+                        s = s.substring(0, s.length() - 1);
+                        blockTypes[i] = s;
+                    }
+
+                    if (BlockUtils.stringToBlockNullable(s) == null) {
+                        logDirect(s + " isn't a valid block name");
+                        return true;
+                    }
                 }
 
             }

--- a/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
+++ b/src/api/java/baritone/api/utils/ExampleBaritoneControl.java
@@ -511,11 +511,29 @@ public class ExampleBaritoneControl implements Helper, AbstractGameEventListener
                 logDirect("Will mine " + quantity + " " + blockTypes[0]);
                 return true;
             } catch (NumberFormatException | ArrayIndexOutOfBoundsException | NullPointerException ex) {}
+
+            Map<String, String> aliases = new HashMap(); // This should definitely be in a setting i'm just too dumb for that
+            aliases.put("diamond", "diamond_ore");
+            aliases.put("iron", "iron_ore");
+            aliases.put("coal", "coal_ore");
+            aliases.put("lapis", "lapis_ore");
+            aliases.put("gold", "gold_ore");
+            aliases.put("redstone", "redstone_ore");
+            aliases.put("emerald", "emerald_ore");
+            aliases.put("quartz", "quartz_ore");
+
             for (int i = 0; i < blockTypes.length; i++) {
                 String s = blockTypes[i];
                 if (BlockUtils.stringToBlockNullable(s) == null) {
                     if (s.endsWith("s")) {
                         s = s.substring(0, s.length() - 1);
+                        blockTypes[i] = s;
+                    }
+
+                    String alias = aliases.get(s);
+
+                    if (alias != null) {
+                        s = alias;
                         blockTypes[i] = s;
                     }
 


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->

* Added an alias map, that allows you to use shorthand for certain blocks (e.x. "diamond" -> "diamond_ore"). Currently just has ores.
* Blocks / aliases can be typed with a tailing s, which will be ignored (e.x "logs" -> "log"). This does not affect things that should have a tailing s like glass, nor aliases with tailing s's.

Resolves #816