### PR TITLE
Add currentgoal command

### DIFF
--- a/src/main/java/baritone/command/defaults/CurrentGoalCommand.java
+++ b/src/main/java/baritone/command/defaults/CurrentGoalCommand.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.api.IBaritone;
+import baritone.api.pathing.goals.Goal;
+import baritone.api.process.ICustomGoalProcess;
+import baritone.api.command.Command;
+import baritone.api.command.exception.CommandException;
+import baritone.api.command.argument.IArgConsumer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class CurrentGoalCommand extends Command {
+
+    public CurrentGoalCommand(IBaritone baritone) {
+        super(baritone, "currentgoal");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        args.requireMax(0);
+        ICustomGoalProcess customGoalProcess = baritone.getCustomGoalProcess();
+        Goal currentGoal = customGoalProcess.getGoal();
+        if (currentGoal != null)
+            logDirect(String.format("Goal: %s", customGoalProcess.getGoal().toString()));
+        else
+            logDirect("No current goal.");
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) {
+        return Stream.empty();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Outputs the current goal.";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "CurrentGoal outputs the position of the goal.",
+                "",
+                "Usage:",
+                "> currentgoal"
+        );
+    }
+}

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -64,7 +64,8 @@ public final class DefaultCommands {
             new WaypointsCommand(baritone),
             new CommandAlias(baritone, "sethome", "Sets your home waypoint", "waypoints save home"),
             new CommandAlias(baritone, "home", "Set goal to your home waypoint", "waypoints goal home"),
-            new SelCommand(baritone)
+            new SelCommand(baritone),
+            new CurrentGoalCommand(baritone)
         ));
         PauseResumeCommands prc = new PauseResumeCommands(baritone);
         commands.add(prc.pauseCommand);


### PR DESCRIPTION
Allows the user to know which the exact goal the baritone client is heading to, if any. 
<!-- No UwU's or OwO's allowed -->
