### PR TITLE
Stop backfill from filling while paused

### DIFF
--- a/src/main/java/baritone/process/BackfillProcess.java
+++ b/src/main/java/baritone/process/BackfillProcess.java
@@ -56,12 +56,12 @@ public final class BackfillProcess extends BaritoneProcessHelper {
             Baritone.settings().backfill.value = false;
             return false;
         }
-        amIBreakingABlockHMMMMMMM();
         for (BlockPos pos : new ArrayList<>(blocksToReplace.keySet())) {
-            if (ctx.world().getChunk(pos) instanceof EmptyChunk) {
+            if (ctx.world().getChunk(pos) instanceof EmptyChunk || ctx.world().getBlockState(pos).getBlock() != Blocks.AIR) {
                 blocksToReplace.remove(pos);
             }
         }
+        amIBreakingABlockHMMMMMMM();
         baritone.getInputOverrideHandler().clearAllKeys();
 
         return !toFillIn().isEmpty();

--- a/src/main/java/baritone/process/BackfillProcess.java
+++ b/src/main/java/baritone/process/BackfillProcess.java
@@ -93,7 +93,7 @@ public final class BackfillProcess extends BaritoneProcessHelper {
     }
 
     private void amIBreakingABlockHMMMMMMM() {
-        if (!ctx.getSelectedBlock().isPresent()) {
+        if (!ctx.getSelectedBlock().isPresent() || !baritone.getPathingBehavior().isPathing()) {
             return;
         }
         blocksToReplace.put(ctx.getSelectedBlock().get(), ctx.world().getBlockState(ctx.getSelectedBlock().get()));


### PR DESCRIPTION
It's not perfect; while paused, it will still attempt to fill in any blocks that were added to blocksToReplace while running. So for example, if you pause it, then break a block that was previously backfilled, it will instantly replace it. For any other block however, it will not fill it.