### PR TITLE
Build fix

### DIFF
--- a/buildSrc/src/main/java/baritone/gradle/task/BaritoneGradleTask.java
+++ b/buildSrc/src/main/java/baritone/gradle/task/BaritoneGradleTask.java
@@ -83,7 +83,7 @@ class BaritoneGradleTask extends DefaultTask {
 
     protected void verifyArtifacts() throws IllegalStateException {
         if (!Files.exists(this.artifactPath)) {
-            throw new IllegalStateException("Artifact not found! Run build first!");
+            throw new IllegalStateException("Artifact not found! Run build first! Missing file: " + this.artifactPath);
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,3 +38,5 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+rootProject.name = 'baritone'


### PR DESCRIPTION
The build failed for me and also the docker build would fail. The built artifacts are always named "baritone....jar" but the BaritoneGradleTask would look for a jar named "code....jar" (in the case of docker) because that's the name of the directory where the sources were in.

Setting the rootProject's name property to "baritone" fixes this and the build will work even when the project is located in a directory named differently than "baritone".
