### PR TITLE
Fixing crash after clicking into the air using the #click command

### DIFF
--- a/src/main/java/baritone/utils/GuiClick.java
+++ b/src/main/java/baritone/utils/GuiClick.java
@@ -93,10 +93,16 @@ public class GuiClick extends GuiScreen {
                 Helper.HELPER.logDirect(component);
                 clickStart = null;
             } else {
-                BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalTwoBlocks(currentMouseOver));
+                if(currentMouseOver != null)//Catch this, or else a click into void will result in a crash
+                    BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalBlock(currentMouseOver));
+                else
+                    Helper.HELPER.logDirect("Sorry, I can't go to nothing");
             }
         } else if (mouseButton == 1) {
-            BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalBlock(currentMouseOver.up()));
+            if(currentMouseOver != null)
+                BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalBlock(currentMouseOver.up()));
+            else
+                Helper.HELPER.logDirect("Sorry, I can't go to nothing");
         }
         clickStart = null;
     }

--- a/src/main/java/baritone/utils/GuiClick.java
+++ b/src/main/java/baritone/utils/GuiClick.java
@@ -20,7 +20,6 @@ package baritone.utils;
 import baritone.Baritone;
 import baritone.api.BaritoneAPI;
 import baritone.api.pathing.goals.GoalBlock;
-import baritone.api.pathing.goals.GoalTwoBlocks;
 import baritone.api.utils.BetterBlockPos;
 import baritone.api.utils.Helper;
 import net.minecraft.client.gui.GuiScreen;
@@ -43,8 +42,8 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.Collections;
 
-import static org.lwjgl.opengl.GL11.*;
 import static baritone.api.command.IBaritoneChatControl.FORCE_COMMAND_PREFIX;
+import static org.lwjgl.opengl.GL11.*;
 
 public class GuiClick extends GuiScreen {
 
@@ -93,13 +92,13 @@ public class GuiClick extends GuiScreen {
                 Helper.HELPER.logDirect(component);
                 clickStart = null;
             } else {
-                if(currentMouseOver != null)//Catch this, or else a click into void will result in a crash
+                if (currentMouseOver != null)//Catch this, or else a click into void will result in a crash
                     BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalBlock(currentMouseOver));
                 else
                     Helper.HELPER.logDirect("Sorry, I can't go to nothing");
             }
         } else if (mouseButton == 1) {
-            if(currentMouseOver != null)
+            if (currentMouseOver != null)
                 BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalBlock(currentMouseOver.up()));
             else
                 Helper.HELPER.logDirect("Sorry, I can't go to nothing");

--- a/src/main/java/baritone/utils/GuiClick.java
+++ b/src/main/java/baritone/utils/GuiClick.java
@@ -78,30 +78,26 @@ public class GuiClick extends GuiScreen {
 
     @Override
     protected void mouseReleased(int mouseX, int mouseY, int mouseButton) {
-        if (mouseButton == 0) {
-            if (clickStart != null && !clickStart.equals(currentMouseOver)) {
-                BaritoneAPI.getProvider().getPrimaryBaritone().getSelectionManager().removeAllSelections();
-                BaritoneAPI.getProvider().getPrimaryBaritone().getSelectionManager().addSelection(BetterBlockPos.from(clickStart), BetterBlockPos.from(currentMouseOver));
-                ITextComponent component = new TextComponentString("Selection made! For usage: " + Baritone.settings().prefix.value + "help sel");
-                component.getStyle()
-                        .setColor(TextFormatting.WHITE)
-                        .setClickEvent(new ClickEvent(
-                                ClickEvent.Action.RUN_COMMAND,
-                                FORCE_COMMAND_PREFIX + "help sel"
-                        ));
-                Helper.HELPER.logDirect(component);
-                clickStart = null;
-            } else {
-                if (currentMouseOver != null)//Catch this, or else a click into void will result in a crash
+        if (currentMouseOver != null) { //Catch this, or else a click into void will result in a crash
+            if (mouseButton == 0) {
+                if (clickStart != null && !clickStart.equals(currentMouseOver)) {
+                    BaritoneAPI.getProvider().getPrimaryBaritone().getSelectionManager().removeAllSelections();
+                    BaritoneAPI.getProvider().getPrimaryBaritone().getSelectionManager().addSelection(BetterBlockPos.from(clickStart), BetterBlockPos.from(currentMouseOver));
+                    ITextComponent component = new TextComponentString("Selection made! For usage: " + Baritone.settings().prefix.value + "help sel");
+                    component.getStyle()
+                            .setColor(TextFormatting.WHITE)
+                            .setClickEvent(new ClickEvent(
+                                    ClickEvent.Action.RUN_COMMAND,
+                                    FORCE_COMMAND_PREFIX + "help sel"
+                            ));
+                    Helper.HELPER.logDirect(component);
+                    clickStart = null;
+                } else {
                     BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalBlock(currentMouseOver));
-                else
-                    Helper.HELPER.logDirect("Sorry, I can't go to nothing");
-            }
-        } else if (mouseButton == 1) {
-            if (currentMouseOver != null)
+                }
+            } else if (mouseButton == 1) {
                 BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalBlock(currentMouseOver.up()));
-            else
-                Helper.HELPER.logDirect("Sorry, I can't go to nothing");
+            }
         }
         clickStart = null;
     }


### PR DESCRIPTION
When using the `#click` command the game would crash due to a NullPointerException.

This commit fixes that by not allowing a `null` value after clicking.

I am not sure about the chat message, but I think it's usefull to remind a player.
Maybe the chat message should be changed to a debug message?