### PR TITLE
Add buildAvoidBreakCheck setting

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -207,6 +207,11 @@ public final class Settings {
     )));
 
     /**
+     * If this is true, the builder will use avoid checks from mining(for example: does will not break block near liquid).
+     */
+    public final Setting<Boolean> buildAvoidBreakCheck = new Setting<>(false);
+
+    /**
      * A list of blocks to become air
      * <p>
      * If a schematic asks for a block on this list, only air will be accepted at that location (and nothing on buildIgnoreBlocks)

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -208,7 +208,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                         continue; // irrelevant
                     }
                     IBlockState curr = bcc.bsi.get0(x, y, z);
-                    if (curr.getBlock() != Blocks.AIR && !(curr.getBlock() instanceof BlockLiquid) && !valid(curr, desired, false)) {
+                    if (curr.getBlock() != Blocks.AIR && !(curr.getBlock() instanceof BlockLiquid) && !valid(bcc.bsi, x, y, z, curr, desired, false)) {
                         BetterBlockPos pos = new BetterBlockPos(x, y, z);
                         Optional<Rotation> rot = RotationUtils.reachable(ctx.player(), pos, ctx.playerController().getBlockReachDistance());
                         if (rot.isPresent()) {
@@ -534,7 +534,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                     if (desired != null) {
                         // we care about this position
                         BetterBlockPos pos = new BetterBlockPos(x, y, z);
-                        if (valid(bcc.bsi.get0(x, y, z), desired, false)) {
+                        if (valid(bcc.bsi, x, y, z, bcc.bsi.get0(x, y, z), desired, false)) {
                             incorrectPositions.remove(pos);
                             observedCompleted.add(BetterBlockPos.longHash(pos));
                         } else {
@@ -561,7 +561,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                     }
                     if (bcc.bsi.worldContainsLoadedChunk(blockX, blockZ)) { // check if its in render distance, not if its in cache
                         // we can directly observe this block, it is in render distance
-                        if (valid(bcc.bsi.get0(blockX, blockY, blockZ), schematic.desiredState(x, y, z, current, this.approxPlaceable), false)) {
+                        if (valid(bcc.bsi, blockX, blockY, blockZ, bcc.bsi.get0(blockX, blockY, blockZ), schematic.desiredState(x, y, z, current, this.approxPlaceable), false)) {
                             observedCompleted.add(BetterBlockPos.longHash(blockX, blockY, blockZ));
                         } else {
                             incorrectPositions.add(new BetterBlockPos(blockX, blockY, blockZ));
@@ -802,6 +802,14 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         return result;
     }
 
+    private boolean valid(BlockStateInterface bsi, int x, int y, int z, IBlockState current, IBlockState desired, boolean itemVerify) {
+        if (desired.getBlock() instanceof BlockAir && Baritone.settings().buildAvoidBreakCheck.value && MovementHelper.avoidBreaking(bsi, x, y, z, desired)) {
+            return true;
+        } else {
+            return valid(current, desired, itemVerify);
+        }
+    }
+
     private boolean valid(IBlockState current, IBlockState desired, boolean itemVerify) {
         if (desired == null) {
             return true;
@@ -897,7 +905,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 }
                 // it should be a real block
                 // is it already that block?
-                if (valid(bsi.get0(x, y, z), sch, false)) {
+                if (valid(bsi, x, y, z, bsi.get0(x, y, z), sch, false)) {
                     return Baritone.settings().breakCorrectBlockPenaltyMultiplier.value;
                 } else {
                     // can break if it's wrong


### PR DESCRIPTION
Allow to deny builder break unsafe blocks (like blocks that are adjacent to liquids).

| `#set buildAvoidBreakCheck true` | `#set buildAvoidBreakCheck false` |
|----------------------------------------------|------------------------------------------------|
| ![example1.1](https://user-images.githubusercontent.com/16339036/108174280-49698680-7110-11eb-9092-5d1ffef1619f.png) | ![example1.2](https://user-images.githubusercontent.com/16339036/108174609-b11fd180-7110-11eb-98c4-9c3ea791064c.png) |
| ![example2.1](https://user-images.githubusercontent.com/16339036/108174703-d7457180-7110-11eb-9f3c-7e78249329d1.png)  | ![example2.2](https://user-images.githubusercontent.com/16339036/108174816-022fc580-7111-11eb-9d60-284cd28cbd78.png) |


### todo
English is not my native language so javadoc description may be better. "Allow edits by maintainers" checked.


### Final checklist
- [ ] I have not used any OwO's or UwU's in this pull request.