### PR TITLE
Sort results of the `find` command by distance to player

### DIFF
--- a/src/api/java/baritone/api/utils/BetterBlockPos.java
+++ b/src/api/java/baritone/api/utils/BetterBlockPos.java
@@ -115,6 +115,34 @@ public final class BetterBlockPos extends BlockPos {
         return oth.getX() == x && oth.getY() == y && oth.getZ() == z;
     }
 
+    /**
+     * Squared distance from this object to another. Given a null
+     * BetterBlockPos, the returned distance is -1.
+     * 
+     * This is more performant than distanceFrom due to sqrt's relatively
+     * high cost and should be used unless the exact distance is needed. For
+     * comparisons, use this.
+     */
+    public double distanceFromSquared(BetterBlockPos pos) {
+        if (pos == null) {
+            return -1
+        }
+        return Math.pow(this.x - pos.x, 2) + Math.pow(this.y - pos.y, 2) + Math.pow(this.z - pos.z, 2)
+    }
+
+    /**
+     * Distance from this object to another.
+     * 
+     * This should only be used when the exact distance is needed. The sqrt
+     * operation is somewhat heavy. Use distanceFromSquared for comparison.
+     */
+    public double distanceFrom(BetterBlockPos pos) {
+        if (pos == null) {
+            return -1
+        }
+        return Math.sqrt(distanceFromSquared(pos))
+    }
+
     @Override
     public BetterBlockPos up() {
         // this is unimaginably faster than blockpos.up

--- a/src/api/java/baritone/api/utils/BetterBlockPos.java
+++ b/src/api/java/baritone/api/utils/BetterBlockPos.java
@@ -125,9 +125,9 @@ public final class BetterBlockPos extends BlockPos {
      */
     public double distanceFromSquared(BetterBlockPos pos) {
         if (pos == null) {
-            return -1
+            return -1;
         }
-        return Math.pow(this.x - pos.x, 2) + Math.pow(this.y - pos.y, 2) + Math.pow(this.z - pos.z, 2)
+        return Math.pow(this.x - pos.x, 2) + Math.pow(this.y - pos.y, 2) + Math.pow(this.z - pos.z, 2);
     }
 
     /**
@@ -138,9 +138,9 @@ public final class BetterBlockPos extends BlockPos {
      */
     public double distanceFrom(BetterBlockPos pos) {
         if (pos == null) {
-            return -1
+            return -1;
         }
-        return Math.sqrt(distanceFromSquared(pos))
+        return Math.sqrt(distanceFromSquared(pos));
     }
 
     @Override

--- a/src/main/java/baritone/command/defaults/FindCommand.java
+++ b/src/main/java/baritone/command/defaults/FindCommand.java
@@ -54,7 +54,7 @@ public class FindCommand extends Command {
                         ).stream()
                 )
                 .map(BetterBlockPos::new)
-                .sorted(bps -> ctx.playerFeet().squaredDistanceFrom(bps))
+                .sorted((x, y) -> (int)(ctx.playerFeet().distanceFromSquared(x) - ctx.playerFeet().distanceFromSquared(y)))
                 .map(BetterBlockPos::toString)
                 .forEach(this::logDirect);
     }

--- a/src/main/java/baritone/command/defaults/FindCommand.java
+++ b/src/main/java/baritone/command/defaults/FindCommand.java
@@ -72,10 +72,11 @@ public class FindCommand extends Command {
     @Override
     public List<String> getLongDesc() {
         return Arrays.asList(
-                "",
+                "Find positions of a certain block.",
+                "Results are ordered by distance from the player.",
                 "",
                 "Usage:",
-                "> "
+                "> find <block> [block]... - List known locations of a block"
         );
     }
 }

--- a/src/main/java/baritone/command/defaults/FindCommand.java
+++ b/src/main/java/baritone/command/defaults/FindCommand.java
@@ -54,6 +54,7 @@ public class FindCommand extends Command {
                         ).stream()
                 )
                 .map(BetterBlockPos::new)
+                .sorted(bps -> ctx.playerFeet().squaredDistanceFrom(bps))
                 .map(BetterBlockPos::toString)
                 .forEach(this::logDirect);
     }


### PR DESCRIPTION
Sorts the results of the `find` command by the distance to the player. Makes reading the output much less frustrating.

Adds `distanceFrom` and `distanceFromSquared` utilities to `BetterBlockPos`

- Add distance between BetterBlockPos
- Sort find command results by distance
- Update find command usage documentation
- I've spent too much time in python, aka adding ;
- Comply to the Compatator lambda interface

<!-- No UwU's or OwO's allowed -->
