### PR TITLE
Revert "make #paws be an alias for #pause"

### DIFF
--- a/src/main/java/baritone/command/defaults/ExecutionControlCommands.java
+++ b/src/main/java/baritone/command/defaults/ExecutionControlCommands.java
@@ -79,7 +79,7 @@ public class ExecutionControlCommands {
                     }
                 }
         );
-        pauseCommand = new Command(baritone, "pause", "p", "paws") {
+        pauseCommand = new Command(baritone, "pause", "p") {
             @Override
             public void execute(String label, IArgConsumer args) throws CommandException {
                 args.requireMax(0);


### PR DESCRIPTION
This commit reverses the "paws" alias for the "#pause" command.

`<!-- No UwU's or OwO's allowed -->`

If your PR template says that... then we shouldn't need this command. "unpaws" should be OK though.

Please merge my commit liewy jurwy :)))))))