### PR TITLE
Remove error message when running goto with less than 3 args

### DIFF
--- a/src/api/java/baritone/api/command/datatypes/RelativeGoal.java
+++ b/src/api/java/baritone/api/command/datatypes/RelativeGoal.java
@@ -38,38 +38,26 @@ public enum RelativeGoal implements IDatatypePost<Goal, BetterBlockPos> {
         if (origin == null) {
             origin = BetterBlockPos.ORIGIN;
         }
+
         final IArgConsumer consumer = ctx.getConsumer();
 
-        List<IDatatypePostFunction<Double, Double>> coords = new ArrayList<>();
-        final IArgConsumer copy = consumer.copy(); // This is a hack and should be fixed in the future probably
-        for (int i = 0; i < 3; i++) {
-            if (copy.peekDatatypeOrNull(RelativeCoordinate.INSTANCE) != null) {
-                coords.add(o -> consumer.getDatatypePost(RelativeCoordinate.INSTANCE, o));
-                copy.get(); // Consume so we actually decrement the remaining arguments
-            }
+        GoalBlock goalBlock = consumer.peekDatatypePostOrNull(RelativeGoalBlock.INSTANCE, origin);
+        if (goalBlock != null) {
+            return goalBlock;
         }
 
-        switch (coords.size()) {
-            case 0:
-                return new GoalBlock(origin);
-            case 1:
-                return new GoalYLevel(
-                        MathHelper.floor(coords.get(0).apply((double) origin.y))
-                );
-            case 2:
-                return new GoalXZ(
-                        MathHelper.floor(coords.get(0).apply((double) origin.x)),
-                        MathHelper.floor(coords.get(1).apply((double) origin.z))
-                );
-            case 3:
-                return new GoalBlock(
-                        MathHelper.floor(coords.get(0).apply((double) origin.x)),
-                        MathHelper.floor(coords.get(1).apply((double) origin.y)),
-                        MathHelper.floor(coords.get(2).apply((double) origin.z))
-                );
-            default:
-                throw new IllegalStateException("Unexpected coords size: " + coords.size());
+        GoalXZ goalXZ = consumer.peekDatatypePostOrNull(RelativeGoalXZ.INSTANCE, origin);
+        if (goalXZ != null) {
+            return goalXZ;
         }
+
+        GoalYLevel goalYLevel = consumer.peekDatatypePostOrNull(RelativeGoalYLevel.INSTANCE, origin);
+        if (goalYLevel != null) {
+            return goalYLevel;
+        }
+
+        // when the user doesn't input anything, default to the origin
+        return new GoalBlock(origin);
     }
 
     @Override

--- a/src/api/java/baritone/api/command/exception/CommandErrorMessageException.java
+++ b/src/api/java/baritone/api/command/exception/CommandErrorMessageException.java
@@ -22,4 +22,8 @@ public abstract class CommandErrorMessageException extends CommandException {
     protected CommandErrorMessageException(String reason) {
         super(reason);
     }
+
+    protected CommandErrorMessageException(String reason, Throwable cause) {
+        super(reason, cause);
+    }
 }

--- a/src/api/java/baritone/api/command/exception/CommandException.java
+++ b/src/api/java/baritone/api/command/exception/CommandException.java
@@ -22,4 +22,8 @@ public abstract class CommandException extends Exception implements ICommandExce
     protected CommandException(String reason) {
         super(reason);
     }
+
+    protected CommandException(String reason, Throwable cause) {
+        super(reason, cause);
+    }
 }

--- a/src/api/java/baritone/api/command/exception/CommandInvalidArgumentException.java
+++ b/src/api/java/baritone/api/command/exception/CommandInvalidArgumentException.java
@@ -23,12 +23,21 @@ public abstract class CommandInvalidArgumentException extends CommandErrorMessag
 
     public final ICommandArgument arg;
 
-    protected CommandInvalidArgumentException(ICommandArgument arg, String reason) {
-        super(String.format(
+    protected CommandInvalidArgumentException(ICommandArgument arg, String message) {
+        super(formatMessage(arg, message));
+        this.arg = arg;
+    }
+
+    protected CommandInvalidArgumentException(ICommandArgument arg, String message, Throwable cause) {
+        super(formatMessage(arg, message), cause);
+        this.arg = arg;
+    }
+
+    private static String formatMessage(ICommandArgument arg, String message) {
+        return String.format(
                 "Error at argument #%s: %s",
                 arg.getIndex() == -1 ? "<unknown>" : Integer.toString(arg.getIndex() + 1),
-                reason
-        ));
-        this.arg = arg;
+                message
+        );
     }
 }

--- a/src/api/java/baritone/api/command/exception/CommandInvalidTypeException.java
+++ b/src/api/java/baritone/api/command/exception/CommandInvalidTypeException.java
@@ -26,7 +26,7 @@ public class CommandInvalidTypeException extends CommandInvalidArgumentException
     }
 
     public CommandInvalidTypeException(ICommandArgument arg, String expected, Throwable cause) {
-        super(arg, String.format("Expected %s.\nMore details: %s", expected, cause.getMessage()));
+        super(arg, String.format("Expected %s", expected), cause);
     }
 
     public CommandInvalidTypeException(ICommandArgument arg, String expected, String got) {
@@ -34,6 +34,6 @@ public class CommandInvalidTypeException extends CommandInvalidArgumentException
     }
 
     public CommandInvalidTypeException(ICommandArgument arg, String expected, String got, Throwable cause) {
-        super(arg, String.format("Expected %s, but got %s instead.\nMore details: %s", expected, got, cause.getMessage()));
+        super(arg, String.format("Expected %s, but got %s instead", expected, got), cause);
     }
 }

--- a/src/api/java/baritone/api/command/exception/CommandUnhandledException.java
+++ b/src/api/java/baritone/api/command/exception/CommandUnhandledException.java
@@ -37,7 +37,7 @@ public class CommandUnhandledException extends RuntimeException implements IComm
 
     @Override
     public void handle(ICommand command, List<ICommandArgument> args) {
-        HELPER.logDirect("An unhandled exception occurred." +
+        HELPER.logDirect("An unhandled exception occurred. " +
                 "The error is in your game's log, please report this at https://github.com/cabaletta/baritone/issues",
                 TextFormatting.RED);
 

--- a/src/main/java/baritone/command/argument/ArgConsumer.java
+++ b/src/main/java/baritone/command/argument/ArgConsumer.java
@@ -316,8 +316,7 @@ public class ArgConsumer implements IArgConsumer {
         try {
             return datatype.apply(this.context, original);
         } catch (Exception e) {
-            e.printStackTrace();
-            throw new CommandInvalidTypeException(hasAny() ? peek() : consumed(), datatype.getClass().getSimpleName());
+            throw new CommandInvalidTypeException(hasAny() ? peek() : consumed(), datatype.getClass().getSimpleName(), e);
         }
     }
 
@@ -346,7 +345,7 @@ public class ArgConsumer implements IArgConsumer {
         try {
             return datatype.get(this.context);
         } catch (Exception e) {
-            throw new CommandInvalidTypeException(hasAny() ? peek() : consumed(), datatype.getClass().getSimpleName());
+            throw new CommandInvalidTypeException(hasAny() ? peek() : consumed(), datatype.getClass().getSimpleName(), e);
         }
     }
 

--- a/src/main/java/baritone/command/defaults/GotoCommand.java
+++ b/src/main/java/baritone/command/defaults/GotoCommand.java
@@ -41,9 +41,13 @@ public class GotoCommand extends Command {
 
     @Override
     public void execute(String label, IArgConsumer args) throws CommandException {
-        if (args.peekDatatypeOrNull(RelativeCoordinate.INSTANCE) != null) { // if we have a numeric first argument...
+        // If we have a numeric first argument, then parse arguments as coordinates.
+        // Note: There is no reason to want to go where you're already at so there
+        // is no need to handle the case of empty arguments.
+        if (args.peekDatatypeOrNull(RelativeCoordinate.INSTANCE) != null) {
+            args.requireMax(3);
             BetterBlockPos origin = baritone.getPlayerContext().playerFeet();
-            Goal goal = args.getDatatypePostOrNull(RelativeGoal.INSTANCE, origin);
+            Goal goal = args.getDatatypePost(RelativeGoal.INSTANCE, origin);
             logDirect(String.format("Going to: %s", goal.toString()));
             baritone.getCustomGoalProcess().setGoalAndPath(goal);
             return;


### PR DESCRIPTION
When I run the `goto 0 0` command, it works but it prints this to stderr:

```
[14:58:17] [main/INFO]: [CHAT] [Baritone] > goto 0 0
[14:58:17] [main/INFO]: [STDERR]: baritone.api.command.exception.CommandNotEnoughArgumentsException: Not enough arguments (expected at least 3)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.requireMin(ArgConsumer.java:391)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.get(ArgConsumer.java:262)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.getString(ArgConsumer.java:270)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.api.command.datatypes.RelativeCoordinate.apply(RelativeCoordinate.java:37)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.api.command.datatypes.RelativeCoordinate.apply(RelativeCoordinate.java:27)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.getDatatypePost(ArgConsumer.java:317)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.getDatatypePostOrDefault(ArgConsumer.java:329)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.getDatatypePostOrNull(ArgConsumer.java:341)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.peekDatatypeOrNull(ArgConsumer.java:227)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.api.command.datatypes.RelativeGoal.apply(RelativeGoal.java:46)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.api.command.datatypes.RelativeGoal.apply(RelativeGoal.java:33)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.getDatatypePost(ArgConsumer.java:317)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.getDatatypePostOrDefault(ArgConsumer.java:329)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.argument.ArgConsumer.getDatatypePostOrNull(ArgConsumer.java:341)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.defaults.GotoCommand.execute(GotoCommand.java:46)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.manager.CommandManager$ExecutionWrapper.execute(CommandManager.java:140)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.manager.CommandManager$ExecutionWrapper.access$000(CommandManager.java:127)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.manager.CommandManager.execute(CommandManager.java:83)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.BaritoneChatControl.runCommand(BaritoneChatControl.java:145)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.command.BaritoneChatControl.onSendChatMessage(BaritoneChatControl.java:70)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.event.GameEventHandler.lambda$onSendChatMessage$2(GameEventHandler.java:69)
[14:58:17] [main/INFO]: [STDERR]: 	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:891)
[14:58:17] [main/INFO]: [STDERR]: 	at baritone.event.GameEventHandler.onSendChatMessage(GameEventHandler.java:69)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.entity.EntityPlayerSP.handler$sendChatMessage$zze000(EntityPlayerSP.java:1416)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.entity.EntityPlayerSP.sendChatMessage(EntityPlayerSP.java)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.gui.GuiScreen.sendChatMessage(GuiScreen.java:456)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.gui.GuiScreen.sendChatMessage(GuiScreen.java:446)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.gui.GuiChat.keyTyped(GuiChat.java:126)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.gui.GuiScreen.handleKeyboardInput(GuiScreen.java:607)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.gui.GuiScreen.handleInput(GuiScreen.java:556)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.Minecraft.runTick(Minecraft.java:1852)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1165)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.Minecraft.run(Minecraft.java:439)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.client.main.Main.main(Main.java:115)
[14:58:17] [main/INFO]: [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[14:58:17] [main/INFO]: [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[14:58:17] [main/INFO]: [STDERR]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[14:58:17] [main/INFO]: [STDERR]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
[14:58:17] [main/INFO]: [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[14:58:17] [main/INFO]: [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[14:58:17] [main/INFO]: [STDERR]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[14:58:17] [main/INFO]: [STDERR]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[14:58:17] [main/INFO]: [STDERR]: 	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
[14:58:17] [main/INFO]: [STDERR]: 	at GradleStart.main(GradleStart.java:25)
[14:58:17] [main/INFO]: [CHAT] [Baritone] Going to: GoalXZ{x=0,z=0}
```

I think the reason why this is printed is because `CommandInvalidTypeException` cannot be constructed with a cause so the error is printed here to make sure it will appear in the log if there is a problem. I removed the code that prints the error and modified `CommandInvalidTypeException` to accept a cause.

I also modified a bit of code for the goto command to remove a hack and added a space in the error message for when a command throws an exception. If you want, I can make another PR with this but it's a very small change so I thought it would be simpler to put it in this one.