### PR TITLE
don't make non-forge jars valid mods (fixes #2124)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,12 @@ javadoc {
 
 jar {
     from sourceSets.launch.output, sourceSets.api.output
+
+    if (!getProject().hasProperty("baritone.forge_build")) {
+        exclude "**/BaritoneForgeModXD.class"
+        exclude "**/mods.toml"
+    }
+
     preserveFileTimestamps = false
     reproducibleFileOrder = true
 


### PR DESCRIPTION
this excludes the files making the jar a Forge mod unless the baritone.forge_build property exists.
This does effectively nothing on 1.12.2, as the files this change removes don't exist there
fixes #2124 
<!-- No UwU's or OwO's allowed -->
