### PR TITLE
Fixed vertical cost calculation

### DIFF
--- a/src/api/java/baritone/api/pathing/goals/GoalBlock.java
+++ b/src/api/java/baritone/api/pathing/goals/GoalBlock.java
@@ -89,7 +89,7 @@ public class GoalBlock implements Goal, IGoalRenderPos {
 
         // if yDiff is 1 that means that pos.getY()-this.y==1 which means that we're 1 block below where we should be
         // therefore going from 0,0,0 to a GoalYLevel of pos.getY()-this.y is accurate
-        heuristic += GoalYLevel.calculate(yDiff, 0);
+        heuristic += GoalYLevel.calculate(0, yDiff);
 
         //use the pythagorean and manhattan mixture from GoalXZ
         heuristic += GoalXZ.calculate(xDiff, zDiff);


### PR DESCRIPTION
See [#2947](https://github.com/cabaletta/baritone/issues/2947) for more information.

Essentially, when baritone calculated vertical costs in combination with horizontal costs (as in [GoalBlock.java](https://github.com/cabaletta/baritone/blob/13d0e2a5bf0dbff3fcfe4d1c9def6add3af1bdbf/src/api/java/baritone/api/pathing/goals/GoalBlock.java)), it calculated falling costs when it needed to go up and jumping costs when it needed to go down.

This change should fix 'GoalBlock', 'GoalNear' and 'GoalTwoBlocks'.