### PR TITLE
Remove false information from `#help mine`

### DIFF
--- a/src/main/java/baritone/command/defaults/MineCommand.java
+++ b/src/main/java/baritone/command/defaults/MineCommand.java
@@ -70,7 +70,7 @@ public class MineCommand extends Command {
                 "Also see the legitMine settings (see #set l legitMine).",
                 "",
                 "Usage:",
-                "> mine diamond_ore - Mines all diamonds it can find.",
+                "> mine diamond_ore - Mines all diamonds it can find."
         );
     }
 }

--- a/src/main/java/baritone/command/defaults/MineCommand.java
+++ b/src/main/java/baritone/command/defaults/MineCommand.java
@@ -65,14 +65,12 @@ public class MineCommand extends Command {
         return Arrays.asList(
                 "The mine command allows you to tell Baritone to search for and mine individual blocks.",
                 "",
-                "The specified blocks can be ores (which are commonly cached), or any other block.",
+                "The specified blocks can be ores, or any other block.",
                 "",
                 "Also see the legitMine settings (see #set l legitMine).",
                 "",
                 "Usage:",
                 "> mine diamond_ore - Mines all diamonds it can find.",
-                "> mine redstone_ore lit_redstone_ore - Mines redstone ore.",
-                "> mine log:0 - Mines only oak logs."
         );
     }
 }


### PR DESCRIPTION
Baritone no longer caches ores on Minecraft 1.13+
Metadata values were removed in Minecraft 1.13
lit_redstone_ore was merged into redstone_ore in Minecraft 1.13

<!-- No UwU's or OwO's allowed -->
