### PR TITLE
🐛 Fix a Rendering Conflict with some other Mods

### DIFF
--- a/src/main/java/baritone/utils/IRenderer.java
+++ b/src/main/java/baritone/utils/IRenderer.java
@@ -45,7 +45,6 @@ public interface IRenderer {
 
     static void startLines(Color color, float alpha, float lineWidth, boolean ignoreDepth) {
         GlStateManager.enableBlend();
-        GlStateManager.disableLighting();
         GlStateManager.tryBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
         glColor(color, alpha);
         GlStateManager.glLineWidth(lineWidth);
@@ -68,7 +67,6 @@ public interface IRenderer {
 
         GlStateManager.depthMask(true);
         GlStateManager.enableTexture2D();
-        GlStateManager.enableLighting();
         GlStateManager.disableBlend();
     }
 


### PR DESCRIPTION
In testing within Fabritone, it was found that these two lines (Which were previously used for an unknown optifine workaround) are no longer needed, and had no known side effects as of writing.

This can be backported as needed, but details are unknown how far this can go down

Future me PS: This PR is a superseed of my last one, erased during repo refactors, so now it lives on master branch. Testing recommended and can be up-ported/down-ported as you wish.
