### PR TITLE
Fix proguard from being broken.

### DIFF
--- a/scripts/proguard.pro
+++ b/scripts/proguard.pro
@@ -81,7 +81,7 @@
 
 -libraryjars 'tempLibraries/netty-all-4.1.9.Final.jar'
 -libraryjars 'tempLibraries/oshi-core-1.1.jar'
--libraryjars 'tempLibraries/patchy-1.1.jar'
+-libraryjars 'tempLibraries/patchy-1.2.jar'
 -libraryjars 'tempLibraries/platform-3.4.0.jar'
 -libraryjars 'tempLibraries/realms-1.10.22.jar'
 -libraryjars 'tempLibraries/soundsystem-20120107.jar'


### PR DESCRIPTION
Currently every build is failing as soon as it is run.

This seems to be to do with a update in one of the dependencies changing the version of patchy, which wasn't later changed in proguard.pro leading to a null pointer exception.