### PR TITLE
Fix the builder place-break loop with carpet and similar blocks

### DIFF
--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -204,6 +204,9 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         if (state.getBlock() == Blocks.AIR) {
             return null;
         }
+        if (!MovementHelper.canWalkOn(new BlockStateInterface(ctx),x,y,z,state)) { // throwaways have to be canWalkOn so we have to place a wrong block here, air is separate because it is so common
+            return null;
+        }
         return state;
     }
 
@@ -924,7 +927,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                     // this won't be a schematic block, this will be a throwaway
                     return placeBlockCost * 2; // we're going to have to break it eventually
                 }
-                if (placeable.contains(sch)) {
+                if (placeable.contains(sch) && MovementHelper.canWalkOn(bsi,x,y,z,sch)) { // we can only allow placing canWalkOn blocks because of how MovementAscend breaks canWalkThrough blocks
                     return 0; // thats right we gonna make it FREE to place a block where it should go in a structure
                     // no place block penalty at all 😎
                     // i'm such an idiot that i just tried to copy and paste the epic gamer moment emoji too

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -269,7 +269,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                     }
                     IBlockState curr = bcc.bsi.get0(x, y, z);
                     if (MovementHelper.isReplaceable(x, y, z, curr, bcc.bsi) && !valid(curr, desired, false)) {
-                        if (dy == 1 && bcc.bsi.get0(x, y + 1, z).getBlock() == Blocks.AIR) {
+                        if (dy == 1 && MovementHelper.canWalkThrough(bcc.bsi, x, y + 1, z) && !MovementHelper.canWalkThrough(bcc.bsi, x, y, z, desired)) {
                             continue;
                         }
                         desirableOnHotbar.add(desired);


### PR DESCRIPTION
Pathing sometimes planned a `MovementPillar` on a carpet, which was then broken by the movement and immediately placed back by the builder and broken again by the movement and so on.
This prevents considering non `canWalkOn` blocks as a throwaway for the schematic and also places the goal next to the blocks instead of on it. Additionally the builder is now allowed to place `canWalkThrough` blocks at eye height because it can't block itself with those but it helps with decorative blocks or carpet on stairs.
I also fixed the problem of standing partially inside a block by making the builder move to the centre of `pathStart` when it can't do anything.

New problems:
It cannot place unsupported carpet (and other `canWalkThrough` blocks which need support) anymore. It previously had trouble with those and with the schematic requesting air below it got stuck in a place-break loop for the supporting block, but the problem was obviously visible. Now it just stands there doing nothing but making sure it's in the centre of the block.
I could force it to place a block below by setting the goal into the block if it is unsupported, but that would only help for `canWalkThrough` blocks needing support from below and also cause blocks being placed under any other `canWalkThrough` block like torches or signs on walls.
<!-- No UwU's or OwO's allowed -->
