### PR TITLE
Added the license field that forge is forcing

### DIFF
--- a/src/launch/resources/META-INF/mods.toml
+++ b/src/launch/resources/META-INF/mods.toml
@@ -6,7 +6,8 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[32,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[33,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+license="https://raw.githubusercontent.com/cabaletta/baritone/1.16.2/LICENSE"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/cabaletta/baritone/issues" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->

This will likely also need to be done to 1.16.1, but it's replaced by 1.16.2, so idgaf