### PR TITLE
Replace BlockPos with BetterBlockPos in BuilderProcess API to avoid…

### DIFF
--- a/src/api/java/baritone/api/process/IBuilderProcess.java
+++ b/src/api/java/baritone/api/process/IBuilderProcess.java
@@ -17,6 +17,7 @@
 
 package baritone.api.process;
 
+import baritone.api.utils.BetterBlockPos;
 import baritone.api.utils.ISchematic;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -49,9 +50,9 @@ public interface IBuilderProcess extends IBaritoneProcess {
      * @param origin    The origin position of the schematic being built
      * @return Whether or not the schematic was able to load from file
      */
-    boolean build(String name, File schematic, Vec3i origin);
+    boolean build(String name, File schematic, BetterBlockPos origin);
 
-    default boolean build(String schematicFile, BlockPos origin) {
+    default boolean build(String schematicFile, BetterBlockPos origin) {
         File file = new File(new File(Minecraft.getMinecraft().gameDir, "schematics"), schematicFile);
         return build(schematicFile, file, origin);
     }

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -111,7 +111,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
     }
 
     @Override
-    public boolean build(String name, File schematic, Vec3i origin) {
+    public boolean build(String name, File schematic, BetterBlockPos origin) {
         NBTTagCompound tag;
         try (FileInputStream fileIn = new FileInputStream(schematic)) {
             tag = CompressedStreamTools.readCompressed(fileIn);


### PR DESCRIPTION
Obfuscating the origin method parameter.

e.g. calling via the API:

> boolean success = BaritoneAPI.getProvider().getPrimaryBaritone().getBuilderProcess().build(file, origin);

From a different mod

<!-- No UwU's or OwO's allowed -->
