### PR TITLE
Remove broken hit count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Baritone
 <p align="center">
-  <a href="http://hits.dwyl.com/cabaletta/baritone/"><img src="http://hits.dwyl.com/cabaletta/baritone.svg" alt="HitCount"/></a>
   <a href="https://github.com/cabaletta/baritone/releases/"><img src="https://img.shields.io/github/downloads/cabaletta/baritone/total.svg" alt="GitHub All Releases"/></a>
 </p>
 


### PR DESCRIPTION
Remove this broken badge. I haven't seen it working at all in the past few weeks.