### PR TITLE
Fix "#entity follow <name>" under Forge

### DIFF
--- a/src/api/java/baritone/api/command/datatypes/EntityClassById.java
+++ b/src/api/java/baritone/api/command/datatypes/EntityClassById.java
@@ -32,7 +32,19 @@ public enum EntityClassById implements IDatatypeFor<Class<? extends Entity>> {
     public Class<? extends Entity> get(IDatatypeContext ctx) throws CommandException {
         ResourceLocation id = new ResourceLocation(ctx.getConsumer().getString());
         Class<? extends Entity> entity;
-        if ((entity = EntityList.REGISTRY.getObject(id)) == null) {
+        try {
+            entity = EntityList.REGISTRY.getObject(id);
+        } catch(NoSuchFieldError e) {
+            // Forge removes EntityList.REGISTRY field and provides the getClass method as a replacement
+            // See https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+            try {
+                entity = (Class<? extends Entity>) EntityList.class.getMethod("getClass", ResourceLocation.class).invoke(null, id);
+            } catch (Exception ex) {
+                throw new RuntimeException("EntityList.REGISTRY does not exist and failed to call the Forge-replacement method", ex);
+            }
+        }
+
+        if (entity == null) {
             throw new IllegalArgumentException("no entity found by that id");
         }
         return entity;


### PR DESCRIPTION
One of the Forge patches removes EntityList.REGISTRY and provides the getClass method as a replacement.

The fix is based on a similar one I found in WorldDownloader. See my comment in https://github.com/cabaletta/baritone/issues/1376#issuecomment-679300658

I tested that it now works fine both with and without Forge

Closes #1376 (and duplicates: #1777 and #1815)