### PR TITLE
make `#wp goto` behave like `#wp goal` and `#path`

### DIFF
--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -63,7 +63,7 @@ public final class DefaultCommands {
                 new ThisWayCommand(baritone),
                 new WaypointsCommand(baritone),
                 new CommandAlias(baritone, "sethome", "Sets your home waypoint", "waypoints save home"),
-                new CommandAlias(baritone, "home", "Set goal to your home waypoint", "waypoints goal home"),
+                new CommandAlias(baritone, "home", "Path to your home waypoint", "waypoints goto home"),
                 new SelCommand(baritone)
         ));
         ExecutionControlCommands prc = new ExecutionControlCommands(baritone);

--- a/src/main/java/baritone/command/defaults/WaypointsCommand.java
+++ b/src/main/java/baritone/command/defaults/WaypointsCommand.java
@@ -296,7 +296,8 @@ public class WaypointsCommand extends Command {
                 "> wp <s/save> <tag> <name> <pos> - Save the waypoint with the specified name and position.",
                 "> wp <i/info/show> <tag> - Show info on a waypoint by tag.",
                 "> wp <d/delete> <tag> - Delete a waypoint by tag.",
-                "> wp <g/goal/goto> <tag> - Set a goal to a waypoint by tag."
+                "> wp <g/goal> <tag> - Set a goal to a waypoint by tag.",
+                "> wp <goto> <tag> - Set a goal to a waypoint by tag and start pathing."
         );
     }
 

--- a/src/main/java/baritone/command/defaults/WaypointsCommand.java
+++ b/src/main/java/baritone/command/defaults/WaypointsCommand.java
@@ -235,6 +235,10 @@ public class WaypointsCommand extends Command {
                     Goal goal = new GoalBlock(waypoint.getLocation());
                     baritone.getCustomGoalProcess().setGoal(goal);
                     logDirect(String.format("Goal: %s", goal));
+                } else if (action == Action.GOTO) {
+                    Goal goal = new GoalBlock(waypoint.getLocation());
+                    baritone.getCustomGoalProcess().setGoalAndPath(goal);
+                    logDirect(String.format("Going to: %s", goal));
                 }
             }
         }
@@ -302,7 +306,8 @@ public class WaypointsCommand extends Command {
         SAVE("save", "s"),
         INFO("info", "show", "i"),
         DELETE("delete", "d"),
-        GOAL("goal", "goto", "g");
+        GOAL("goal", "g"),
+        GOTO("goto");
         private final String[] names;
 
         Action(String... names) {


### PR DESCRIPTION
It now is a combined `#wp goal` and `#path` just like `#goto` is `#goal` and `#path`

<!-- No UwU's or OwO's allowed -->
