### PR TITLE
Fix for a sprint bug that can cause death

### DIFF
--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -73,8 +73,8 @@ public class PathExecutor implements IPathExecutor, Helper {
     private HashSet<BlockPos> toPlace = new HashSet<>();
     private HashSet<BlockPos> toWalkInto = new HashSet<>();
 
-    private PathingBehavior behavior;
-    private IPlayerContext ctx;
+    private final PathingBehavior behavior;
+    private final IPlayerContext ctx;
 
     private boolean sprintNextTick;
 
@@ -385,7 +385,7 @@ public class PathExecutor implements IPathExecutor, Helper {
                 return false;
             }
 
-            if (pathPosition < path.length() - 3) {
+            if (pathPosition < path.length() - 2) {
                 IMovement next = path.movements().get(pathPosition + 1);
                 if (next instanceof MovementAscend && current.getDirection().up().equals(next.getDirection().down())) {
                     // a descend then an ascend in the same direction
@@ -396,13 +396,21 @@ public class PathExecutor implements IPathExecutor, Helper {
                     logDebug("Skipping descend to straight ascend");
                     return true;
                 }
-                if (canSprintFromDescendInto(ctx, current, next) &&
-                        canSprintFromDescendInto(ctx, next, path.movements().get(pathPosition + 2))) {
+                if (canSprintFromDescendInto(ctx, current, next)) {
+
+                    if (next instanceof MovementDescend && pathPosition < path.length() - 3) {
+                        IMovement next_next = path.movements().get(pathPosition + 2);
+                        if (next_next instanceof MovementDescend && !canSprintFromDescendInto(ctx, next, next_next)) {
+                            return false;
+                        }
+
+                    }
                     if (ctx.playerFeet().equals(current.getDest())) {
                         pathPosition++;
                         onChangeInPathPosition();
                         onTick();
                     }
+
                     return true;
                 }
                 //logDebug("Turning off sprinting " + movement + " " + next + " " + movement.getDirection() + " " + next.getDirection().down() + " " + next.getDirection().down().equals(movement.getDirection()));

--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -536,11 +536,11 @@ public class PathExecutor implements IPathExecutor, Helper {
     }
 
     private static boolean canSprintFromDescendInto(IPlayerContext ctx, IMovement current, IMovement next) {
-        if (next instanceof MovementDescend && next.getDirection().equals(current.getDirection())) {
-            return true;
-        }
         if (!MovementHelper.canWalkOn(ctx, current.getDest().add(current.getDirection()))) {
             return false;
+        }
+        if (next instanceof MovementDescend && next.getDirection().equals(current.getDirection())) {
+            return true;
         }
         if (next instanceof MovementTraverse && next.getDirection().down().equals(current.getDirection())) {
             return true;

--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -385,7 +385,7 @@ public class PathExecutor implements IPathExecutor, Helper {
                 return false;
             }
 
-            if (pathPosition < path.length() - 2) {
+            if (pathPosition < path.length() - 3) {
                 IMovement next = path.movements().get(pathPosition + 1);
                 if (next instanceof MovementAscend && current.getDirection().up().equals(next.getDirection().down())) {
                     // a descend then an ascend in the same direction
@@ -396,7 +396,8 @@ public class PathExecutor implements IPathExecutor, Helper {
                     logDebug("Skipping descend to straight ascend");
                     return true;
                 }
-                if (canSprintFromDescendInto(ctx, current, next)) {
+                if (canSprintFromDescendInto(ctx, current, next) &&
+                        canSprintFromDescendInto(ctx, next, path.movements().get(pathPosition + 2))) {
                     if (ctx.playerFeet().equals(current.getDest())) {
                         pathPosition++;
                         onChangeInPathPosition();
@@ -536,11 +537,11 @@ public class PathExecutor implements IPathExecutor, Helper {
     }
 
     private static boolean canSprintFromDescendInto(IPlayerContext ctx, IMovement current, IMovement next) {
-        if (!MovementHelper.canWalkOn(ctx, current.getDest().add(current.getDirection()))) {
-            return false;
-        }
         if (next instanceof MovementDescend && next.getDirection().equals(current.getDirection())) {
             return true;
+        }
+        if (!MovementHelper.canWalkOn(ctx, current.getDest().add(current.getDirection()))) {
+            return false;
         }
         if (next instanceof MovementTraverse && next.getDirection().down().equals(current.getDirection())) {
             return true;


### PR DESCRIPTION
In the case where we're descending stairs and need to stop at the bottom to mine a block to our left or right. If the next space is lava or a hole, we'll currently overshoot right into it even with default settings.

Currently 

```
        if (next instanceof MovementDescend && next.getDirection().equals(current.getDirection())) {
            return true;
        }
```
is checked first inside the canSprintFromDescendInto, which will return True before MovementHelper.canWalkOn is checked. 


Checking MovementHelper.canWalkOn first ensures we won't sprint onto a block where the next block is not walkable. 