### PR TITLE
Fix dynamic mixin dependency to 0.8.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,7 @@ dependencies {
         }
         runtime launchCompile('org.ow2.asm:asm-debug-all:5.2')
         runtime launchCompile('com.github.ImpactDevelopment:SimpleTweaker:1.2')
-        runtime launchCompile('org.spongepowered:mixin:0.8.+') {
+        runtime launchCompile('org.spongepowered:mixin:0.8.3') {
             // Mixin includes a lot of dependencies that are too up-to-date
             exclude module: 'launchwrapper'
             exclude module: 'guava'


### PR DESCRIPTION
Newer Mixin versions use a class file format Proguard can't handle.

This is an alternative to #3371 and since it avoids problems with further updates I would personally prefer merging this one and closing the other.
<!-- No UwU's or OwO's allowed -->
