### PR TITLE
Improve output to user in eta command

### DIFF
--- a/src/main/java/baritone/command/defaults/ETACommand.java
+++ b/src/main/java/baritone/command/defaults/ETACommand.java
@@ -47,21 +47,17 @@ public class ETACommand extends Command {
         }
         IPathingBehavior pathingBehavior = baritone.getPathingBehavior();
 
-        Optional<Double> ticksRemainingInSegment = pathingBehavior.ticksRemainingInSegment();
-        Optional<Double> ticksRemainingInGoal = pathingBehavior.estimatedTicksToGoal();
+        double ticksRemainingInSegment = pathingBehavior.ticksRemainingInSegment().orElse(Double.NaN);
+        double ticksRemainingInGoal = pathingBehavior.estimatedTicksToGoal().orElse(Double.NaN);
 
-        if (ticksRemainingInGoal.isPresent() && ticksRemainingInSegment.isPresent()) {
-            logDirect(String.format(
-                    "Next segment: %.1fs (%.0f ticks)\n" +
-                            "Goal: %.1fs (%.0f ticks)",
-                    ticksRemainingInSegment.get() / 20, // we just assume tps is 20, it isn't worth the effort that is needed to calculate it exactly
-                    ticksRemainingInSegment.get(),
-                    ticksRemainingInGoal.get() / 20,
-                    ticksRemainingInGoal.get()
-            ));
-        } else {
-            logDirect("Not currently pathing");
-        }
+        logDirect(String.format(
+                "Next segment: %.1fs (%.0f ticks)\n" +
+                        "Goal: %.1fs (%.0f ticks)",
+                ticksRemainingInSegment / 20, // we just assume tps is 20, it isn't worth the effort that is needed to calculate it exactly
+                ticksRemainingInSegment,
+                ticksRemainingInGoal / 20,
+                ticksRemainingInGoal
+        ));
     }
 
     @Override

--- a/src/main/java/baritone/command/defaults/ETACommand.java
+++ b/src/main/java/baritone/command/defaults/ETACommand.java
@@ -28,6 +28,7 @@ import baritone.api.command.argument.IArgConsumer;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public class ETACommand extends Command {
@@ -45,12 +46,22 @@ public class ETACommand extends Command {
             throw new CommandInvalidStateException("No process in control");
         }
         IPathingBehavior pathingBehavior = baritone.getPathingBehavior();
-        logDirect(String.format(
-                "Next segment: %.2f\n" +
-                "Goal: %.2f",
-                pathingBehavior.ticksRemainingInSegment().orElse(-1.0),
-                pathingBehavior.estimatedTicksToGoal().orElse(-1.0)
-        ));
+
+        Optional<Double> ticksRemainingInSegment = pathingBehavior.ticksRemainingInSegment();
+        Optional<Double> ticksRemainingInGoal = pathingBehavior.estimatedTicksToGoal();
+
+        if (ticksRemainingInGoal.isPresent() && ticksRemainingInSegment.isPresent()) {
+            logDirect(String.format(
+                    "Next segment: %.1fs (%.0f ticks)\n" +
+                            "Goal: %.1fs (%.0f ticks)",
+                    ticksRemainingInSegment.get() / 20, // we just assume tps is 20, it isn't worth the effort that is needed to calculate it exactly
+                    ticksRemainingInSegment.get(),
+                    ticksRemainingInGoal.get() / 20,
+                    ticksRemainingInGoal.get()
+            ));
+        } else {
+            logDirect("Not currently pathing");
+        }
     }
 
     @Override


### PR DESCRIPTION
Currently it outputs in ticks, however it is easier to understand when there is also a second estimate.