### PR TITLE
Fix MovementDiagonal being safeToCancel while cornering over air

### DIFF
--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -213,6 +213,21 @@ public class MovementDiagonal extends Movement {
         res.z = destZ;
     }
 
+    protected boolean safeToCancel(MovementState currentState) {
+        //too simple. backfill does not work after cornering with this
+        //return MovementHelper.canWalkOn(ctx, ctx.playerFeet().down());
+        //check the corners of the hitbox instead
+        EntityPlayerSP player = ctx.player();
+        double offset = 0.25;
+        double x = player.posX;
+        double y = player.posY - 1;
+        double z = player.posZ;
+        return MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
+            || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z - offset))
+            || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z + offset))
+            || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset));
+    }
+
     @Override
     public MovementState updateState(MovementState state) {
         super.updateState(state);

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -31,6 +31,7 @@ import baritone.utils.pathing.MutableMoveResult;
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;


### PR DESCRIPTION
Movement diagonal was considered to be always safe to cancel, but when cornering over air it isn't.
This caused baritone to reliably fall when backfilling at the source of a MovementDiagonal (Fixed #1788)
Added a check for a supporting block and only consider the current state safe when there is one that is canWalkOn

<!-- No UwU's or OwO's allowed -->
