### PR TITLE
fix Null params on getCollisionShape causing NPEs

### DIFF
--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -39,6 +39,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockReader;
 
+import java.util.List;
 import java.util.Optional;
 
 import static baritone.pathing.movement.Movement.HORIZONTALS_BUT_ALSO_DOWN_____SO_EVERY_DIRECTION_EXCEPT_UP;
@@ -522,7 +523,12 @@ public interface MovementHelper extends ActionCosts, Helper {
                 || block instanceof ShulkerBoxBlock) {
             return false;
         }
-        return Block.isOpaque(state.getCollisionShape(null, null));
+        try {
+            return Block.isOpaque(state.getCollisionShape(null, null));
+        } catch (Exception ignored) {
+            // if we can't get the collision shape, assume it's bad and add to blocksToAvoid
+        }
+        return false;
     }
 
     static PlaceResult attemptToPlaceABlock(MovementState state, IBaritone baritone, BlockPos placeAt, boolean preferDown, boolean wouldSneak) {


### PR DESCRIPTION
player can get stuck on the "irregular" blocks if looking at the center of the block doesn't actually target it for breaking. I see that as "acceptable" but lmk if I should dynamically add them to blocksToAvoidBreaking as they come up

fixes #2148
