### PR TITLE
Settable IWorldScanner

### DIFF
--- a/src/api/java/baritone/api/IBaritoneProvider.java
+++ b/src/api/java/baritone/api/IBaritoneProvider.java
@@ -88,4 +88,11 @@ public interface IBaritoneProvider {
      * @return The {@link ISchematicSystem} instance.
      */
     ISchematicSystem getSchematicSystem();
+
+    /**
+     * @param scanner new world scanner to replace current
+     *
+     * @return current world scanner
+     */
+    IWorldScanner overrideWorldScanner(IWorldScanner scanner);
 }

--- a/src/main/java/baritone/BaritoneProvider.java
+++ b/src/main/java/baritone/BaritoneProvider.java
@@ -34,10 +34,12 @@ import java.util.List;
  * @author Brady
  * @since 9/29/2018
  */
+@SuppressWarnings("Idea: FieldMayBeFinal")
 public final class BaritoneProvider implements IBaritoneProvider {
 
     private final Baritone primary;
     private final List<IBaritone> all;
+    private IWorldScanner worldScanner = WorldScanner.INSTANCE;
 
     {
         this.primary = new Baritone();
@@ -59,7 +61,7 @@ public final class BaritoneProvider implements IBaritoneProvider {
 
     @Override
     public IWorldScanner getWorldScanner() {
-        return WorldScanner.INSTANCE;
+        return worldScanner;
     }
 
     @Override
@@ -71,4 +73,10 @@ public final class BaritoneProvider implements IBaritoneProvider {
     public ISchematicSystem getSchematicSystem() {
         return SchematicSystem.INSTANCE;
     }
+
+    @Override
+    public IWorldScanner overrideWorldScanner(IWorldScanner scanner) {
+        return worldScanner;
+    }
+
 }

--- a/src/main/java/baritone/BaritoneProvider.java
+++ b/src/main/java/baritone/BaritoneProvider.java
@@ -76,7 +76,9 @@ public final class BaritoneProvider implements IBaritoneProvider {
 
     @Override
     public IWorldScanner overrideWorldScanner(IWorldScanner scanner) {
-        return worldScanner;
+        IWorldScanner old = this.worldScanner;
+        this.worldScanner = scanner;
+        return old;
     }
 
 }

--- a/src/main/java/baritone/cache/WorldScanner.java
+++ b/src/main/java/baritone/cache/WorldScanner.java
@@ -17,6 +17,7 @@
 
 package baritone.cache;
 
+import baritone.api.IBaritoneProvider;
 import baritone.api.cache.ICachedWorld;
 import baritone.api.cache.IWorldScanner;
 import baritone.api.utils.BetterBlockPos;
@@ -35,7 +36,9 @@ import java.util.*;
 import java.util.stream.IntStream;
 
 public enum WorldScanner implements IWorldScanner {
-
+    /**
+     * don't access directly, use through {@link IBaritoneProvider#getWorldScanner()}
+     */
     INSTANCE;
 
     private static final int[] DEFAULT_COORDINATE_ITERATION_ORDER = IntStream.range(0, 16).toArray();

--- a/src/main/java/baritone/command/defaults/MineCommand.java
+++ b/src/main/java/baritone/command/defaults/MineCommand.java
@@ -17,6 +17,8 @@
 
 package baritone.command.defaults;
 
+import baritone.Baritone;
+import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.command.Command;
 import baritone.api.command.argument.IArgConsumer;
@@ -45,7 +47,7 @@ public class MineCommand extends Command {
         while (args.hasAny()) {
             boms.add(args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE));
         }
-        WorldScanner.INSTANCE.repack(ctx);
+        BaritoneAPI.getProvider().getWorldScanner().repack(ctx);
         logDirect(String.format("Mining %s", boms.toString()));
         baritone.getMineProcess().mine(quantity, boms.toArray(new BlockOptionalMeta[0]));
     }

--- a/src/main/java/baritone/command/defaults/PathCommand.java
+++ b/src/main/java/baritone/command/defaults/PathCommand.java
@@ -17,6 +17,7 @@
 
 package baritone.command.defaults;
 
+import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.command.Command;
 import baritone.api.command.argument.IArgConsumer;
@@ -38,7 +39,7 @@ public class PathCommand extends Command {
     public void execute(String label, IArgConsumer args) throws CommandException {
         ICustomGoalProcess customGoalProcess = baritone.getCustomGoalProcess();
         args.requireMax(0);
-        WorldScanner.INSTANCE.repack(ctx);
+        BaritoneAPI.getProvider().getWorldScanner().repack(ctx);
         customGoalProcess.path();
         logDirect("Now pathing");
     }

--- a/src/main/java/baritone/command/defaults/RepackCommand.java
+++ b/src/main/java/baritone/command/defaults/RepackCommand.java
@@ -17,6 +17,7 @@
 
 package baritone.command.defaults;
 
+import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.command.Command;
 import baritone.api.command.argument.IArgConsumer;
@@ -36,7 +37,7 @@ public class RepackCommand extends Command {
     @Override
     public void execute(String label, IArgConsumer args) throws CommandException {
         args.requireMax(0);
-        logDirect(String.format("Queued %d chunks for repacking", WorldScanner.INSTANCE.repack(ctx)));
+        logDirect(String.format("Queued %d chunks for repacking", BaritoneAPI.getProvider().getWorldScanner().repack(ctx)));
     }
 
     @Override

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -18,6 +18,7 @@
 package baritone.process;
 
 import baritone.Baritone;
+import baritone.api.BaritoneAPI;
 import baritone.api.pathing.goals.Goal;
 import baritone.api.pathing.goals.GoalBlock;
 import baritone.api.pathing.goals.GoalComposite;
@@ -189,7 +190,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         }
 
         if (Baritone.settings().mineGoalUpdateInterval.value != 0 && tickCount++ % Baritone.settings().mineGoalUpdateInterval.value == 0) {
-            Baritone.getExecutor().execute(() -> locations = WorldScanner.INSTANCE.scanChunkRadius(ctx, scan, 256, 10, 10));
+            Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
         }
         if (locations == null) {
             return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -18,6 +18,7 @@
 package baritone.process;
 
 import baritone.Baritone;
+import baritone.api.BaritoneAPI;
 import baritone.api.pathing.goals.*;
 import baritone.api.process.IMineProcess;
 import baritone.api.process.PathingCommand;
@@ -355,7 +356,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
         locs = prune(ctx, locs, filter, max, blacklist, dropped);
 
         if (!untracked.isEmpty() || (Baritone.settings().extendCacheOnThreshold.value && locs.size() < max)) {
-            locs.addAll(WorldScanner.INSTANCE.scanChunkRadius(
+            locs.addAll(BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(
                     ctx.getBaritone().getPlayerContext(),
                     filter,
                     max,


### PR DESCRIPTION
Provide functionality for the `IWorldScanner` to be overridden.
this would allow (for example) a different mod to feed in ore locations for `MineProcess`

### TODO:
[] - make `MineProcess`'s `prune` function able to not remove ores that don't match the filter when the world scanner has been overriden