### PR TITLE
fix inner class attribute being stripped

### DIFF
--- a/scripts/proguard.pro
+++ b/scripts/proguard.pro
@@ -1,5 +1,6 @@
 -keepattributes Signature
 -keepattributes *Annotation*
+-keepattributes InnerClasses
 
 -optimizationpasses 5
 -verbose


### PR DESCRIPTION
this fixes Setting.value issue in ide's when using the api jar as a dependency

why didn't I do this sooner. I've known about this issue for like a year...