### PR TITLE
Tweak help section

### DIFF
--- a/src/main/java/baritone/command/defaults/MineCommand.java
+++ b/src/main/java/baritone/command/defaults/MineCommand.java
@@ -71,7 +71,7 @@ public class MineCommand extends Command {
                 "",
                 "Usage:",
                 "> mine diamond_ore - Mines all diamonds it can find.",
-                "> mine redstone_ore lit_redstone_ore - Mines redstone ore.",
+                "> mine redstone_ore iron_ore - Mines redstone ore and iron ore.",
                 "> mine log:0 - Mines only oak logs."
         );
     }


### PR DESCRIPTION
redstone_ore and lit_resdstone_ore are not 2 detected as 2 different block types and passing both as arguments in a command causes baritone to fail. Help section should be updated to reflect this.