### PR TITLE
If context.player() returns none we don't want to use its position for pruning.

### DIFF
--- a/src/main/java/baritone/cache/CachedWorld.java
+++ b/src/main/java/baritone/cache/CachedWorld.java
@@ -209,7 +209,7 @@ public final class CachedWorld implements ICachedWorld, Helper {
     private BlockPos guessPosition() {
         for (IBaritone ibaritone : BaritoneAPI.getProvider().getAllBaritones()) {
             IWorldData data = ibaritone.getWorldProvider().getCurrentWorld();
-            if (data != null && data.getCachedWorld() == this) {
+            if (data != null && data.getCachedWorld() == this && ibaritone.getPlayerContext().player() != null) {
                 return ibaritone.getPlayerContext().playerFeet();
             }
         }


### PR DESCRIPTION
This fixes a really rare error which will crash the region saving thread, thus making it not save regions when they are explored.

This crash of that thread only occurs when time loading the minecraft world is > 30 seconds, making it pretty rare, however in these cases IPlayerContext.player() returns null, so we need to protect against this in guessing the position.

closes #3289