### PR TITLE
improved mine command (range & quantity for every single block)

### DIFF
--- a/src/api/java/baritone/api/process/IMineProcess.java
+++ b/src/api/java/baritone/api/process/IMineProcess.java
@@ -21,6 +21,8 @@ import baritone.api.utils.BlockOptionalMeta;
 import baritone.api.utils.BlockOptionalMetaLookup;
 import net.minecraft.block.Block;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -34,20 +36,20 @@ public interface IMineProcess extends IBaritoneProcess {
      * the number of specified items to get from the blocks that
      * are mined.
      *
-     * @param quantity The total number of items to get
+     * @param quantity The number of items to get per block
      * @param blocks   The blocks to mine
      */
-    void mineByName(int quantity, String... blocks);
+    void mineByName(Map<BlockOptionalMeta, Integer> quantity, String... blocks);
 
     /**
      * Begin to search for and mine the specified blocks until
      * the number of specified items to get from the blocks that
      * are mined. This is based on the first target block to mine.
      *
-     * @param quantity The number of items to get from blocks mined
+     * @param quantity The number of items to get for a block
      * @param filter   The blocks to mine
      */
-    void mine(int quantity, BlockOptionalMetaLookup filter);
+    void mine(Map<BlockOptionalMeta, Integer> quantity, BlockOptionalMetaLookup filter);
 
     /**
      * Begin to search for and mine the specified blocks.
@@ -55,7 +57,11 @@ public interface IMineProcess extends IBaritoneProcess {
      * @param filter The blocks to mine
      */
     default void mine(BlockOptionalMetaLookup filter) {
-        mine(0, filter);
+        Map<BlockOptionalMeta, Integer> quantity = new HashMap<>();
+        for (BlockOptionalMeta bom : filter.blocks()) {
+            quantity.put(bom, 0);
+        }
+        mine(quantity, filter);
     }
 
     /**
@@ -64,7 +70,7 @@ public interface IMineProcess extends IBaritoneProcess {
      * @param blocks The blocks to mine
      */
     default void mineByName(String... blocks) {
-        mineByName(0, blocks);
+        mine(new BlockOptionalMetaLookup(blocks));
     }
 
     /**
@@ -72,7 +78,7 @@ public interface IMineProcess extends IBaritoneProcess {
      *
      * @param boms The blocks to mine
      */
-    default void mine(int quantity, BlockOptionalMeta... boms) {
+    default void mine(Map<BlockOptionalMeta, Integer> quantity, BlockOptionalMeta... boms) {
         mine(quantity, new BlockOptionalMetaLookup(boms));
     }
 
@@ -82,16 +88,20 @@ public interface IMineProcess extends IBaritoneProcess {
      * @param boms The blocks to mine
      */
     default void mine(BlockOptionalMeta... boms) {
-        mine(0, boms);
+        Map<BlockOptionalMeta, Integer> quantity = new HashMap<>();
+        for (BlockOptionalMeta bom : boms) {
+            quantity.put(bom, 0);
+        }
+        mine(quantity, boms);
     }
 
     /**
      * Begin to search for and mine the specified blocks.
      *
-     * @param quantity The total number of items to get
+     * @param quantity The number of items to get for a block block
      * @param blocks   The blocks to mine
      */
-    default void mine(int quantity, Block... blocks) {
+    default void mine(Map<BlockOptionalMeta, Integer> quantity, Block... blocks) {
         mine(quantity, new BlockOptionalMetaLookup(
                 Stream.of(blocks)
                         .map(BlockOptionalMeta::new)
@@ -105,7 +115,12 @@ public interface IMineProcess extends IBaritoneProcess {
      * @param blocks The blocks to mine
      */
     default void mine(Block... blocks) {
-        mine(0, blocks);
+        BlockOptionalMetaLookup boml = new BlockOptionalMetaLookup(Stream.of(blocks).map(BlockOptionalMeta::new).toArray(BlockOptionalMeta[]::new));
+        Map<BlockOptionalMeta, Integer> quantity = new HashMap<>();
+        for (BlockOptionalMeta bom : boml.blocks()) {
+            quantity.put(bom, 0);
+        }
+        mine(quantity, boml);
     }
 
     /**

--- a/src/api/java/baritone/api/process/IMineProcess.java
+++ b/src/api/java/baritone/api/process/IMineProcess.java
@@ -20,6 +20,7 @@ package baritone.api.process;
 import baritone.api.utils.BlockOptionalMeta;
 import baritone.api.utils.BlockOptionalMetaLookup;
 import net.minecraft.block.Block;
+import net.minecraft.util.math.BlockPos;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,14 +43,16 @@ public interface IMineProcess extends IBaritoneProcess {
     void mineByName(Map<BlockOptionalMeta, Integer> quantity, String... blocks);
 
     /**
-     * Begin to search for and mine the specified blocks until
+     * Begin to search for and mine the specified blocks in a specified radius until
      * the number of specified items to get from the blocks that
      * are mined. This is based on the first target block to mine.
      *
+     * @param startPos center of the circle
+     * @param radius   radius of the circle that is used for mining
      * @param quantity The number of items to get for a block
      * @param filter   The blocks to mine
      */
-    void mine(Map<BlockOptionalMeta, Integer> quantity, BlockOptionalMetaLookup filter);
+    void mine(BlockPos startPos, int radius, Map<BlockOptionalMeta, Integer> quantity, BlockOptionalMetaLookup filter);
 
     /**
      * Begin to search for and mine the specified blocks.
@@ -61,7 +64,7 @@ public interface IMineProcess extends IBaritoneProcess {
         for (BlockOptionalMeta bom : filter.blocks()) {
             quantity.put(bom, 0);
         }
-        mine(quantity, filter);
+        mine(null, 0, quantity, filter);
     }
 
     /**
@@ -79,7 +82,7 @@ public interface IMineProcess extends IBaritoneProcess {
      * @param boms The blocks to mine
      */
     default void mine(Map<BlockOptionalMeta, Integer> quantity, BlockOptionalMeta... boms) {
-        mine(quantity, new BlockOptionalMetaLookup(boms));
+        mine(null, 0, quantity, new BlockOptionalMetaLookup(boms));
     }
 
     /**
@@ -102,7 +105,7 @@ public interface IMineProcess extends IBaritoneProcess {
      * @param blocks   The blocks to mine
      */
     default void mine(Map<BlockOptionalMeta, Integer> quantity, Block... blocks) {
-        mine(quantity, new BlockOptionalMetaLookup(
+        mine(null, 0, quantity, new BlockOptionalMetaLookup(
                 Stream.of(blocks)
                         .map(BlockOptionalMeta::new)
                         .toArray(BlockOptionalMeta[]::new)
@@ -120,7 +123,7 @@ public interface IMineProcess extends IBaritoneProcess {
         for (BlockOptionalMeta bom : boml.blocks()) {
             quantity.put(bom, 0);
         }
-        mine(quantity, boml);
+        mine(null, 0, quantity, boml);
     }
 
     /**

--- a/src/main/java/baritone/command/defaults/MineCommand.java
+++ b/src/main/java/baritone/command/defaults/MineCommand.java
@@ -18,17 +18,16 @@
 package baritone.command.defaults;
 
 import baritone.api.IBaritone;
-import baritone.api.utils.BlockOptionalMeta;
 import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
 import baritone.api.command.datatypes.BlockById;
 import baritone.api.command.datatypes.ForBlockOptionalMeta;
 import baritone.api.command.exception.CommandException;
-import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.exception.CommandNotEnoughArgumentsException;
+import baritone.api.utils.BlockOptionalMeta;
 import baritone.cache.WorldScanner;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Stream;
 
 public class MineCommand extends Command {
@@ -39,11 +38,20 @@ public class MineCommand extends Command {
 
     @Override
     public void execute(String label, IArgConsumer args) throws CommandException {
-        int quantity = args.getAsOrDefault(Integer.class, 0);
         args.requireMin(1);
         List<BlockOptionalMeta> boms = new ArrayList<>();
+        Map<BlockOptionalMeta, Integer> quantity = new HashMap<>();
         while (args.hasAny()) {
-            boms.add(args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE));
+            BlockOptionalMeta bom = args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE);
+            // check if there is at least 1 argument left
+            try {
+                args.peek();
+                quantity.put(bom, args.getAsOrDefault(Integer.class, 0));
+            } catch (CommandNotEnoughArgumentsException e) {
+                quantity.put(bom, 0);
+            }
+
+            boms.add(bom);
         }
         WorldScanner.INSTANCE.repack(ctx);
         logDirect(String.format("Mining %s", boms.toString()));
@@ -72,7 +80,8 @@ public class MineCommand extends Command {
                 "Usage:",
                 "> mine diamond_ore - Mines all diamonds it can find.",
                 "> mine redstone_ore lit_redstone_ore - Mines redstone ore.",
-                "> mine log:0 - Mines only oak logs."
+                "> mine log:0 - Mines only oak logs.",
+                "> mine iron_ore 64 coal_ore 128 - Mines 64 iron ore blocks and 128 coal/coal ore blocks "
         );
     }
 }


### PR DESCRIPTION
based on #2054  also allowing to set the mining quantity for every single block. the command now works like this `mine [[home] blockradius] block1 [quantity1] [block2 [quantity2] block3 [quantity3] ...]`
