### PR TITLE
Make how to use checkboxes more clear in issue templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -20,6 +20,7 @@ You can find your logs in `%appdata%/.minecraft/logs/` (Windows) or `/Library/Ap
 Add your steps to reproduce the issue/bug experienced here.
 
 ## Final checklist
+- [x] I know how to properly use check boxes 
 - [ ] I have included the version of Minecraft I'm running, baritone's version and forge mods (if used).
 - [ ] I have included logs, exceptions and / or steps to reproduce the issue.
 - [ ] I have not used any OwO's or UwU's in this issue.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -10,4 +10,5 @@ assignees: ''
 With as much detail as possible, describe your question and what you may need help with.
 
 ## Final checklist
+- [x] I know how to properly use check boxes 
 - [ ] I have not used any OwO's or UwU's in this issue.

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -16,4 +16,5 @@ If applicable, what settings/customizability should be offered to tweak the func
 Describe how your suggestion would improve Baritone, or the reason behind it being added.
 
 ## Final checklist
+- [x] I know how to properly use check boxes 
 - [ ] I have not used any OwO's or UwU's in this issue.


### PR DESCRIPTION
Seriously pisses me off that somehow people don't know how markdown works. 

***

I've seen people use fucking emojis (#1282), `v`s (#1284), not even fill in the checkboxes in their issue or even have it like this once. 
```
- [ x] thng 1 
- [x ] Thing 2
- [ x] thing3
```
so the markdown doesn't work. 
This pull request would hopefully solve that so people learn to fill out issues properly.

***

An example of how this works when done properly (as shown by the templates):
 - [x] I have not used any owos or uwus
 - [ ] I do not shill KAMI Blue