### PR TITLE
Loot command

### DIFF
--- a/src/api/java/baritone/api/IBaritone.java
+++ b/src/api/java/baritone/api/IBaritone.java
@@ -134,6 +134,12 @@ public interface IBaritone {
     ICommandManager getCommandManager();
 
     /**
+     * @return The {@link ILootProcess} instance
+     * @see ILootProcess
+     */
+    ILootProcess getLootProcess();
+
+    /**
      * Open click
      */
     void openClick();

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -30,8 +30,8 @@ import java.awt.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
 
 /**
@@ -498,6 +498,39 @@ public final class Settings {
     public final Setting<Boolean> containerMemory = new Setting<>(false);
 
     /**
+     * List of containers to loot
+     */
+    public final Setting<List<Block>> lootContainers = new Setting<>(new ArrayList<>(Arrays.asList(
+            Blocks.CHEST,
+            Blocks.BLACK_SHULKER_BOX,
+            Blocks.BLUE_SHULKER_BOX,
+            Blocks.BROWN_SHULKER_BOX,
+            Blocks.CYAN_SHULKER_BOX,
+            Blocks.GRAY_SHULKER_BOX,
+            Blocks.GREEN_SHULKER_BOX,
+            Blocks.LIGHT_BLUE_SHULKER_BOX,
+            Blocks.LIME_SHULKER_BOX,
+            Blocks.MAGENTA_SHULKER_BOX,
+            Blocks.ORANGE_SHULKER_BOX,
+            Blocks.PINK_SHULKER_BOX,
+            Blocks.PURPLE_SHULKER_BOX,
+            Blocks.RED_SHULKER_BOX,
+            Blocks.SILVER_SHULKER_BOX,
+            Blocks.WHITE_SHULKER_BOX,
+            Blocks.YELLOW_SHULKER_BOX
+    )));
+
+    /**
+     * Steal not only the items, but also the container when looting
+     */
+    public final Setting<Boolean> stealContainer = new Setting<>(false);
+
+    /**
+     * While looting, should it also consider dropped items of the correct type as a pathing destination (as well as containers)?
+     */
+    public final Setting<Boolean> lootScanDroppedItems = new Setting<>(true);
+
+    /**
      * Fill in blocks behind you
      */
     public final Setting<Boolean> backfill = new Setting<>(false);
@@ -601,9 +634,9 @@ public final class Settings {
     public final Setting<Boolean> sprintInWater = new Setting<>(true);
 
     /**
-     * When GetToBlockProcess or MineProcess fails to calculate a path, instead of just giving up, mark the closest instance
-     * of that block as "unreachable" and go towards the next closest. GetToBlock expands this seaarch to the whole "vein"; MineProcess does not.
-     * This is because MineProcess finds individual impossible blocks (like one block in a vein that has gravel on top then lava, so it can't break)
+     * When GetToBlockProcess, LootProcess, or MineProcess fails to calculate a path, instead of just giving up, mark the closest instance
+     * of that block as "unreachable" and go towards the next closest. GetToBlock expands this search to the whole "vein"; MineProcess and LootProcess does not.
+     * This is because MineProcess and LootProcess finds individual impossible blocks (like one block in a vein that has gravel on top then lava, so it can't break)
      * Whereas GetToBlock should blacklist the whole "vein" if it can't get to any of them.
      */
     public final Setting<Boolean> blacklistClosestOnFailure = new Setting<>(true);

--- a/src/api/java/baritone/api/process/ILootProcess.java
+++ b/src/api/java/baritone/api/process/ILootProcess.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.process;
+
+import net.minecraft.item.Item;
+
+import java.util.List;
+
+public interface ILootProcess extends IBaritoneProcess {
+
+    /**
+     * Loot nearest containers for items.
+     *
+     * @param amount
+     * @param items
+     */
+    void loot(int amount, List<Item> items);
+
+    /**
+     * Cancels the current looting task
+     */
+    default void cancel() {
+        onLostControl();
+    }
+}

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -21,6 +21,7 @@ import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.Settings;
 import baritone.api.event.listener.IEventBus;
+import baritone.api.process.ILootProcess;
 import baritone.api.utils.Helper;
 import baritone.api.utils.IPlayerContext;
 import baritone.behavior.*;
@@ -72,6 +73,7 @@ public class Baritone implements IBaritone {
     private FollowProcess followProcess;
     private MineProcess mineProcess;
     private GetToBlockProcess getToBlockProcess;
+    private LootProcess lootProcess;
     private CustomGoalProcess customGoalProcess;
     private BuilderProcess builderProcess;
     private ExploreProcess exploreProcess;
@@ -108,6 +110,7 @@ public class Baritone implements IBaritone {
             mineProcess = new MineProcess(this);
             customGoalProcess = new CustomGoalProcess(this); // very high iq
             getToBlockProcess = new GetToBlockProcess(this);
+            lootProcess = new LootProcess(this);
             builderProcess = new BuilderProcess(this);
             exploreProcess = new ExploreProcess(this);
             backfillProcess = new BackfillProcess(this);
@@ -212,6 +215,9 @@ public class Baritone implements IBaritone {
     public CommandManager getCommandManager() {
         return this.commandManager;
     }
+
+    @Override
+    public LootProcess getLootProcess() { return this.lootProcess; }
 
     @Override
     public void openClick() {

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -64,7 +64,8 @@ public final class DefaultCommands {
                 new WaypointsCommand(baritone),
                 new CommandAlias(baritone, "sethome", "Sets your home waypoint", "waypoints save home"),
                 new CommandAlias(baritone, "home", "Set goal to your home waypoint", "waypoints goal home"),
-                new SelCommand(baritone)
+                new SelCommand(baritone),
+                new LootCommand(baritone)
         ));
         ExecutionControlCommands prc = new ExecutionControlCommands(baritone);
         commands.add(prc.pauseCommand);

--- a/src/main/java/baritone/command/defaults/LootCommand.java
+++ b/src/main/java/baritone/command/defaults/LootCommand.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.api.IBaritone;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.datatypes.BlockById;
+import baritone.api.command.exception.CommandException;
+import net.minecraft.item.Item;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+
+public class LootCommand extends Command {
+    protected LootCommand(IBaritone baritone) {
+        super(baritone, "loot", "steal");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        int amount;
+        if (args.hasExactly(0)) {
+            amount = -1;
+        } else {
+            amount = args.get().getAs(int.class);
+        }
+        List<Item> items = new ArrayList<>();
+        if (args.hasAny()) {
+            do {
+                items.add(Item.getByNameOrId(args.getString()));
+            } while (args.hasAny());
+        } else {
+            items = null;
+        }
+        baritone.getLootProcess().loot(amount, items);
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) throws CommandException {
+        return args.tabCompleteDatatype(BlockById.INSTANCE);
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Loot containers";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "The loot command allows you to tell Baritone to search for and loot nearby containers.",
+                "",
+                "If no item(s) are specified, Baritone steals all items from every container",
+                "",
+                "You can change the list of containers that Baritone loots in the lootContainers setting.",
+                "",
+                "Usage:",
+                "> loot - Loot all containers it can find until stopped.",
+                "> loot -1 - Same as loot without arguments",
+                "> loot <amount> - Loot amount of containers that are closest.",
+                "> loot <amount> <item> [item] [item]... - Loot specific items from the 25 closest containers."
+        );
+    }
+}

--- a/src/main/java/baritone/process/LootProcess.java
+++ b/src/main/java/baritone/process/LootProcess.java
@@ -1,0 +1,215 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.process;
+
+import baritone.Baritone;
+import baritone.api.pathing.goals.Goal;
+import baritone.api.pathing.goals.GoalBlock;
+import baritone.api.pathing.goals.GoalComposite;
+import baritone.api.process.ILootProcess;
+import baritone.api.process.PathingCommand;
+import baritone.api.process.PathingCommandType;
+import baritone.api.utils.BlockOptionalMetaLookup;
+import baritone.pathing.movement.CalculationContext;
+import baritone.utils.BaritoneProcessHelper;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.BlockShulkerBox;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyDirection;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static baritone.api.pathing.movement.ActionCosts.COST_INF;
+
+public final class LootProcess  extends BaritoneProcessHelper implements ILootProcess {
+
+    private static final int MAX_CONTAINER_POSITIONS = 64;
+
+    private List<BlockPos> knownContainerPositions;
+    private List<BlockPos> blacklist; // inaccessible
+    private int desiredContainers;
+    private int containersLeft;
+    private List<Item> itemsToCollect;
+
+    public LootProcess(Baritone baritone) { super(baritone); }
+
+    @Override
+    public boolean isActive() { return containersLeft != 0; }
+
+    @Override
+    public void loot(int amount, List<Item> items) {
+        itemsToCollect = items;
+        desiredContainers = amount;
+        containersLeft = desiredContainers;
+        knownContainerPositions = new ArrayList<>();
+        blacklist = new ArrayList<>();
+        itemsToCollect = items;
+    }
+
+    @Override
+    public PathingCommand onTick(boolean calcFailed, boolean isSafeToCancel) {
+        if (containersLeft != 0) {
+            logDirect("Looting of " + desiredContainers + " containers completed.");
+            cancel();
+        }
+        if (calcFailed) {
+            if (!knownContainerPositions.isEmpty() && Baritone.settings().blacklistClosestOnFailure.value) {
+                logDirect("Unable to find any path to a valid container, blacklisting presumably unreachable closest instance...");
+                knownContainerPositions.stream().min(Comparator.comparingDouble(ctx.player()::getDistanceSq)).ifPresent(blacklist::add);
+                knownContainerPositions.removeIf(blacklist::contains);
+            } else {
+                logDirect("Unable to find any path to a valid container, cancelling loot");
+                cancel();
+                return null;
+            }
+        }
+        if (Baritone.settings().stealContainer.value && !Baritone.settings().allowBreak.value) {
+            logDirect("Cannot steal the containers when allowBreak is false!");
+            cancel();
+            return null;
+        }
+        return null;
+    }
+
+    private PathingCommand updateGoal() {
+        List<BlockPos> locs = knownContainerPositions;
+        if (!locs.isEmpty()) {
+            CalculationContext context = new CalculationContext(baritone);
+            List<BlockPos> locs2 = prune(context, new ArrayList<>(locs), Baritone.settings().lootContainers.value, MAX_CONTAINER_POSITIONS, blacklist, droppedItemsScan());
+            // can't reassign locs, gotta make a new var locs2, because we use it in a lambda right here, and variables you use in a lambda must be effectively final
+            Goal goal = new GoalComposite(locs2.stream().map(GoalBlock::new).toArray(Goal[]::new));
+            knownContainerPositions = locs2;
+            return new PathingCommand(goal, PathingCommandType.REVALIDATE_GOAL_AND_PATH);
+        }
+        return null;
+    }
+
+    @Override
+    public void onLostControl() {
+        knownContainerPositions = null;
+        desiredContainers = 0;
+        containersLeft = 0;
+        itemsToCollect = null;
+    }
+
+    private final static List<Block> shulkers = new ArrayList<>();
+
+    public static boolean plausibleToLoot(CalculationContext ctx, BlockPos pos) {
+        int x = pos.getX();
+        int y = pos.getY();
+        int z = pos.getZ();
+        IBlockState state = ctx.get(pos);
+        Block block = state.getBlock();
+        if (shulkers.contains(block)) {
+            EnumFacing direction = state.getValue(PropertyDirection.create(("facing")));
+            IBlockState topState;
+            Block top;
+            switch (direction) {
+                case UP:
+                default:
+                    topState = ctx.get(x, y + 1, z);
+                    break;
+                case DOWN:
+                    topState = ctx.get(x, y - 1, z);
+                    break;
+                case NORTH:
+                    topState = ctx.get(x + 1, y, z);
+                    break;
+                case SOUTH:
+                    topState = ctx.get(x - 1, y, z);
+                    break;
+                case EAST:
+                    topState = ctx.get(x, y, z + 1);
+                    break;
+                case WEST:
+                    topState = ctx.get(x, y, z - 1);
+            }
+            top = topState.getBlock();
+            return (topState.isTranslucent() && !topState.isOpaqueCube()) || top == Blocks.AIR;
+            // correct me if this isn't how shulkers work
+        } else if (block == Blocks.CHEST || block == Blocks.TRAPPED_CHEST || block == Blocks.ENDER_CHEST) { // idk why you would want to loot a echest but whatever
+            return ctx.getBlock(x, y + 1, z) == Blocks.AIR;
+        } else {
+            return block instanceof BlockContainer;
+        }
+    }
+
+    private static List<BlockPos> prune(CalculationContext ctx, List<BlockPos> locs2, List<Block> containers, int max, List<BlockPos> blacklist, List<BlockPos> dropped) {
+        dropped.removeIf(drop -> {
+            for (BlockPos pos : locs2) {
+                if (pos.distanceSq(drop) <= 9 && containers.contains(ctx.get(pos.getX(), pos.getY(), pos.getZ())) && plausibleToLoot(ctx, pos)) { // TODO maybe drop also has to be supported? no lava below?
+                    return true;
+                }
+            }
+            return false;
+        });
+        List<BlockPos> locs = locs2
+                .stream()
+                .distinct()
+
+                // remove any that are within loaded chunks that aren't actually what we want
+                .filter(pos -> !ctx.bsi.worldContainsLoadedChunk(pos.getX(), pos.getZ()) || containers.contains(ctx.get(pos.getX(), pos.getY(), pos.getZ())) || dropped.contains(pos))
+
+                // remove any that are implausible to mine (encased in bedrock, or touching lava)
+                .filter(pos -> MineProcess.plausibleToBreak(ctx, pos))
+
+                .filter(pos -> !blacklist.contains(pos))
+
+                .sorted(Comparator.comparingDouble(ctx.getBaritone().getPlayerContext().player()::getDistanceSq))
+                .collect(Collectors.toList());
+
+        if (locs.size() > max) {
+            return locs.subList(0, max);
+        }
+        return locs;
+    }
+
+    public List<BlockPos> droppedItemsScan() {
+        if (!Baritone.settings().lootScanDroppedItems.value) {
+            return Collections.emptyList();
+        }
+        List<BlockPos> ret = new ArrayList<>();
+        for (Entity entity : ctx.world().loadedEntityList) {
+            if (entity instanceof EntityItem) {
+                EntityItem ei = (EntityItem) entity;
+                if (itemsToCollect.contains(ei.getItem())) {
+                    ret.add(new BlockPos(entity));
+                }
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public String displayName0() {
+        return "Loot Containers";
+    }
+
+}


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->
# `#loot`
Implement a looting command, fixes #1579 

## Command structure
#### Base
```
loot [amount] [item] [item] [item] ...
```
- `int amount` - Amount of containers to loot, leave blank or -1 for infinite
- `List<Item> items` - Items to take (e.g. `diamond iron gold`), leave blank for all

#### Individual commands
- `loot`: loot all items from all containers until stopped
- `loot <amount>`: loot all items from `amount` of containers
- `loot <amount> <item> [item] [item] [item] ...`: loot `item`s from `amount` of containers

When `item`s to take are specified and the setting `lootScanDroppedItems` is `true`, dropped items matching the `item`s are matched as a valid target, similar to what `MineProcess` (a.k.a. `#mine`) does.

## TODO (WIP at top)
- [ ] scan for container locations
- [ ] scan for dropped items
- [ ] move to locations
- [ ] open containers
- [ ] steal containers