### PR TITLE
Added the waypointOnDeath setting so you can disable the creation of waypoints when you die.

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -1223,6 +1223,11 @@ public final class Settings {
     public final Setting<Boolean> notificationOnMineFail = new Setting<>(true);
 
     /**
+     * Creates a waypoint where you die
+     */
+    public final Setting<Boolean> waypointOnDeath = new Setting<>(true);
+
+    /**
      * A map of lowercase setting field names to their respective setting
      */
     public final Map<String, Setting<?>> byLowerName;

--- a/src/main/java/baritone/behavior/MemoryBehavior.java
+++ b/src/main/java/baritone/behavior/MemoryBehavior.java
@@ -174,25 +174,43 @@ public final class MemoryBehavior extends Behavior {
 
     @Override
     public void onPlayerDeath() {
-        Waypoint deathWaypoint = new Waypoint("death", Waypoint.Tag.DEATH, ctx.playerFeet());
-        baritone.getWorldProvider().getCurrentWorld().getWaypoints().addWaypoint(deathWaypoint);
-        ITextComponent component = new TextComponentString("Death position saved.");
-        component.getStyle()
-                .setColor(TextFormatting.WHITE)
-                .setHoverEvent(new HoverEvent(
-                        HoverEvent.Action.SHOW_TEXT,
-                        new TextComponentString("Click to goto death")
-                ))
-                .setClickEvent(new ClickEvent(
-                        ClickEvent.Action.RUN_COMMAND,
-                        String.format(
-                                "%s%s goto %s @ %d",
-                                FORCE_COMMAND_PREFIX,
-                                "wp",
-                                deathWaypoint.getTag().getName(),
-                                deathWaypoint.getCreationTimestamp()
-                        )
-                ));
+        ITextComponent component;
+        if (Baritone.settings().waypointOnDeath.value) {
+            Waypoint deathWaypoint = new Waypoint("death", Waypoint.Tag.DEATH, ctx.playerFeet());
+            baritone.getWorldProvider().getCurrentWorld().getWaypoints().addWaypoint(deathWaypoint);
+            component = new TextComponentString("Death position saved.");
+            component.getStyle()
+                    .setColor(TextFormatting.WHITE)
+                    .setHoverEvent(new HoverEvent(
+                            HoverEvent.Action.SHOW_TEXT,
+                            new TextComponentString("Click to goto death")
+                    ))
+                    .setClickEvent(new ClickEvent(
+                            ClickEvent.Action.RUN_COMMAND,
+                            String.format(
+                                    "%s%s goto %s @ %d",
+                                    FORCE_COMMAND_PREFIX,
+                                    "wp",
+                                    deathWaypoint.getTag().getName(),
+                                    deathWaypoint.getCreationTimestamp()
+                            )
+                    ));
+        } else {
+            component = new TextComponentString("No death position saved.");
+            component.getStyle()
+                    .setColor(TextFormatting.WHITE)
+                    .setHoverEvent(new HoverEvent(
+                            HoverEvent.Action.SHOW_TEXT,
+                            new TextComponentString("Enable waypointOnDeath")
+                    ))
+                    .setClickEvent(new ClickEvent(
+                            ClickEvent.Action.RUN_COMMAND,
+                            String.format(
+                                    "%swaypointOnDeath true",
+                                    FORCE_COMMAND_PREFIX
+                            )
+                    ));
+        }
         Helper.HELPER.logDirect(component);
     }
 


### PR DESCRIPTION
Added the waypointOnDeath setting so you can disable the creation of waypoints when you die.
They are not needed in some situations, especially when you use the same launcher profile for anarchy ánd crystal pvp servers(they are a complete waste of time and, although waypoint data is small, storage space when you die over and over and over again).