### PR TITLE
Fix "missing null"

### DIFF
--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -108,6 +108,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         this.layer = Baritone.settings().startAtLayer.value;
         this.numRepeats = 0;
         this.observedCompleted = new LongOpenHashSet();
+        this.incorrectPositions = null;
     }
 
     public void resume() {


### PR DESCRIPTION
This caused positions outside the schematic being marked as incorrect (because they were incorrect in the previous build) and if those positions are queried to determine the needed material the result is `null`, leading to the error message that you are missing items to place null.

Fixes #3428
Fixes #2720
Closes #3432

Also there are a few older issues that are possibly for this bug as well but they used Baritone versions that don't list the missing materials so I can't tell from the logs.
<!-- No UwU's or OwO's allowed -->
