### PR TITLE
Clear caches of schematics when moving them

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -835,6 +835,13 @@ public final class Settings {
     public final Setting<Integer> buildRepeatCount = new Setting<>(-1);
 
     /**
+     * Don't notify schematics that they are moved.
+     * e.g. replacing will replace the same spots for every repetition
+     * Mainly for backward compatibility.
+     */
+    public final Setting<Boolean> buildRepeatSneaky = new Setting<>(true);
+
+    /**
      * Allow standing above a block while mining it, in BuilderProcess
      * <p>
      * Experimental

--- a/src/api/java/baritone/api/schematic/CompositeSchematic.java
+++ b/src/api/java/baritone/api/schematic/CompositeSchematic.java
@@ -75,9 +75,7 @@ public class CompositeSchematic extends AbstractSchematic {
     @Override
     public void reset() {
         for (CompositeSchematicEntry entry : schematicArr) {
-            if (!(entry.schematic instanceof IStaticSchematic)) {
-                entry.schematic.reset();
-            }
+            entry.schematic.reset();
         }
     }
 }

--- a/src/api/java/baritone/api/schematic/CompositeSchematic.java
+++ b/src/api/java/baritone/api/schematic/CompositeSchematic.java
@@ -73,8 +73,8 @@ public class CompositeSchematic extends AbstractSchematic {
     }
 
     @Override
-    public void reset(){
-        for (CompositeSchematicEntry entry : schematicArr){
+    public void reset() {
+        for (CompositeSchematicEntry entry : schematicArr) {
             if (!(entry.schematic instanceof IStaticSchematic)) {
                 entry.schematic.reset();
             }

--- a/src/api/java/baritone/api/schematic/CompositeSchematic.java
+++ b/src/api/java/baritone/api/schematic/CompositeSchematic.java
@@ -71,4 +71,13 @@ public class CompositeSchematic extends AbstractSchematic {
         }
         return entry.schematic.desiredState(x - entry.x, y - entry.y, z - entry.z, current, approxPlaceable);
     }
+
+    @Override
+    public void reset(){
+        for (CompositeSchematicEntry entry : schematicArr){
+            if (!(entry.schematic instanceof IStaticSchematic)) {
+                entry.schematic.reset();
+            }
+        }
+    }
 }

--- a/src/api/java/baritone/api/schematic/ISchematic.java
+++ b/src/api/java/baritone/api/schematic/ISchematic.java
@@ -74,9 +74,9 @@ public interface ISchematic {
     IBlockState desiredState(int x, int y, int z, IBlockState current, List<IBlockState> approxPlaceable);
 
     /**
-    * Resets possible caches to avoid wrong behavior when moving the schematic around
-    */
-    default void reset(){}
+     * Resets possible caches to avoid wrong behavior when moving the schematic around
+     */
+    default void reset() {}
 
     /**
      * @return The width (X axis length) of this schematic

--- a/src/api/java/baritone/api/schematic/ISchematic.java
+++ b/src/api/java/baritone/api/schematic/ISchematic.java
@@ -74,6 +74,11 @@ public interface ISchematic {
     IBlockState desiredState(int x, int y, int z, IBlockState current, List<IBlockState> approxPlaceable);
 
     /**
+    * Resets possible caches to avoid wrong behavior when moving the schematic around
+    */
+    default void reset(){}
+
+    /**
      * @return The width (X axis length) of this schematic
      */
     int widthX();

--- a/src/api/java/baritone/api/schematic/ReplaceSchematic.java
+++ b/src/api/java/baritone/api/schematic/ReplaceSchematic.java
@@ -32,6 +32,18 @@ public class ReplaceSchematic extends MaskSchematic {
     }
 
     @Override
+    public void reset(){
+        // it's final, can't use this.cache = new Boolean[widthX()][heightY()][lengthZ()]
+        for (int x = 0; x < cache.length; x++){
+            for (int y = 0; y < cache[0].length; y++){
+                for (int z = 0; z < cache[0][0].length; z++){
+                    cache[x][y][z] = null;
+                }
+            }
+        }
+    }
+
+    @Override
     protected boolean partOfMask(int x, int y, int z, IBlockState currentState) {
         if (cache[x][y][z] == null) {
             cache[x][y][z] = filter.has(currentState);

--- a/src/api/java/baritone/api/schematic/ReplaceSchematic.java
+++ b/src/api/java/baritone/api/schematic/ReplaceSchematic.java
@@ -32,11 +32,11 @@ public class ReplaceSchematic extends MaskSchematic {
     }
 
     @Override
-    public void reset(){
+    public void reset() {
         // it's final, can't use this.cache = new Boolean[widthX()][heightY()][lengthZ()]
-        for (int x = 0; x < cache.length; x++){
-            for (int y = 0; y < cache[0].length; y++){
-                for (int z = 0; z < cache[0][0].length; z++){
+        for (int x = 0; x < cache.length; x++) {
+            for (int y = 0; y < cache[0].length; y++) {
+                for (int z = 0; z < cache[0][0].length; z++) {
                     cache[x][y][z] = null;
                 }
             }

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -382,9 +382,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
 
                 @Override
                 public void reset() {
-                    if (!(realSchematic instanceof IStaticSchematic)) {
-                        realSchematic.reset();
-                    }
+                    realSchematic.reset();
                 }
 
                 @Override
@@ -424,7 +422,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             // build repeat time
             layer = 0;
             origin = new BlockPos(origin).add(repeat);
-            if (!(schematic instanceof IStaticSchematic) && !Baritone.settings().buildRepeatSneaky.value) {
+            if (!Baritone.settings().buildRepeatSneaky.value) {
                 schematic.reset();
             }
             logDirect("Repeating build in vector " + repeat + ", new origin is " + origin);

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -381,6 +381,13 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 }
 
                 @Override
+                public void reset(){
+                    if (!(realSchematic instanceof IStaticSchematic)){
+                        realSchematic.reset();
+                    }
+                }
+
+                @Override
                 public int widthX() {
                     return realSchematic.widthX();
                 }
@@ -417,6 +424,9 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             // build repeat time
             layer = 0;
             origin = new BlockPos(origin).add(repeat);
+            if (!(schematic instanceof IStaticSchematic) && !Baritone.settings().buildRepeatSneaky.value){
+                schematic.reset();
+            }
             logDirect("Repeating build in vector " + repeat + ", new origin is " + origin);
             return onTick(calcFailed, isSafeToCancel);
         }

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -381,8 +381,8 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 }
 
                 @Override
-                public void reset(){
-                    if (!(realSchematic instanceof IStaticSchematic)){
+                public void reset() {
+                    if (!(realSchematic instanceof IStaticSchematic)) {
                         realSchematic.reset();
                     }
                 }
@@ -424,7 +424,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             // build repeat time
             layer = 0;
             origin = new BlockPos(origin).add(repeat);
-            if (!(schematic instanceof IStaticSchematic) && !Baritone.settings().buildRepeatSneaky.value){
+            if (!(schematic instanceof IStaticSchematic) && !Baritone.settings().buildRepeatSneaky.value) {
                 schematic.reset();
             }
             logDirect("Repeating build in vector " + repeat + ", new origin is " + origin);


### PR DESCRIPTION
Some of Baritone's schematics have a cache, that becomes outdated when the schematic is moved by `buildRepeat`. For expamle this caused `#replace` combined with `#buildRepeat` to always replace the same positions relative to the origin of the schematic.
Since this behaviour is actually being used, I added a setting to toggle it and set the default to not change anything.

fixes #1925 
<!-- No UwU's or OwO's allowed -->
