### PR TITLE
Add instructions to build with forge for minecraft 1.15+

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -83,7 +83,7 @@ Building Baritone:
 $ gradlew build
 ```
 
-For minecrat 1.15.2+, run the following instead to include the Forge jars:
+For minecraft 1.15.2+, run the following instead to include the Forge jars:
 
 ```
 $ gradlew build -Pbaritone.forge_build

--- a/SETUP.md
+++ b/SETUP.md
@@ -83,6 +83,12 @@ Building Baritone:
 $ gradlew build
 ```
 
+For minecrat 1.15.2+, run the following instead to include the Forge jars:
+
+```
+$ gradlew build -Pbaritone.forge_build
+```
+
 Running Baritone:
 
 ```


### PR DESCRIPTION
This will save someone some time figuring out why there are no forge jars

