### PR TITLE
compatibility for SodiumChunkManager

### DIFF
--- a/src/launch/java/baritone/launch/mixins/MixinSodiumChunkProvider.java
+++ b/src/launch/java/baritone/launch/mixins/MixinSodiumChunkProvider.java
@@ -75,18 +75,15 @@ public class MixinSodiumChunkProvider implements IClientChunkProvider {
     
     @Override
     public ISodiumChunkArray extractReferenceArray() {
+        https://docs.oracle.com/javase/specs/jls/se7/html/jls-14.html#jls-14.15
         if (chunkArrayField == null) {
-            boolean flag = true;
             for (Field f : this.getClass().getDeclaredFields()) {
                 if (ISodiumChunkArray.class.isAssignableFrom(f.getType())) {
                     chunkArrayField = f;
-                    flag = false;
-                    break;
+                    break https;
                 }
-            } // else
-            if (flag) {
-                throw new RuntimeException(Arrays.toString(this.getClass().getDeclaredFields()));
             }
+            throw new RuntimeException(Arrays.toString(this.getClass().getDeclaredFields()));
         }
         try {
             return (ISodiumChunkArray) chunkArrayField.get(this);

--- a/src/launch/java/baritone/launch/mixins/MixinSodiumChunkProvider.java
+++ b/src/launch/java/baritone/launch/mixins/MixinSodiumChunkProvider.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.launch.mixins;
+
+import baritone.utils.accessor.IChunkArray;
+import baritone.utils.accessor.IClientChunkProvider;
+import baritone.utils.accessor.ISodiumChunkArray;
+import net.minecraft.client.multiplayer.ClientChunkProvider;
+import net.minecraft.client.world.ClientWorld;
+import org.spongepowered.asm.mixin.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.concurrent.locks.StampedLock;
+
+@Pseudo
+@Mixin(targets = "me.jellysquid.mods.sodium.client.world.SodiumChunkManager", remap = false)
+public class MixinSodiumChunkProvider implements IClientChunkProvider {
+    
+    @Shadow
+    @Final
+    private StampedLock lock;
+    
+    @Shadow
+    @Final
+    private ClientWorld world;
+    
+    @Shadow
+    private int radius;
+    
+    @Unique
+    private static Constructor<?> thisConstructor = null;
+    
+    @Unique
+    private static Field chunkArrayField = null;
+    
+    @Override
+    public ClientChunkProvider createThreadSafeCopy() {
+        // similar operation to https://github.com/jellysquid3/sodium-fabric/blob/d3528521d48a130322c910c6f0725cf365ebae6f/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java#L139
+        long stamp = this.lock.writeLock();
+        
+        try {
+            ISodiumChunkArray refArray = extractReferenceArray();
+            if (thisConstructor == null) {
+                thisConstructor = this.getClass().getConstructor(ClientWorld.class, int.class);
+            }
+            ClientChunkProvider result = (ClientChunkProvider) thisConstructor.newInstance(world, radius - 3); // -3 because it adds 3 for no reason here too lmao
+            IChunkArray copyArr = ((IClientChunkProvider) result).extractReferenceArray();
+            copyArr.copyFrom(refArray);
+            return result;
+        } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException("Sodium chunk manager initialization for baritone failed", e);
+        } finally {
+            // put this in finally so we can't break anything.
+            this.lock.unlockWrite(stamp);
+        }
+    }
+    
+    @Override
+    public ISodiumChunkArray extractReferenceArray() {
+        if (chunkArrayField == null) {
+            boolean flag = true;
+            for (Field f : this.getClass().getDeclaredFields()) {
+                if (ISodiumChunkArray.class.isAssignableFrom(f.getType())) {
+                    chunkArrayField = f;
+                    flag = false;
+                    break;
+                }
+            } // else
+            if (flag) {
+                throw new RuntimeException(Arrays.toString(this.getClass().getDeclaredFields()));
+            }
+        }
+        try {
+            return (ISodiumChunkArray) chunkArrayField.get(this);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/launch/java/baritone/launch/mixins/MixinSodiumFixedLongHashTable.java
+++ b/src/launch/java/baritone/launch/mixins/MixinSodiumFixedLongHashTable.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.launch.mixins;
+
+import baritone.utils.accessor.IChunkArray;
+import baritone.utils.accessor.ISodiumChunkArray;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import net.minecraft.world.chunk.Chunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+@Pseudo
+@Mixin(targets = "me.jellysquid.mods.sodium.client.util.collections.FixedLongHashTable", remap = false)
+public abstract class MixinSodiumFixedLongHashTable implements ISodiumChunkArray {
+    
+    @Shadow
+    public abstract ObjectIterator<Long2ObjectMap.Entry<Object>> iterator();
+    
+    @Shadow
+    public abstract Object put(final long k, final Object v);
+    
+    /**
+    * similar to https://github.com/jellysquid3/sodium-fabric/blob/d3528521d48a130322c910c6f0725cf365ebae6f/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java#L149
+    * except that since we aren't changing the radius, the key value doesn't change.
+    */
+    @Override
+    public void copyFrom(IChunkArray other) {
+        ObjectIterator<Long2ObjectMap.Entry<Object>> it = ((ISodiumChunkArray) other).callIterator();
+        while (it.hasNext()) {
+            Long2ObjectMap.Entry<Object> entry = it.next();
+            this.put(entry.getLongKey(), entry.getValue());
+        }
+    }
+    
+    @Override
+    public ObjectIterator<Long2ObjectMap.Entry<Object>> callIterator() {
+        return iterator();
+    }
+    
+    //these are useless here...
+    @Override
+    public AtomicReferenceArray<Chunk> getChunks() {
+        return null;
+    }
+    
+    @Override
+    public int centerX() {
+        return 0;
+    }
+    
+    @Override
+    public int centerZ() {
+        return 0;
+    }
+    
+    @Override
+    public int viewDistance() {
+        return 0;
+    }
+    
+}

--- a/src/launch/resources/mixins.baritone.json
+++ b/src/launch/resources/mixins.baritone.json
@@ -22,6 +22,8 @@
     "MixinNetworkManager",
     "MixinPlayerController",
     "MixinScreen",
+    "MixinSodiumChunkProvider",
+    "MixinSodiumFixedLongHashTable",
     "MixinWorldRenderer"
   ]
 }

--- a/src/main/java/baritone/utils/accessor/ISodiumChunkArray.java
+++ b/src/main/java/baritone/utils/accessor/ISodiumChunkArray.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils.accessor;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+
+public interface ISodiumChunkArray extends IChunkArray {
+    
+    ObjectIterator<Long2ObjectMap.Entry<Object>> callIterator();
+}


### PR DESCRIPTION
This addition adds compatibility for https://github.com/jellysquid3/sodium-fabric to baritone. It is done in this way with `@Pseudo` in order for the non fabric builds to not have issues since they obviously wouldn't be able to reference a fabric mod. this is a follow up to #2086 