### PR TITLE
Settings to alter block treatment while builing

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -216,6 +216,13 @@ public final class Settings {
     )));
 
     /**
+     * A mapping of blocks to blocks treated as correct in their position
+     * <p>
+     * If a schematic asks for a block on this mapping, all blocks on the mapped list will be accepted at that location as well
+     */
+    public final Setting<Map<Block, List<Block>>> buildValidSubstitutes = new Setting<>(new HashMap<>());
+
+    /**
      * A list of blocks to become air
      * <p>
      * If a schematic asks for a block on this list, only air will be accepted at that location (and nothing on buildIgnoreBlocks)

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -223,6 +223,13 @@ public final class Settings {
     public final Setting<Map<Block, List<Block>>> buildValidSubstitutes = new Setting<>(new HashMap<>());
 
     /**
+     * A mapping of blocks to blocks to be built instead
+     * <p>
+     * If a schematic asks for a block on this mapping, Baritone will place the first placeable block in the mapped list
+     */
+    public final Setting<Map<Block, List<Block>>> buildSubstitutes = new Setting<>(new HashMap<>());
+
+    /**
      * A list of blocks to become air
      * <p>
      * If a schematic asks for a block on this list, only air will be accepted at that location (and nothing on buildIgnoreBlocks)

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -207,6 +207,15 @@ public final class Settings {
     )));
 
     /**
+     * A list of blocks to be treated as correct.
+     * <p>
+     * If a schematic asks for any block on this list at a certain position, it will be treated as correct, regardless of what it currently is.
+     */
+    public final Setting<List<Block>> buildSkipBlocks = new Setting<>(new ArrayList<>(Arrays.asList(
+
+    )));
+
+    /**
      * A list of blocks to become air
      * <p>
      * If a schematic asks for a block on this list, only air will be accepted at that location (and nothing on buildIgnoreBlocks)

--- a/src/api/java/baritone/api/schematic/FillSchematic.java
+++ b/src/api/java/baritone/api/schematic/FillSchematic.java
@@ -19,7 +19,6 @@ package baritone.api.schematic;
 
 import baritone.api.utils.BlockOptionalMeta;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.init.Blocks;
 
 import java.util.List;
 

--- a/src/api/java/baritone/api/schematic/FillSchematic.java
+++ b/src/api/java/baritone/api/schematic/FillSchematic.java
@@ -44,8 +44,6 @@ public class FillSchematic extends AbstractSchematic {
     public IBlockState desiredState(int x, int y, int z, IBlockState current, List<IBlockState> approxPlaceable) {
         if (bom.matches(current)) {
             return current;
-        } else if (current.getBlock() != Blocks.AIR) {
-            return Blocks.AIR.getDefaultState();
         }
         for (IBlockState placeable : approxPlaceable) {
             if (bom.matches(placeable)) {

--- a/src/api/java/baritone/api/schematic/SubstituteSchematic.java
+++ b/src/api/java/baritone/api/schematic/SubstituteSchematic.java
@@ -17,7 +17,6 @@
 
 package baritone.api.schematic;
 
-import baritone.api.utils.BlockOptionalMetaLookup;
 import net.minecraft.block.Block;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;

--- a/src/api/java/baritone/api/schematic/SubstituteSchematic.java
+++ b/src/api/java/baritone/api/schematic/SubstituteSchematic.java
@@ -23,6 +23,7 @@ import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +31,7 @@ public class SubstituteSchematic extends AbstractSchematic {
 
     private final ISchematic schematic;
     private final Map<Block, List<Block>> substitutions;
+    private final Map<IBlockState, Map<Block, IBlockState>> blockStateCache = new HashMap<>();
 
     public SubstituteSchematic(ISchematic schematic, Map<Block,List<Block>> substitutions) {
         super(schematic.widthX(), schematic.heightY(), schematic.lengthZ());
@@ -67,6 +69,9 @@ public class SubstituteSchematic extends AbstractSchematic {
     }
 
     private IBlockState withBlock(IBlockState state, Block block) {
+        if (blockStateCache.containsKey(state) && blockStateCache.get(state).containsKey(block)) {
+            return blockStateCache.get(state).get(block);
+        }
         Collection<IProperty<?>> properties = state.getPropertyKeys();
         IBlockState newState = block.getDefaultState();
         for (IProperty<?> property : properties) {
@@ -75,6 +80,7 @@ public class SubstituteSchematic extends AbstractSchematic {
             } catch (IllegalArgumentException e) { //property does not exist for target block
             }
         }
+        blockStateCache.computeIfAbsent(state, s -> new HashMap<Block,IBlockState>()).put(block, newState);
         return newState;
     }
     private <T extends Comparable<T>> IBlockState copySingleProp(IBlockState fromState, IBlockState toState, IProperty<T> prop) {

--- a/src/api/java/baritone/api/schematic/SubstituteSchematic.java
+++ b/src/api/java/baritone/api/schematic/SubstituteSchematic.java
@@ -18,6 +18,7 @@
 package baritone.api.schematic;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockAir;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -49,12 +50,12 @@ public class SubstituteSchematic extends AbstractSchematic {
             return desired;
         }
         List<Block> substitutes = substitutions.get(desiredBlock);
-        if (substitutes.contains(current.getBlock()) && !current.getBlock().equals(Blocks.AIR)) {// don't preserve air, it's almost always there and almost never wanted
+        if (substitutes.contains(current.getBlock()) && !(current.getBlock() instanceof BlockAir)) {// don't preserve air, it's almost always there and almost never wanted
             return withBlock(desired, current.getBlock());
         }
         for (Block substitute : substitutes) {
-            if (substitute.equals(Blocks.AIR)) {
-                return Blocks.AIR.getDefaultState(); // can always "place" air
+            if (substitute instanceof BlockAir) {
+                return current.getBlock() instanceof BlockAir ? current : Blocks.AIR.getDefaultState(); // can always "place" air
             }
             for (IBlockState placeable : approxPlaceable) {
                 if (substitute.equals(placeable.getBlock())) {

--- a/src/api/java/baritone/api/schematic/SubstituteSchematic.java
+++ b/src/api/java/baritone/api/schematic/SubstituteSchematic.java
@@ -49,23 +49,18 @@ public class SubstituteSchematic extends AbstractSchematic {
         }
         List<Block> substitutes = substitutions.get(desiredBlock);
         if (substitutes.contains(current.getBlock()) && !current.getBlock().equals(Blocks.AIR)) {// don't preserve air, it's almost always there and almost never wanted
-            System.out.println(String.format("%s is already placed", current));
             return current;
         }
         for (Block substitute : substitutes) {
             if (substitute.equals(Blocks.AIR)) {
-                System.out.println("air, lol");
                 return Blocks.AIR.getDefaultState(); // can always "place" air
             }
             for (IBlockState placeable : approxPlaceable) {
                 if (substitute.equals(placeable.getBlock())) {
-                    System.out.println(String.format("%s can be placed", placeable));
                     return placeable;
                 }
             }
-            System.out.println(String.format("%s is not an option", substitute));
         }
-        System.out.println(String.format("%s fail", substitutes.get(0).getDefaultState()));
         return substitutes.get(0).getDefaultState();
     }
 }

--- a/src/api/java/baritone/api/schematic/SubstituteSchematic.java
+++ b/src/api/java/baritone/api/schematic/SubstituteSchematic.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.schematic;
+
+import baritone.api.utils.BlockOptionalMetaLookup;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import java.util.List;
+import java.util.Map;
+
+public class SubstituteSchematic extends AbstractSchematic {
+
+    private final ISchematic schematic;
+    private final Map<Block, List<Block>> substitutions;
+
+    public SubstituteSchematic(ISchematic schematic, Map<Block,List<Block>> substitutions) {
+        super(schematic.widthX(), schematic.heightY(), schematic.lengthZ());
+        this.schematic = schematic;
+        this.substitutions = substitutions;
+    }
+
+    @Override
+    public boolean inSchematic(int x, int y, int z, IBlockState currentState) {
+        return schematic.inSchematic(x, y, z, currentState);
+    }
+
+    @Override
+    public IBlockState desiredState(int x, int y, int z, IBlockState current, List<IBlockState> approxPlaceable) {
+        IBlockState desired = schematic.desiredState(x, y, z, current, approxPlaceable);
+        Block desiredBlock = desired.getBlock();
+        if (!substitutions.containsKey(desiredBlock)) {
+            return desired;
+        }
+        List<Block> substitutes = substitutions.get(desiredBlock);
+        if (substitutes.contains(current.getBlock()) && !current.getBlock().equals(Blocks.AIR)) {// don't preserve air, it's almost always there and almost never wanted
+            System.out.println(String.format("%s is already placed", current));
+            return current;
+        }
+        for (Block substitute : substitutes) {
+            if (substitute.equals(Blocks.AIR)) {
+                System.out.println("air, lol");
+                return Blocks.AIR.getDefaultState(); // can always "place" air
+            }
+            for (IBlockState placeable : approxPlaceable) {
+                if (substitute.equals(placeable.getBlock())) {
+                    System.out.println(String.format("%s can be placed", placeable));
+                    return placeable;
+                }
+            }
+            System.out.println(String.format("%s is not an option", substitute));
+        }
+        System.out.println(String.format("%s fail", substitutes.get(0).getDefaultState()));
+        return substitutes.get(0).getDefaultState();
+    }
+}

--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -35,6 +35,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -260,6 +261,36 @@ public class SettingsUtil {
             @Override
             public boolean accepts(Type type) {
                 return List.class.isAssignableFrom(TypeUtils.resolveBaseClass(type));
+            }
+        },
+        MAPPING() {
+            @Override
+            public Object parse(ParserContext context, String raw) {
+                Type keyType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[0];
+                Type valueType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[1];
+                Parser keyParser = Parser.getParser(keyType);
+                Parser valueParser = Parser.getParser(valueType);
+
+                return Stream.of(raw.split(",(?=[^,]*->)"))
+                        .map(s -> s.split("->"))
+                        .collect(Collectors.toMap(s -> keyParser.parse(context, s[0]), s -> valueParser.parse(context, s[1])));
+            }
+
+            @Override
+            public String toString(ParserContext context, Object value) {
+                Type keyType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[0];
+                Type valueType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[1];
+                Parser keyParser = Parser.getParser(keyType);
+                Parser valueParser = Parser.getParser(valueType);
+
+                return ((Map<?,?>) value).entrySet().stream()
+                        .map(o -> keyParser.toString(context, o.getKey()) + "->" + valueParser.toString(context, o.getValue()))
+                        .collect(Collectors.joining(","));
+            }
+
+            @Override
+            public boolean accepts(Type type) {
+                return Map.class.isAssignableFrom(TypeUtils.resolveBaseClass(type));
             }
         };
 

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -26,6 +26,7 @@ import baritone.api.process.IBuilderProcess;
 import baritone.api.process.PathingCommand;
 import baritone.api.process.PathingCommandType;
 import baritone.api.schematic.FillSchematic;
+import baritone.api.schematic.SubstituteSchematic;
 import baritone.api.schematic.ISchematic;
 import baritone.api.schematic.IStaticSchematic;
 import baritone.api.schematic.format.ISchematicFormat;
@@ -84,6 +85,9 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         this.name = name;
         this.schematic = schematic;
         this.realSchematic = null;
+        if (!Baritone.settings().buildSubstitutes.value.isEmpty()) {
+            this.schematic = new SubstituteSchematic(this.schematic, Baritone.settings().buildSubstitutes.value);
+        }
         int x = origin.getX();
         int y = origin.getY();
         int z = origin.getZ();

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -797,6 +797,9 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         if (Baritone.settings().buildSkipBlocks.value.contains(desired.getBlock()) && !itemVerify) {
             return true;
         }
+        if (Baritone.settings().buildValidSubstitutes.value.getOrDefault(desired.getBlock(), Arrays.asList()).contains(current.getBlock()) && !itemVerify) {
+            return true;
+        }
         return current.equals(desired);
     }
 

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -802,7 +802,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         if (Baritone.settings().buildSkipBlocks.value.contains(desired.getBlock()) && !itemVerify) {
             return true;
         }
-        if (Baritone.settings().buildValidSubstitutes.value.getOrDefault(desired.getBlock(), Arrays.asList()).contains(current.getBlock()) && !itemVerify) {
+        if (Baritone.settings().buildValidSubstitutes.value.getOrDefault(desired.getBlock(), Collections.emptyList()).contains(current.getBlock()) && !itemVerify) {
             return true;
         }
         return current.equals(desired);

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -794,7 +794,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         if (!(current.getBlock() instanceof BlockAir) && Baritone.settings().buildIgnoreExisting.value && !itemVerify) {
             return true;
         }
-        if (Baritone.settings().buildSkipBlocks.value.contains(desired.getBlock())) {
+        if (Baritone.settings().buildSkipBlocks.value.contains(desired.getBlock()) && !itemVerify) {
             return true;
         }
         return current.equals(desired);
@@ -834,7 +834,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 return COST_INF;
             }
             IBlockState sch = getSchematic(x, y, z, current);
-            if (sch != null) {
+            if (sch != null && !Baritone.settings().buildSkipBlocks.value.contains(sch.getBlock())) {
                 // TODO this can return true even when allowPlace is off.... is that an issue?
                 if (sch.getBlock() == Blocks.AIR) {
                     // we want this to be air, but they're asking if they can place here
@@ -868,7 +868,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 return COST_INF;
             }
             IBlockState sch = getSchematic(x, y, z, current);
-            if (sch != null) {
+            if (sch != null && !Baritone.settings().buildSkipBlocks.value.contains(sch.getBlock())) {
                 if (sch.getBlock() == Blocks.AIR) {
                     // it should be air
                     // regardless of current contents, we can break it

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -576,7 +576,8 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                         continue;
                     }
                     // this is not in render distance
-                    if (!observedCompleted.contains(BetterBlockPos.longHash(blockX, blockY, blockZ))) {
+                    if (!observedCompleted.contains(BetterBlockPos.longHash(blockX, blockY, blockZ))
+                          && !Baritone.settings().buildSkipBlocks.value.contains(schematic.desiredState(x, y, z, current, this.approxPlaceable).getBlock())) {
                         // and we've never seen this position be correct
                         // therefore mark as incorrect
                         incorrectPositions.add(new BetterBlockPos(blockX, blockY, blockZ));

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -794,6 +794,9 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         if (!(current.getBlock() instanceof BlockAir) && Baritone.settings().buildIgnoreExisting.value && !itemVerify) {
             return true;
         }
+        if (Baritone.settings().buildSkipBlocks.value.contains(desired.getBlock())) {
+            return true;
+        }
         return current.equals(desired);
     }
 


### PR DESCRIPTION
This adds the following new settings
* `#buildSkipBlocks` a list of blocks that are treated as if they were outside the schematic
* `#buildValidSubstitutes` a mapping of blocks to blocks that are treated as correct in their position<br>the same as what `#buildIgnoreExisting` does, but more general
* `#buildSubstitutes` a mapping of blocks to blocks that will be placed instead, preferring blocks in the order they are given in

While writing this I noticed that this additionally "breaks" buildIgnoreBlocks so that the behaviour is now the same for filling and building schematics from disk and fits the behaviour the user would expect after reading the documentation, which wasn't the case for filling.

closes #2323
closes #2225
fixes #2344 
fixes #2318
and from what @scorbett123 said I conclude this should fix #2227 as well
maybe fixes #1523
that's more closed issues for a side effect of this pr (4 duplicates/symptoms of 1 bug) than for what it was made for (2 enhancements), lol  
<!-- No UwU's or OwO's allowed -->
