### PR TITLE
Don't crash when worldData is null, and get0 is called in 1.18

### DIFF
--- a/src/main/java/baritone/utils/BlockStateInterface.java
+++ b/src/main/java/baritone/utils/BlockStateInterface.java
@@ -97,6 +97,10 @@ public class BlockStateInterface {
     }
 
     public BlockState get0(int x, int y, int z) { // Mickey resigned
+        if (worldData == null) {
+            return AIR;
+        }
+
         y -= worldData.dimension.minY();
         // Invalid vertical position
         if (y < 0 || y >= worldData.dimension.height()) {
@@ -124,9 +128,6 @@ public class BlockStateInterface {
         // except here, it's 512x512 tiles instead of 16x16, so even better repetition
         CachedRegion cached = prevCached;
         if (cached == null || cached.getX() != x >> 9 || cached.getZ() != z >> 9) {
-            if (worldData == null) {
-                return AIR;
-            }
             CachedRegion region = worldData.cache.getRegion(x >> 9, z >> 9);
             if (region == null) {
                 return AIR;


### PR DESCRIPTION
Changes in d22a52976b2988a0daa7ec8324de32ab2c095d0c mean that BlockStateInterface.get0, crashes when world data is null.

World data is rarely null, however one case I have found it being null is when launching mc with the --server option.