### PR TITLE
Add support for the Structure Block file format (.nbt files)

### DIFF
--- a/src/main/java/baritone/utils/schematic/format/DefaultSchematicFormats.java
+++ b/src/main/java/baritone/utils/schematic/format/DefaultSchematicFormats.java
@@ -21,6 +21,7 @@ import baritone.api.schematic.IStaticSchematic;
 import baritone.api.schematic.format.ISchematicFormat;
 import baritone.utils.schematic.format.defaults.MCEditSchematic;
 import baritone.utils.schematic.format.defaults.SpongeSchematic;
+import baritone.utils.schematic.format.defaults.StructureNBT;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import org.apache.commons.io.FilenameUtils;
@@ -64,6 +65,18 @@ public enum DefaultSchematicFormats implements ISchematicFormat {
                 default:
                     throw new UnsupportedOperationException("Unsupported Version of a Sponge Schematic");
             }
+        }
+    },
+
+    /**
+     * The vanilla structure block file format. Commonly denoted by the ".nbt" file extension.
+     *
+     * @see <a href="https://minecraft.fandom.com/wiki/Structure_Block_file_format>Structure Block file format</a>
+     */
+    STRUCTURE("nbt") {
+        @Override
+        public IStaticSchematic parse(InputStream input) throws IOException {
+            return new StructureNBT(CompressedStreamTools.readCompressed(input));
         }
     };
 

--- a/src/main/java/baritone/utils/schematic/format/defaults/StructureNBT.java
+++ b/src/main/java/baritone/utils/schematic/format/defaults/StructureNBT.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils.schematic.format.defaults;
+
+import baritone.utils.schematic.StaticSchematic;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.structure.template.Template;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+/**
+ * @author Sam
+ * @since 03/11/2022
+ */
+public final class StructureNBT extends StaticSchematic {
+
+    public StructureNBT(NBTTagCompound schematic) {
+        Template template = new Template();
+        template.read(schematic);
+
+        BlockPos size = template.getSize();
+        this.x = size.getX();
+        this.y = size.getY();
+        this.z = size.getZ();
+
+        List<Template.BlockInfo> blocks;
+        try {
+            Field f = template.getClass().getDeclaredField("field_186270_a"); // Template.blocks
+            f.setAccessible(true);
+            blocks = (List<Template.BlockInfo>) f.get(template);
+        } catch (final Exception e) {
+            // This should never happen since SRG names are canonical
+            throw new IllegalStateException("reflection error");
+        }
+
+        this.states = new IBlockState[this.x][this.z][this.y];
+        for (Template.BlockInfo block : blocks ) {
+            this.states[block.pos.getX()][block.pos.getZ()][block.pos.getY()] = block.blockState;
+        }
+    }
+
+    @Override
+    public boolean inSchematic(int x, int y, int z, IBlockState currentState) {
+        // Filtering out Structure Void
+        if (x >= 0 && x < widthX() && y >= 0 && y < heightY() && z >= 0 && z < lengthZ()) {
+            return this.states[x][z][y] != null;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This adds support for .nbt files with the `#build` command. Small demo here: https://youtu.be/Gnp5JsKG9Ug

Closes #750 

Notes:
Tile-Entity data doesnt get read. Schematica supports this and since this is basically copy and paste from its source, it would not be difficult to add support (but i dont know enough about Baritone to know if it would make sense).
Check out the Schematica source here: https://github.com/Lunatrius/Schematica/blob/master/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicStructure.java#L30-L43

Also note that this is the first time i've ever done anything with Java, so you might wanna check everything twice :)