### PR TITLE
Fix MovementDiagonal being safeToCancel while cornering over air 2.0

### DIFF
--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -76,15 +76,14 @@ public class MovementDiagonal extends Movement {
                 return true;
         }
         //we are in a likely unwalkable corner, check for a supporting block
-        if ((ctx.playerFeet().equals(new BetterBlockPos(src.x, src.y, dest.z))
-            || ctx.playerFeet().equals(new BetterBlockPos(dest.x, src.y, src.z)))
-                && (MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
+        if (ctx.playerFeet().equals(new BetterBlockPos(src.x, src.y, dest.z))
+            || ctx.playerFeet().equals(new BetterBlockPos(dest.x, src.y, src.z))){
+                return (MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z - offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z + offset))
-                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset)))){
-                        return true;
+                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset)));
         }
-        return false;
+        return true;
    }
 
     @Override

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -76,12 +76,12 @@ public class MovementDiagonal extends Movement {
                 return true;
         }
         //we are in a likely unwalkable corner, check for a supporting block
-        if (ctx.playerFeet().equals(new BetterBlockPos(src.x, src.y, dest.z))
+        if ((ctx.playerFeet().equals(new BetterBlockPos(src.x, src.y, dest.z))
             || ctx.playerFeet().equals(new BetterBlockPos(dest.x, src.y, src.z)))
                 && (MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z - offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z + offset))
-                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset))){
+                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset)))){
                         return true;
         }
         return false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -77,11 +77,11 @@ public class MovementDiagonal extends Movement {
         }
         //we are in a likely unwalkable corner, check for a supporting block
         if (ctx.playerFeet().equals(new BetterBlockPos(src.x, src.y, dest.z))
-            || ctx.playerFeet().equals(new BetterBlockPos(dest.x, src.y, src.z))){
+            || ctx.playerFeet().equals(new BetterBlockPos(dest.x, src.y, src.z)))
                 && (MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z - offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z + offset))
-                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset)))
+                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset))){
                         return true;
         }
         return false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -31,6 +31,7 @@ import baritone.utils.pathing.MutableMoveResult;
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -58,11 +59,34 @@ public class MovementDiagonal extends Movement {
 
     @Override
     protected boolean safeToCancel(MovementState state) {
-        return ctx.playerFeet().equals(src) || ((
-                MovementHelper.canWalkOn(ctx, new BlockPos(src.x, src.y - 1, dest.z))
-        ) &&
-                MovementHelper.canWalkOn(ctx, new BlockPos(dest.x, src.y - 1, src.z)));
-    }
+        //too simple. backfill does not work after cornering with this
+        //return MovementHelper.canWalkOn(ctx, ctx.playerFeet().down());
+        EntityPlayerSP player = ctx.player();
+        double offset = 0.25;
+        double x = player.posX;
+        double y = player.posY - 1;
+        double z = player.posZ;
+        //standard
+        if (ctx.playerFeet().equals(src)){
+            return true;
+        }
+        //both corners are walkable
+        if (MovementHelper.canWalkOn(ctx, new BlockPos(src.x, src.y - 1, dest.z))
+            && MovementHelper.canWalkOn(ctx, new BlockPos(dest.x, src.y - 1, src.z))){
+                return true;
+        }
+        //we are in a likely unwalkable corner, check for a supporting block
+        if (ctx.playerFeet().equals(new BetterBlockPos(src.x, src.y, dest.z))
+            || ctx.playerFeet().equals(new BetterBlockPos(dest.x, src.y, src.z))){
+                if (MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
+                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z - offset))
+                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z + offset))
+                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset))){
+                        return true;
+                }
+        }
+        return false;
+   }
 
     @Override
     public double calculateCost(CalculationContext context) {

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -78,12 +78,11 @@ public class MovementDiagonal extends Movement {
         //we are in a likely unwalkable corner, check for a supporting block
         if (ctx.playerFeet().equals(new BetterBlockPos(src.x, src.y, dest.z))
             || ctx.playerFeet().equals(new BetterBlockPos(dest.x, src.y, src.z))){
-                if (MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
+                && (MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z + offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x + offset, y, z - offset))
                    || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z + offset))
-                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset))){
+                   || MovementHelper.canWalkOn(ctx, new BetterBlockPos(x - offset, y, z - offset)))
                         return true;
-                }
         }
         return false;
    }


### PR DESCRIPTION
This is the successor of #1922 and the result of the conversation there
it is a combination of 02e7886 and #1922 

## Original description:
Movement diagonal was considered to be always safe to cancel, but when cornering over air it isn't.
This caused baritone to reliably fall when backfilling at the source of a MovementDiagonal (Fixed #1788)
Added a check for a supporting block and only consider the current state safe when there is one that is canWalkOn