### PR TITLE
apply beta versioning (git shorthash) to github action builds

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -21,7 +21,6 @@ jobs:
         distribution: 'adopt'
 
     - uses: actions/github-script@v2
-      id: fname
       name: apply beta versioning
       with:
         result-encoding: string
@@ -30,9 +29,6 @@ jobs:
           let file = fs.readFileSync("./gradle.properties");
           file = file.toString().split("\n").map(e => e.trim().startsWith("mod_version") ? `${e}-beta-${process.env.GITHUB_SHA.substring(0, 7)}` : e).join("\n");
           fs.writeFileSync("./gradle.properties", file);
-          const mod_version = file.toString().split("\n").filter(e => e.trim().startsWith("mod_version"))[0].split("=")[1].trim();
-          const archives_base_name = file.toString().split("\n").filter(e => e.trim().startsWith("archives_base_name"))[0].split("=")[1].trim();
-          return `${archives_base_name}-${mod_version}`;
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -29,6 +29,7 @@ jobs:
           let file = fs.readFileSync("./gradle.properties");
           file = file.toString().split("\n").map(e => {
             if (!e.trim().startsWith("mod_version")) return e;
+            if (process.env.GITHUB_REF.includes("tags")) return e;
             let vers = e.split(".");
             let n = parseInt(vers[vers.length-1].trim()) + 1;
             vers = vers.slice(0, vers.length - 1);

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -30,7 +30,7 @@ jobs:
           file = file.toString().split("\n").map(e => {
             if (!e.trim().startsWith("mod_version")) return e;
             let vers = e.split(".");
-            let n = parseInt(vers[vers.length]) + 1;
+            let n = parseInt(vers[vers.length-1].trim()) + 1;
             vers = vers.slice(0, vers.length - 1);
             vers.push(n);
             return `${vers.join(".")}-beta-${process.env.GITHUB_SHA.substring(0, 7)}`;

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -27,7 +27,14 @@ jobs:
         script: |
           const fs = require("fs");
           let file = fs.readFileSync("./gradle.properties");
-          file = file.toString().split("\n").map(e => e.trim().startsWith("mod_version") ? `${e}-beta-${process.env.GITHUB_SHA.substring(0, 7)}` : e).join("\n");
+          file = file.toString().split("\n").map(e => {
+            if (!e.trim().startsWith("mod_version")) return e;
+            let vers = e.split(".");
+            let n = parseInt(vers[vers.length]) + 1;
+            vers = vers.slice(0, vers.length - 1);
+            vers.push(n);
+            return `${vers.join(".")}-beta-${process.env.GITHUB_SHA.substring(0, 7)}`;
+          }).join("\n");
           fs.writeFileSync("./gradle.properties", file);
 
     - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -19,7 +19,21 @@ jobs:
       with:
         java-version: '8'
         distribution: 'adopt'
-        
+
+    - uses: actions/github-script@v2
+      id: fname
+      name: apply beta versioning
+      with:
+        result-encoding: string
+        script: |
+          const fs = require("fs");
+          let file = fs.readFileSync("./gradle.properties");
+          file = file.toString().split("\n").map(e => e.trim().startsWith("mod_version") ? `${e}-beta-${process.env.GITHUB_SHA.substring(0, 7)}` : e).join("\n");
+          fs.writeFileSync("./gradle.properties", file);
+          const mod_version = file.toString().split("\n").filter(e => e.trim().startsWith("mod_version"))[0].split("=")[1].trim();
+          const archives_base_name = file.toString().split("\n").filter(e => e.trim().startsWith("archives_base_name"))[0].split("=")[1].trim();
+          return `${archives_base_name}-${mod_version}`;
+
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 group 'baritone'
-version '1.2.15'
+version project.mod_version
 
 buildscript {
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,18 @@
+#
+# This file is part of Baritone.
+#
+# Baritone is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Baritone is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+mod_version = 1.2.15


### PR DESCRIPTION
baritone version gets incremented and appended with `-beta-<git shorthash>` on github action builds
great for users who report issues on unreleased versions as we can see exactly what commit they were using