### PR TITLE
fix modded toolmaterials (1.12.2)

### DIFF
--- a/src/launch/java/baritone/launch/mixins/MixinItemTool.java
+++ b/src/launch/java/baritone/launch/mixins/MixinItemTool.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.launch.mixins;
+
+import baritone.utils.accessor.IItemTool;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemTool;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ItemTool.class)
+public class MixinItemTool implements IItemTool {
+    @Shadow protected Item.ToolMaterial toolMaterial;
+
+    @Override
+    public int getHarvestLevel() {
+        return toolMaterial.getHarvestLevel();
+    }
+
+}

--- a/src/launch/resources/mixins.baritone.json
+++ b/src/launch/resources/mixins.baritone.json
@@ -21,6 +21,7 @@
     "MixinEntityRenderer",
     "MixinGuiScreen",
     "MixinItemStack",
+    "MixinItemTool",
     "MixinMinecraft",
     "MixinNetHandlerPlayClient",
     "MixinNetworkManager",

--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -18,6 +18,7 @@
 package baritone.utils;
 
 import baritone.Baritone;
+import baritone.utils.accessor.IItemTool;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -78,15 +79,16 @@ public class ToolSet {
 
     /**
      * Evaluate the material cost of a possible tool. The priority matches the
-     * listed order in the Item.ToolMaterial enum.
+     * harvest level order; there is a chance for multiple at the same with modded tools
+     * but in that case we don't really care.
      *
      * @param itemStack a possibly empty ItemStack
-     * @return values range from -1 to 4
+     * @return values from 0 up
      */
     private int getMaterialCost(ItemStack itemStack) {
         if (itemStack.getItem() instanceof ItemTool) {
             ItemTool tool = (ItemTool) itemStack.getItem();
-            return ToolMaterial.valueOf(tool.getToolMaterialName()).ordinal();
+            return ((IItemTool) tool).getHarvestLevel();
         } else {
             return -1;
         }

--- a/src/main/java/baritone/utils/accessor/IItemTool.java
+++ b/src/main/java/baritone/utils/accessor/IItemTool.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils.accessor;
+
+public interface IItemTool {
+
+    int getHarvestLevel();
+
+}


### PR DESCRIPTION
as per @ZacSharp 's comment in [#3008](https://github.com/cabaletta/baritone/issues/3008#issuecomment-1024290682), use harvistability level.

(I tested with cofh and it appears to have fixed that)

gold and wood have the same harvest level, but I don't think it really matters if the bot chooses the "wrong" (rarer) one between those two...

fixes #3008 
