### PR TITLE
Fixed incorrect block pos world coordinates

### DIFF
--- a/src/main/java/baritone/cache/ChunkPacker.java
+++ b/src/main/java/baritone/cache/ChunkPacker.java
@@ -123,7 +123,7 @@ public final class ChunkPacker {
                 return PathingBlockType.AVOID;
             }
             if (x == 0 || x == 15 || z == 0 || z == 15) {
-                if (BlockLiquid.getSlopeAngle(chunk.getWorld(), new BlockPos(x + chunk.x << 4, y, z + chunk.z << 4), state.getMaterial(), state) == -1000.0F) {
+                if (BlockLiquid.getSlopeAngle(chunk.getWorld(), new BlockPos(x + (chunk.x << 4), y, z + (chunk.z << 4)), state.getMaterial(), state) == -1000.0F) {
                     return PathingBlockType.WATER;
                 }
                 return PathingBlockType.AVOID;


### PR DESCRIPTION
Hi there!! This is more of a discussion PR, because not sure if this is intended or not.

But anyways, I was working with the baritone API and I kept seeing this error being spammed in console from this chunk of code:
```[baritone.cache.ChunkPacker:pack:84]: java.lang.IllegalArgumentException: Cannot get property PropertyInteger{name=level, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]} as it does not exist in BlockState{block=minecraft:air, properties=[]}
[baritone.cache.ChunkPacker:pack:84]: 	at net.minecraft.block.state.BlockState$StateImplementation.getValue(BlockState.java:137)
[baritone.cache.ChunkPacker:pack:84]: 	at net.minecraft.block.BlockLiquid.getFlowVector(BlockLiquid.java:185)
[baritone.cache.ChunkPacker:pack:84]: 	at net.minecraft.block.BlockLiquid.getFlowDirection(BlockLiquid.java:304)
[baritone.cache.ChunkPacker:pack:84]: 	at baritone.cache.ChunkPacker.getPathingBlockType(ChunkPacker.java:126)
[baritone.cache.ChunkPacker:pack:84]: 	at baritone.cache.ChunkPacker.pack(ChunkPacker.java:71)
[baritone.cache.ChunkPacker:pack:84]: 	at baritone.cache.CachedWorld$PackerThread.run(CachedWorld.java:305)
[baritone.cache.ChunkPacker:pack:84]: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[baritone.cache.ChunkPacker:pack:84]: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[baritone.cache.ChunkPacker:pack:84]: 	at java.lang.Thread.run(Thread.java:748)
```

It seemed to be getting properties for the wrong blocks (air, dirt, etc.), even though the block at that position is supposed to be water. Looked into it, and I noticed that the chunk coordinates seem to be converted wrongly (since addition comes before bit shift). Not sure if this even causes that many issues (since no one has noticed it yet), but thought I'd drop it here!