### PR TITLE
Add the ability to go to items while following

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -994,6 +994,11 @@ public final class Settings {
     public final Setting<Integer> followRadius = new Setting<>(3);
 
     /**
+     * Pick up dropped items in a certain radius whilst following.
+     */
+    public final Setting<Integer> followPickUpDroppedItemRadius = new Setting<>(0);
+
+    /**
      * Turn this on if your exploration filter is enormous, you don't want it to check if it's done,
      * and you are just fine with it just hanging on completion
      */

--- a/src/main/java/baritone/process/FollowProcess.java
+++ b/src/main/java/baritone/process/FollowProcess.java
@@ -18,15 +18,14 @@
 package baritone.process;
 
 import baritone.Baritone;
-import baritone.api.pathing.goals.Goal;
-import baritone.api.pathing.goals.GoalComposite;
-import baritone.api.pathing.goals.GoalNear;
-import baritone.api.pathing.goals.GoalXZ;
+import baritone.api.pathing.goals.*;
 import baritone.api.process.IFollowProcess;
 import baritone.api.process.PathingCommand;
 import baritone.api.process.PathingCommandType;
 import baritone.utils.BaritoneProcessHelper;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
@@ -50,6 +49,13 @@ public final class FollowProcess extends BaritoneProcessHelper implements IFollo
 
     @Override
     public PathingCommand onTick(boolean calcFailed, boolean isSafeToCancel) {
+        for (Entity entity : ctx.world().loadedEntityList) {
+            if (entity instanceof EntityItem | entity instanceof EntityXPOrb) {
+                if (Math.sqrt(entity.getDistanceSq(mc.player)) < Baritone.settings().followPickUpDroppedItemRadius.value) {
+                    return new PathingCommand(new GoalBlock(new BlockPos(entity.posX, entity.posY, entity.posZ)), PathingCommandType.REVALIDATE_GOAL_AND_PATH);
+                }
+            }
+        }
         scanWorld();
         Goal goal = new GoalComposite(cache.stream().map(this::towards).toArray(Goal[]::new));
         return new PathingCommand(goal, PathingCommandType.REVALIDATE_GOAL_AND_PATH);


### PR DESCRIPTION
This is useful for hunting, when you are following an entity, if it is killed you should pick up the items produced, not just leave them on the ground.

When the setting is 0 it is off.