### PR TITLE
better follow command error handling

### DIFF
--- a/src/main/java/baritone/command/defaults/FollowCommand.java
+++ b/src/main/java/baritone/command/defaults/FollowCommand.java
@@ -20,15 +20,12 @@ package baritone.command.defaults;
 import baritone.KeepName;
 import baritone.api.IBaritone;
 import baritone.api.command.Command;
-import baritone.api.command.ICommand;
 import baritone.api.command.argument.IArgConsumer;
-import baritone.api.command.argument.ICommandArgument;
 import baritone.api.command.datatypes.EntityClassById;
 import baritone.api.command.datatypes.IDatatypeFor;
 import baritone.api.command.datatypes.NearbyPlayer;
 import baritone.api.command.exception.CommandErrorMessageException;
 import baritone.api.command.exception.CommandException;
-import baritone.api.command.exception.CommandInvalidArgumentException;
 import baritone.api.command.helpers.TabCompleteHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -165,7 +162,7 @@ public class FollowCommand extends Command {
     public static class NoEntitiesException extends CommandErrorMessageException {
 
         protected NoEntitiesException() {
-            super("no valid entites in range!");
+            super("No valid entities in range!");
         }
 
     }


### PR DESCRIPTION
this change allows the follow command to yell at player when no valid entities are in range instead of spitting a log that ends up being the most common issue on the issue tracker.
![image](https://user-images.githubusercontent.com/6234704/136624184-6576f27e-ae25-46e5-839e-84258eb78602.png)
