### PR TITLE
Add Highlight Command

### DIFF
--- a/src/api/java/baritone/api/IBaritone.java
+++ b/src/api/java/baritone/api/IBaritone.java
@@ -59,6 +59,12 @@ public interface IBaritone {
     IMineProcess getMineProcess();
 
     /**
+     * @return The {@link IHighlightProcess} instance
+     * @see IHighlightProcess
+     */
+    IHighlightProcess getHighlightProcess();
+
+    /**
      * @return The {@link IBuilderProcess} instance
      * @see IBuilderProcess
      */

--- a/src/api/java/baritone/api/process/IHighlightProcess.java
+++ b/src/api/java/baritone/api/process/IHighlightProcess.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.process;
+
+import baritone.api.utils.BlockOptionalMeta;
+import baritone.api.utils.BlockOptionalMetaLookup;
+
+/**
+ * Highlight blocks of a certain type
+ * @author stackmagic
+ * @since 2022-03-22
+ */
+public interface IHighlightProcess {
+
+    /**
+     * Begin to search for the specified blocks until stopped.
+     *
+     * @param filter The blocks to highlight
+     */
+    void highlight(BlockOptionalMetaLookup filter);
+
+    /**
+     * Begin to search for the specified blocks until stopped.
+     *
+     * @param boms The blocks to highlight
+     */
+    default void highlight(BlockOptionalMeta... boms) {
+        highlight(new BlockOptionalMetaLookup(boms));
+    }
+}

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -23,7 +23,10 @@ import baritone.api.Settings;
 import baritone.api.event.listener.IEventBus;
 import baritone.api.utils.Helper;
 import baritone.api.utils.IPlayerContext;
-import baritone.behavior.*;
+import baritone.behavior.Behavior;
+import baritone.behavior.InventoryBehavior;
+import baritone.behavior.LookBehavior;
+import baritone.behavior.PathingBehavior;
 import baritone.cache.WorldProvider;
 import baritone.command.manager.CommandManager;
 import baritone.event.GameEventHandler;
@@ -73,6 +76,7 @@ public class Baritone implements IBaritone {
 
     private FollowProcess followProcess;
     private MineProcess mineProcess;
+    private HighlightProcess highlightProcess;
     private GetToBlockProcess getToBlockProcess;
     private CustomGoalProcess customGoalProcess;
     private BuilderProcess builderProcess;
@@ -107,6 +111,7 @@ public class Baritone implements IBaritone {
         {
             this.pathingControlManager.registerProcess(followProcess = new FollowProcess(this));
             this.pathingControlManager.registerProcess(mineProcess = new MineProcess(this));
+            this.pathingControlManager.registerProcess(highlightProcess = new HighlightProcess(this));
             this.pathingControlManager.registerProcess(customGoalProcess = new CustomGoalProcess(this)); // very high iq
             this.pathingControlManager.registerProcess(getToBlockProcess = new GetToBlockProcess(this));
             this.pathingControlManager.registerProcess(builderProcess = new BuilderProcess(this));
@@ -175,6 +180,11 @@ public class Baritone implements IBaritone {
     @Override
     public MineProcess getMineProcess() {
         return this.mineProcess;
+    }
+
+    @Override
+    public HighlightProcess getHighlightProcess() {
+        return this.highlightProcess;
     }
 
     public FarmProcess getFarmProcess() {

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -59,6 +59,7 @@ public final class DefaultCommands {
                 new BlacklistCommand(baritone),
                 new FindCommand(baritone),
                 new MineCommand(baritone),
+                new HighlightCommand(baritone),
                 new ClickCommand(baritone),
                 new SurfaceCommand(baritone),
                 new ThisWayCommand(baritone),

--- a/src/main/java/baritone/command/defaults/HighlightCommand.java
+++ b/src/main/java/baritone/command/defaults/HighlightCommand.java
@@ -31,23 +31,26 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class MineCommand extends Command {
+/**
+ * Highlight blocks of a certain type
+ * @author stackmagic
+ * @since 2022-03-22
+ */
+public class HighlightCommand extends Command {
 
-    public MineCommand(IBaritone baritone) {
-        super(baritone, "mine");
+    public HighlightCommand(IBaritone baritone) {
+        super(baritone, "highlight");
     }
 
     @Override
     public void execute(String label, IArgConsumer args) throws CommandException {
-        int quantity = args.getAsOrDefault(Integer.class, 0);
-        args.requireMin(1);
         List<BlockOptionalMeta> boms = new ArrayList<>();
         while (args.hasAny()) {
             boms.add(args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE));
         }
         WorldScanner.INSTANCE.repack(ctx);
-        logDirect(String.format("Mining %s", boms));
-        baritone.getMineProcess().mine(quantity, boms.toArray(new BlockOptionalMeta[0]));
+        logDirect(String.format("Highlighting %s", boms));
+        baritone.getHighlightProcess().highlight(boms.toArray(new BlockOptionalMeta[0]));
     }
 
     @Override
@@ -57,22 +60,20 @@ public class MineCommand extends Command {
 
     @Override
     public String getShortDesc() {
-        return "Mine some blocks";
+        return "Highlight some blocks";
     }
 
     @Override
     public List<String> getLongDesc() {
         return Arrays.asList(
-                "The mine command allows you to tell Baritone to search for and mine individual blocks.",
+                "The highlight command allows you to tell Baritone to search for and highlight individual blocks.",
+                "They are highlighted the same way they are while the mine command is running.",
                 "",
                 "The specified blocks can be ores (which are commonly cached), or any other block.",
                 "",
-                "Also see the legitMine settings (see #set l legitMine).",
-                "",
                 "Usage:",
-                "> mine diamond_ore - Mines all diamonds it can find.",
-                "> mine redstone_ore lit_redstone_ore - Mines redstone ore.",
-                "> mine log:0 - Mines only oak logs."
+                "> highlight diamond_ore - Highlight all diamond ore it can find around you.",
+                "> highlight redstone_ore lit_redstone_ore - Highlights redstone ore."
         );
     }
 }

--- a/src/main/java/baritone/process/HighlightProcess.java
+++ b/src/main/java/baritone/process/HighlightProcess.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.process;
+
+import baritone.Baritone;
+import baritone.api.pathing.goals.Goal;
+import baritone.api.pathing.goals.GoalComposite;
+import baritone.api.process.IHighlightProcess;
+import baritone.api.process.PathingCommand;
+import baritone.api.process.PathingCommandType;
+import baritone.api.utils.BlockOptionalMetaLookup;
+import baritone.pathing.movement.CalculationContext;
+import net.minecraft.core.BlockPos;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Highlight blocks of a certain type
+ *
+ * @author stackmagic
+ * @since 2022-03-22
+ */
+public class HighlightProcess extends MineProcess implements IHighlightProcess {
+
+    public HighlightProcess(Baritone baritone) {
+        super(baritone);
+    }
+
+    @Override
+    public void highlight(BlockOptionalMetaLookup filter) {
+        mine(filter);
+    }
+
+    @Override
+    public String displayName0() {
+        return "Highlight " + filter;
+    }
+
+    @Override
+    public PathingCommand onTick(boolean calcFailed, boolean isSafeToCancel) {
+        int mineGoalUpdateInterval = Baritone.settings().mineGoalUpdateInterval.value;
+        List<BlockPos> curr = new ArrayList<>(knownOreLocations);
+        if (mineGoalUpdateInterval != 0 && tickCount++ % mineGoalUpdateInterval == 0) { // big brain
+            CalculationContext context = new CalculationContext(baritone, true);
+            Baritone.getExecutor().execute(() -> rescan(curr, context));
+        }
+        if (Baritone.settings().legitMine.value) {
+            addNearby();
+        }
+
+        return updateGoal();
+    }
+
+    @Override
+    protected PathingCommand updateGoal() {
+        List<BlockPos> locs = knownOreLocations;
+        if (!locs.isEmpty()) {
+            CalculationContext context = new CalculationContext(baritone);
+            List<BlockPos> locs2 = prune(context, new ArrayList<>(locs), filter, ORE_LOCATIONS_COUNT, List.of(), droppedItemsScan());
+            // can't reassign locs, gotta make a new var locs2, because we use it in a lambda right here, and variables you use in a lambda must be effectively final
+            Goal goal = new GoalComposite(locs2.stream().map(loc -> coalesce(loc, locs2, context)).toArray(Goal[]::new));
+            knownOreLocations = locs2;
+            return new PathingCommand(goal, PathingCommandType.CANCEL_AND_SET_GOAL);
+        }
+
+        return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
+    }
+}


### PR DESCRIPTION
I hope this is a desired feature in baritone. I made this because running the 'advanced' clients is a hassle and most are way out of date.

This allows the player to highlight any nearby blocks the exact same way they are shown while mining - except we're not pathing to the blocks and trying to break them. The player remains in full control.

The Implementation is based on extending the MineProcess. I had to make the MineProcess non-final and make a bunch of properties/methods protected in order to re-use existing code.

Let me know if there's a better way to implement this or if you want me to change anything, maybe refactor the common code out into a common superclass for the two Process classes. I didn't  do this refactoring as I first wanted to get your feedback and change as little as possible in this first iteration.