### PR TITLE
Add setting to only build selected part of schematica schematic

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -848,6 +848,11 @@ public final class Settings {
     public final Setting<Boolean> skipFailedLayers = new Setting<>(false);
 
     /**
+     * Only build the selected part of the schematic when using #schematica
+     */
+     public final Setting<Boolean> schematicaOnlyBuildSelection = new Setting<>(false);
+
+    /**
      * How far to move before repeating the build. 0 to disable repeating on a certain axis, 0,0,0 to disable entirely
      */
     public final Setting<Vec3i> buildRepeat = new Setting<>(new Vec3i(0, 0, 0));

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -848,9 +848,9 @@ public final class Settings {
     public final Setting<Boolean> skipFailedLayers = new Setting<>(false);
 
     /**
-     * Only build the selected part of the schematic when using #schematica
+     * Only build the selected part of schematics
      */
-     public final Setting<Boolean> schematicaOnlyBuildSelection = new Setting<>(false);
+     public final Setting<Boolean> buildOnlySelection = new Setting<>(false);
 
     /**
      * How far to move before repeating the build. 0 to disable repeating on a certain axis, 0,0,0 to disable entirely

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -141,6 +141,11 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             parsed = new MapArtSchematic((IStaticSchematic) parsed);
         }
 
+        if (Baritone.settings().buildOnlySelection.value) {
+            parsed = new SelectionSchematic(parsed, origin, baritone.getSelectionManager().getSelections());
+        }
+
+
         build(name, parsed, origin);
         return true;
     }
@@ -153,7 +158,9 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 IStaticSchematic s = schematic.get().getFirst();
                 BlockPos origin = schematic.get().getSecond();
                 ISchematic schem = Baritone.settings().mapArtMode.value ? new MapArtSchematic(s) : s;
-                schem = Baritone.settings().schematicaOnlyBuildSelection.value ? new SelectionSchematic(schem, origin, baritone.getSelectionManager().getSelections()) : schem;
+                if (Baritone.settings().buildOnlySelection.value) {
+                    schem = new SelectionSchematic(schem, origin, baritone.getSelectionManager().getSelections());
+                }
                 this.build(
                         schematic.get().getFirst().toString(),
                         schem,

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -43,6 +43,7 @@ import baritone.utils.BlockStateInterface;
 import baritone.utils.NotificationHelper;
 import baritone.utils.PathingCommandContext;
 import baritone.utils.schematic.MapArtSchematic;
+import baritone.utils.schematic.SelectionSchematic;
 import baritone.utils.schematic.SchematicSystem;
 import baritone.utils.schematic.schematica.SchematicaHelper;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
@@ -150,10 +151,13 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             Optional<Tuple<IStaticSchematic, BlockPos>> schematic = SchematicaHelper.getOpenSchematic();
             if (schematic.isPresent()) {
                 IStaticSchematic s = schematic.get().getFirst();
+                BlockPos origin = schematic.get().getSecond();
+                ISchematic schem = Baritone.settings().mapArtMode.value ? new MapArtSchematic(s) : s;
+                schem = Baritone.settings().schematicaOnlyBuildSelection.value ? new SelectionSchematic(schem, origin, baritone.getSelectionManager().getSelections()) : schem;
                 this.build(
                         schematic.get().getFirst().toString(),
-                        Baritone.settings().mapArtMode.value ? new MapArtSchematic(s) : s,
-                        schematic.get().getSecond()
+                        schem,
+                        origin
                 );
             } else {
                 logDirect("No schematic currently open");

--- a/src/main/java/baritone/utils/schematic/SelectionSchematic.java
+++ b/src/main/java/baritone/utils/schematic/SelectionSchematic.java
@@ -22,7 +22,7 @@ import baritone.api.schematic.MaskSchematic;
 import baritone.api.selection.ISelection;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3i;
 
 import java.util.stream.Stream;
 
@@ -30,17 +30,14 @@ public class SelectionSchematic extends MaskSchematic {
 
     private final ISelection[] selections;
 
-    public SelectionSchematic(ISchematic schematic, BlockPos origin, ISelection[] selections) {
+    public SelectionSchematic(ISchematic schematic, Vec3i origin, ISelection[] selections) {
         super(schematic);
-        baritone.api.utils.Helper.HELPER.logDirect(String.format("%s", selections[0].min()));
         this.selections = Stream.of(selections).map(
                 sel -> sel
                     .shift(EnumFacing.WEST, origin.getX())
                     .shift(EnumFacing.DOWN, origin.getY())
                     .shift(EnumFacing.NORTH, origin.getZ()))
                 .toArray(ISelection[]::new);
-        baritone.api.utils.Helper.HELPER.logDirect(String.format("%s", this.selections[0].min()));
-        baritone.api.utils.Helper.HELPER.logDirect(String.format("%s", origin));
     }
 
     @Override

--- a/src/main/java/baritone/utils/schematic/SelectionSchematic.java
+++ b/src/main/java/baritone/utils/schematic/SelectionSchematic.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils.schematic;
+
+import baritone.api.schematic.ISchematic;
+import baritone.api.schematic.MaskSchematic;
+import baritone.api.selection.ISelection;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.stream.Stream;
+
+public class SelectionSchematic extends MaskSchematic {
+
+    private final ISelection[] selections;
+
+    public SelectionSchematic(ISchematic schematic, BlockPos origin, ISelection[] selections) {
+        super(schematic);
+        baritone.api.utils.Helper.HELPER.logDirect(String.format("%s", selections[0].min()));
+        this.selections = Stream.of(selections).map(
+                sel -> sel
+                    .shift(EnumFacing.WEST, origin.getX())
+                    .shift(EnumFacing.DOWN, origin.getY())
+                    .shift(EnumFacing.NORTH, origin.getZ()))
+                .toArray(ISelection[]::new);
+        baritone.api.utils.Helper.HELPER.logDirect(String.format("%s", this.selections[0].min()));
+        baritone.api.utils.Helper.HELPER.logDirect(String.format("%s", origin));
+    }
+
+    @Override
+    protected boolean partOfMask(int x, int y, int z, IBlockState currentState) {
+        for (ISelection selection : selections) {
+            if (x >= selection.min().x && y >= selection.min().y && z >= selection.min().z
+             && x <= selection.max().x && y <= selection.max().y && z <= selection.max().z) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
I have made it like it was suggested in #2612, but I'm not really happy with it because
* I think it should be useable for `#build` as well (easy with the current implementation, just have to copy the logic to the respective method)
* I don't like the fact that it is a setting functioning as an argument (`#schematica <selectionOnly` but what signature would `#build` have?)

and less important
* I don't like the fact that it is a schematic knowing it's own (initial) position, but can't think of a cleaner solution
* a better name would be nice

closes #2612
<!-- No UwU's or OwO's allowed -->
