### PR TITLE
Fix SpongePowered Maven repo URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         }
         maven {
             name = 'SpongePowered'
-            url = 'http://repo.spongepowered.org/maven'
+            url = 'https://repo.spongepowered.org/repository/maven-public/'
         }
         jcenter()
     }
@@ -80,7 +80,7 @@ repositories {
 
     maven {
         name = 'spongepowered-repo'
-        url = 'http://repo.spongepowered.org/maven/'
+        url = 'https://repo.spongepowered.org/repository/maven-public/'
     }
 
     maven {


### PR DESCRIPTION
SpongePowered recently changed their Maven repo URL, so this is the right one
