### PR TITLE
Use immutable collections for settings

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -21,6 +21,8 @@ import baritone.api.utils.NotificationHelper;
 import baritone.api.utils.SettingsUtil;
 import baritone.api.utils.TypeUtils;
 import baritone.api.utils.gui.BaritoneToast;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
@@ -52,7 +54,7 @@ public final class Settings {
     /**
      * Blocks that baritone will be allowed to break even with allowBreak set to false
      */
-    public final Setting<List<Block>> allowBreakAnyway = new Setting<>(new ArrayList<>());
+    public final Setting<List<Block>> allowBreakAnyway = new Setting<>(ImmutableList.of());
 
     /**
      * Allow Baritone to sprint
@@ -178,31 +180,31 @@ public final class Settings {
     /**
      * Blocks that Baritone is allowed to place (as throwaway, for sneak bridging, pillaring, etc.)
      */
-    public final Setting<List<Item>> acceptableThrowawayItems = new Setting<>(new ArrayList<>(Arrays.asList(
+    public final Setting<List<Item>> acceptableThrowawayItems = new Setting<>(ImmutableList.of(
             Item.getItemFromBlock(Blocks.DIRT),
             Item.getItemFromBlock(Blocks.COBBLESTONE),
             Item.getItemFromBlock(Blocks.NETHERRACK),
             Item.getItemFromBlock(Blocks.STONE)
-    )));
+    ));
 
     /**
      * Blocks that Baritone will attempt to avoid (Used in avoidance)
      */
-    public final Setting<List<Block>> blocksToAvoid = new Setting<>(new ArrayList<>(
+    public final Setting<List<Block>> blocksToAvoid = new Setting<>(ImmutableList.of(
             // Leave Empty by Default
     ));
 
     /**
      * Blocks that Baritone is not allowed to break
      */
-    public final Setting<List<Block>> blocksToDisallowBreaking = new Setting<>(new ArrayList<>(
+    public final Setting<List<Block>> blocksToDisallowBreaking = new Setting<>(ImmutableList.of(
         // Leave Empty by Default
     ));
 
     /**
      * blocks that baritone shouldn't break, but can if it needs to.
      */
-    public final Setting<List<Block>> blocksToAvoidBreaking = new Setting<>(new ArrayList<>(Arrays.asList( // TODO can this be a HashSet or ImmutableSet?
+    public final Setting<List<Block>> blocksToAvoidBreaking = new Setting<>(ImmutableList.of(
             Blocks.CRAFTING_TABLE,
             Blocks.FURNACE,
             Blocks.LIT_FURNACE,
@@ -210,7 +212,7 @@ public final class Settings {
             Blocks.TRAPPED_CHEST,
             Blocks.STANDING_SIGN,
             Blocks.WALL_SIGN
-    )));
+    ));
 
     /**
      * this multiplies the break speed, if set above 1 it's "encourage breaking" instead
@@ -222,18 +224,18 @@ public final class Settings {
      * <p>
      * If a schematic asks for air at a certain position, and that position currently contains a block on this list, it will be treated as correct.
      */
-    public final Setting<List<Block>> buildIgnoreBlocks = new Setting<>(new ArrayList<>(Arrays.asList(
+    public final Setting<List<Block>> buildIgnoreBlocks = new Setting<>(ImmutableList.of(
 
-    )));
+    ));
 
     /**
      * A list of blocks to be treated as correct.
      * <p>
      * If a schematic asks for any block on this list at a certain position, it will be treated as correct, regardless of what it currently is.
      */
-    public final Setting<List<Block>> buildSkipBlocks = new Setting<>(new ArrayList<>(Arrays.asList(
+    public final Setting<List<Block>> buildSkipBlocks = new Setting<>(ImmutableList.of(
 
-    )));
+    ));
 
     /**
      * A mapping of blocks to blocks treated as correct in their position
@@ -242,7 +244,7 @@ public final class Settings {
      * <p>
      * Syntax same as <a href="https://baritone.leijurv.com/baritone/api/Settings.html#buildSubstitutes">buildSubstitutes</a>
      */
-    public final Setting<Map<Block, List<Block>>> buildValidSubstitutes = new Setting<>(new HashMap<>());
+    public final Setting<Map<Block, List<Block>>> buildValidSubstitutes = new Setting<>(ImmutableMap.of());
 
     /**
      * A mapping of blocks to blocks to be built instead
@@ -258,16 +260,16 @@ public final class Settings {
      *     stone->cobblestone,andesite,oak_planks->birch_planks,acacia_planks,glass
      * </pre>
      */
-    public final Setting<Map<Block, List<Block>>> buildSubstitutes = new Setting<>(new HashMap<>());
+    public final Setting<Map<Block, List<Block>>> buildSubstitutes = new Setting<>(ImmutableMap.of());
 
     /**
      * A list of blocks to become air
      * <p>
      * If a schematic asks for a block on this list, only air will be accepted at that location (and nothing on buildIgnoreBlocks)
      */
-    public final Setting<List<Block>> okIfAir = new Setting<>(new ArrayList<>(Arrays.asList(
+    public final Setting<List<Block>> okIfAir = new Setting<>(ImmutableList.of(
 
-    )));
+    ));
 
     /**
      * If this is true, the builder will treat all non-air blocks as correct. It will only place new blocks.

--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -19,6 +19,8 @@ package baritone.api.utils;
 
 import baritone.api.BaritoneAPI;
 import baritone.api.Settings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.util.EnumFacing;
@@ -261,7 +263,10 @@ public class SettingsUtil {
 
                 return Stream.of(raw.split(","))
                         .map(s -> parser.parse(context, s))
-                        .collect(Collectors.toList());
+                        .collect(Collectors.collectingAndThen(
+                            Collectors.toList(),
+                            ImmutableList::copyOf
+                        ));
             }
 
             @Override
@@ -289,7 +294,10 @@ public class SettingsUtil {
 
                 return Stream.of(raw.split(",(?=[^,]*->)"))
                         .map(s -> s.split("->"))
-                        .collect(Collectors.toMap(s -> keyParser.parse(context, s[0]), s -> valueParser.parse(context, s[1])));
+                        .collect(Collectors.collectingAndThen(
+                            Collectors.toMap(s -> keyParser.parse(context, s[0]), s -> valueParser.parse(context, s[1])),
+                            ImmutableMap::copyOf
+                        ));
             }
 
             @Override

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -24,6 +24,7 @@ import baritone.cache.WorldData;
 import baritone.utils.BlockStateInterface;
 import baritone.utils.ToolSet;
 import baritone.utils.pathing.BetterWorldBorder;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -93,7 +94,7 @@ public class CalculationContext {
         this.canSprint = Baritone.settings().allowSprint.value && player.getFoodStats().getFoodLevel() > 6;
         this.placeBlockCost = Baritone.settings().blockPlacementPenalty.value;
         this.allowBreak = Baritone.settings().allowBreak.value;
-        this.allowBreakAnyway = new ArrayList<>(Baritone.settings().allowBreakAnyway.value);
+        this.allowBreakAnyway = ImmutableList.copyOf(Baritone.settings().allowBreakAnyway.value);
         this.allowParkour = Baritone.settings().allowParkour.value;
         this.allowParkourPlace = Baritone.settings().allowParkourPlace.value;
         this.allowJumpAt256 = Baritone.settings().allowJumpAt256.value;


### PR DESCRIPTION
Using an `ImmutableSet` seems to be faster according to [this](https://github.com/ZacSharp/baritone/blob/benchmarks/immutableSettingValues/results.csv) benchmark, but that would either require a breaking API change or improperly making the settings `ImmutableSet`s while exposing only their list views (i.e. lists that behave as ordered sets, which currently works because we only use them as ordered sets).
<!-- No UwU's or OwO's allowed -->
