### PR TITLE
fix an array oob with dynamic worldheight

### DIFF
--- a/src/api/java/baritone/api/pathing/movement/ActionCosts.java
+++ b/src/api/java/baritone/api/pathing/movement/ActionCosts.java
@@ -66,7 +66,7 @@ public interface ActionCosts {
 
     static double[] generateFallNBlocksCost() {
         double[] costs = new double[4097];
-        for (int i = 0; i < 4096; i++) {
+        for (int i = 0; i < 4097; i++) {
             costs[i] = distanceToTicks(i);
         }
         return costs;

--- a/src/api/java/baritone/api/pathing/movement/ActionCosts.java
+++ b/src/api/java/baritone/api/pathing/movement/ActionCosts.java
@@ -65,8 +65,8 @@ public interface ActionCosts {
 
 
     static double[] generateFallNBlocksCost() {
-        double[] costs = new double[257];
-        for (int i = 0; i < 257; i++) {
+        double[] costs = new double[4097];
+        for (int i = 0; i < 4096; i++) {
             costs[i] = distanceToTicks(i);
         }
         return costs;

--- a/src/test/java/baritone/pathing/movement/ActionCostsTest.java
+++ b/src/test/java/baritone/pathing/movement/ActionCostsTest.java
@@ -26,7 +26,7 @@ public class ActionCostsTest {
 
     @Test
     public void testFallNBlocksCost() {
-        assertEquals(FALL_N_BLOCKS_COST.length, 257); // Fall 0 blocks through fall 256 blocks
+        assertEquals(FALL_N_BLOCKS_COST.length, 4097); // Fall 0 blocks through fall 4096 blocks
         for (int i = 0; i < 257; i++) {
             double blocks = ticksToBlocks(FALL_N_BLOCKS_COST[i]);
             assertEquals(blocks, i, 0.000000000001); // If you add another 0 the test fails at i=217 LOL

--- a/src/test/java/baritone/pathing/movement/ActionCostsTest.java
+++ b/src/test/java/baritone/pathing/movement/ActionCostsTest.java
@@ -27,9 +27,9 @@ public class ActionCostsTest {
     @Test
     public void testFallNBlocksCost() {
         assertEquals(FALL_N_BLOCKS_COST.length, 4097); // Fall 0 blocks through fall 4096 blocks
-        for (int i = 0; i < 257; i++) {
+        for (int i = 0; i < 4097; i++) {
             double blocks = ticksToBlocks(FALL_N_BLOCKS_COST[i]);
-            assertEquals(blocks, i, 0.000000000001); // If you add another 0 the test fails at i=217 LOL
+            assertEquals(blocks, i, 0.00000000001); // If you add another 0 the test fails at i=989 LOL
         }
         assertEquals(FALL_1_25_BLOCKS_COST, 6.2344, 0.00001);
         assertEquals(FALL_0_25_BLOCKS_COST, 3.0710, 0.00001);


### PR DESCRIPTION
```java
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: java.lang.ArrayIndexOutOfBoundsException: Index 257 out of bounds for length 257
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at baritone.pathing.movement.movements.MovementDescend.dynamicFallCost(MovementDescend.java:146)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at baritone.pathing.movement.movements.MovementDescend.cost(MovementDescend.java:104)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at baritone.pathing.movement.Moves$11.apply(Moves.java:165)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at baritone.pathing.calc.AStarPathFinder.calculate0(AStarPathFinder.java:118)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at baritone.pathing.calc.AbstractNodeCostSearch.calculate(AbstractNodeCostSearch.java:104)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at baritone.behavior.PathingBehavior.lambda$findPathInNewThread$2(PathingBehavior.java:501)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[01:26:37] [pool-3-thread-3/INFO]: [STDERR]: 	at java.base/java.lang.Thread.run(Thread.java:833)
[01:26:37] [Render thread/INFO]: [CHAT] [Baritone] Pathing exception: java.lang.ArrayIndexOutOfBoundsException: Index 257 out of bounds for length 257
```