### PR TITLE
fix typo in java-doc x2

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -64,7 +64,7 @@ public final class Settings {
     /**
      * Disable baritone's auto-tool at runtime, but still assume that another mod will provide auto tool functionality
      * <p>
-     * Specifically, path calculation will still assume that an auto tool wil run at execution time, even though
+     * Specifically, path calculation will still assume that an auto tool will run at execution time, even though
      * Baritone itself will not do that.
      */
     public final Setting<Boolean> assumeExternalAutoTool = new Setting<>(false);

--- a/src/api/java/baritone/api/process/IBaritoneProcess.java
+++ b/src/api/java/baritone/api/process/IBaritoneProcess.java
@@ -75,7 +75,7 @@ public interface IBaritoneProcess {
      * to start eating this tick. {@code PauseForAutoEatProcess} should only actually right click once onTick is called with
      * {@code isSafeToCancel} true though.
      *
-     * @return Whethor or not if this control is temporary
+     * @return Whether or not if this control is temporary
      */
     boolean isTemporary();
 


### PR DESCRIPTION
fix 2 typos in java-doc.

fixes #1981 

<!-- No UwU's or OwO's allowed -->
