### PR TITLE
Fix fabric building due to dependency issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ buildscript {
     dependencies {
         classpath group: 'com.github.ImpactDevelopment', name: 'ForgeGradle', version: '3.0.115'
         classpath group: 'com.github.ImpactDevelopment', name: 'MixinGradle', version: '0.6.2'
-        classpath group: 'net.fabricmc', name: 'fabric-loom', version: '0.5-SNAPSHOT'
+        classpath group: 'net.fabricmc', name: 'fabric-loom', version: '0.7-SNAPSHOT'
     }
 }
 


### PR DESCRIPTION
there was an issue where one of the eclipse org dependencies updated to require java 11 on a minor version, changing to loom 7 fixes it... please consider merging #2814 instead of going up with this to 1.16