### PR TITLE
Add some world border checks

### DIFF
--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -143,7 +143,6 @@ public class CalculationContext {
             return COST_INF;
         }
         if (!worldBorder.canPlaceAt(x, z)) {
-            // TODO perhaps MovementHelper.canPlaceAgainst could also use this?
             return COST_INF;
         }
         return placeBlockCost;

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -49,6 +49,9 @@ import static baritone.pathing.movement.Movement.HORIZONTALS_BUT_ALSO_DOWN_____S
 public interface MovementHelper extends ActionCosts, Helper {
 
     static boolean avoidBreaking(BlockStateInterface bsi, int x, int y, int z, IBlockState state) {
+        if (!bsi.worldBorder.canPlaceAt(x, y)) {
+            return false;
+        }
         Block b = state.getBlock();
         return Baritone.settings().blocksToDisallowBreaking.value.contains(b)
                 || b == Blocks.ICE // ice becomes water, and water can mess up the path
@@ -368,6 +371,9 @@ public interface MovementHelper extends ActionCosts, Helper {
     }
 
     static boolean canPlaceAgainst(BlockStateInterface bsi, int x, int y, int z, IBlockState state) {
+        if (!bsi.worldBorder.canPlaceAt(x, z)) {
+            return false;
+        }
         // can we look at the center of a side face of this block and likely be able to place?
         // (thats how this check is used)
         // therefore dont include weird things that we technically could place against (like carpet) but practically can't

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -50,7 +50,7 @@ public interface MovementHelper extends ActionCosts, Helper {
 
     static boolean avoidBreaking(BlockStateInterface bsi, int x, int y, int z, IBlockState state) {
         if (!bsi.worldBorder.canPlaceAt(x, y)) {
-            return false;
+            return true;
         }
         Block b = state.getBlock();
         return Baritone.settings().blocksToDisallowBreaking.value.contains(b)

--- a/src/main/java/baritone/utils/BlockStateInterface.java
+++ b/src/main/java/baritone/utils/BlockStateInterface.java
@@ -22,6 +22,7 @@ import baritone.api.utils.IPlayerContext;
 import baritone.cache.CachedRegion;
 import baritone.cache.WorldData;
 import baritone.utils.accessor.IChunkProviderClient;
+import baritone.utils.pathing.BetterWorldBorder;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minecraft.block.Block;
@@ -46,6 +47,7 @@ public class BlockStateInterface {
     protected final IBlockAccess world;
     public final BlockPos.MutableBlockPos isPassableBlockPos;
     public final IBlockAccess access;
+    public final BetterWorldBorder worldBorder;
 
     private Chunk prev = null;
     private CachedRegion prevCached = null;
@@ -64,6 +66,7 @@ public class BlockStateInterface {
 
     public BlockStateInterface(World world, WorldData worldData, boolean copyLoadedChunks) {
         this.world = world;
+        this.worldBorder = new BetterWorldBorder(world.getWorldBorder());
         this.worldData = worldData;
         Long2ObjectMap<Chunk> worldLoaded = ((IChunkProviderClient) world.getChunkProvider()).loadedChunks();
         if (copyLoadedChunks) {


### PR DESCRIPTION
Add world border checks to where they weren't previously, will help in a few cases. 

World border checks where already implemented in the actual A* though, so no edits have been done to that area of pathfinding.

Closes #3236