### PR TITLE
farm: Fortune support

### DIFF
--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -122,6 +122,8 @@ public class ToolSet {
         double highestSpeed = Double.NEGATIVE_INFINITY;
         int lowestCost = Integer.MIN_VALUE;
         boolean bestSilkTouch = false;
+        int bestFortune = Integer.MIN_VALUE;
+        boolean isCrop = b instanceof CropBlock;
         IBlockState blockState = b.getDefaultState();
         for (int i = 0; i < 9; i++) {
             ItemStack itemStack = player.inventory.getStackInSlot(i);
@@ -134,11 +136,13 @@ public class ToolSet {
             }
             double speed = calculateSpeedVsBlock(itemStack, blockState);
             boolean silkTouch = hasSilkTouch(itemStack);
+            int fortune = EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, itemStack);
             if (speed > highestSpeed) {
                 highestSpeed = speed;
                 best = i;
                 lowestCost = getMaterialCost(itemStack);
                 bestSilkTouch = silkTouch;
+                bestFortune = fortune;
             } else if (speed == highestSpeed) {
                 int cost = getMaterialCost(itemStack);
                 if ((cost < lowestCost && (silkTouch || !bestSilkTouch)) ||
@@ -147,6 +151,7 @@ public class ToolSet {
                     best = i;
                     lowestCost = cost;
                     bestSilkTouch = silkTouch;
+                    bestFortune = fortune;
                 }
             }
         }


### PR DESCRIPTION
I'm trying to add [Fortune](https://minecraft.gamepedia.com/Fortune) support to `.b farm`.

Since breaking 0-hardness crops (i.e. Wheat, Carrots, Potatoes, and Nether Wart) does not use a tool's durability, should I selectively ignore the `cost` ca. the `else if` statement here in order to prefer (e.g.) a Golden Hoe with Fortune 3 over a Netherite Pickaxe for mining those blocks in particular?

Or should this logic be injected directly into [`FarmProcess.java#PathingCommand`](https://github.com/cabaletta/baritone/blob/v1.6.3/src/main/java/baritone/process/FarmProcess.java#L236-L239), instead?