### PR TITLE
Option to ignore direction of certain blocks during building

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -259,6 +259,11 @@ public final class Settings {
     public final Setting<Boolean> buildIgnoreExisting = new Setting<>(false);
 
     /**
+     * If this is true, the builder will ignore directionality of certain blocks like glazed terracotta.
+     */
+    public final Setting<Boolean> buildIgnoreDirection = new Setting<>(false);
+
+    /**
      * If this setting is true, Baritone will never break a block that is adjacent to an unsupported falling block.
      * <p>
      * I.E. it will never trigger cascading sand / gravel falls

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -48,6 +48,9 @@ import baritone.utils.schematic.schematica.SchematicaHelper;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.block.BlockAir;
 import net.minecraft.block.BlockLiquid;
+import net.minecraft.block.BlockGlazedTerracotta;
+import net.minecraft.block.BlockBone;
+import net.minecraft.block.BlockHay;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemBlock;
@@ -834,6 +837,10 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
 
     private boolean valid(IBlockState current, IBlockState desired, boolean itemVerify) {
         if (desired == null) {
+            return true;
+        }
+        if ((current.getBlock() instanceof BlockGlazedTerracotta || current.getBlock() instanceof BlockBone || current.getBlock() instanceof BlockHay)
+                && Baritone.settings().buildIgnoreDirection.value && current.getBlock() == desired.getBlock()) {
             return true;
         }
         if (current.getBlock() instanceof BlockLiquid && Baritone.settings().okIfWater.value) {


### PR DESCRIPTION
Toggling this option will let baritone place glazed terracotta, bone blocks and hay bales freely.
Current behavior (with buildignoreexisting false) often includes continuous breaking and placing the same block, as baritone does not understand how to place a block so it faces the right way.