### PR TITLE
fix replaymod crash (on newer versions)

### DIFF
--- a/src/main/java/baritone/cache/WorldProvider.java
+++ b/src/main/java/baritone/cache/WorldProvider.java
@@ -77,7 +77,14 @@ public class WorldProvider implements IWorldProvider, Helper {
             directory = new File(directory, "baritone");
             readme = directory;
         } else { // Otherwise, the server must be remote...
-            String folderName = mc.getCurrentServerData().serverIP;
+            String folderName;
+            if (mc.getCurrentServerData() != null) {
+                folderName = mc.getCurrentServerData().serverIP;
+            } else {
+                //replaymod causes null currentServerData and false singleplayer.
+                currentWorld = null;
+                return;
+            }
             if (SystemUtils.IS_OS_WINDOWS) {
                 folderName = folderName.replace(":", "_");
             }


### PR DESCRIPTION
On some newer versions of minecraft replaymod will leave some fields null causing a NPE when loading/viewing a replay. Since you can't baritone in replays anyway, I just cancel the function and set the current world to null. 

realms is false so when merging up you can have that as it's own if statement outside this one. ie,
```java
String folderName;
if (mc.isConnectedToRealms()) {
    folderName = "realms";
} else {
    if (mc.getCurrentServerData() != null) {
        folderName = mc.getCurrentServerData().serverIP;
    } else {
        //replaymod causes null currentServerData and false singleplayer.
        currentWorld = null;
        return;
    }
}
```
https://github.com/wagyourtail/baritone/tree/replaymod-1.16.5
fixes #2619, #2769 (more detailed duplicate)