### PR TITLE
Added the ability to use KmM as abreviatures

### DIFF
--- a/src/api/java/baritone/api/command/datatypes/RelativeCoordinate.java
+++ b/src/api/java/baritone/api/command/datatypes/RelativeCoordinate.java
@@ -26,7 +26,8 @@ import java.util.stream.Stream;
 
 public enum RelativeCoordinate implements IDatatypePost<Double, Double> {
     INSTANCE;
-    private static Pattern PATTERN = Pattern.compile("^(~?)([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)([k-k]?)|)$");
+    private static String ScalesAliasRegex = "[kKmM]";
+    private static Pattern PATTERN = Pattern.compile("^(~?)([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)("+ScalesAliasRegex+"?)|)$");
 
     @Override
     public Double apply(IDatatypeContext ctx, Double origin) throws CommandException {
@@ -41,11 +42,15 @@ public enum RelativeCoordinate implements IDatatypePost<Double, Double> {
 
         boolean isRelative = !matcher.group(1).isEmpty();
 
-        double offset = matcher.group(2).isEmpty() ? 0 : Double.parseDouble(matcher.group(2).replaceAll("k", ""));
-
-        if (matcher.group(2).contains("k")) {
+        double offset = matcher.group(2).isEmpty() ? 0 : Double.parseDouble(matcher.group(2).replaceAll(ScalesAliasRegex, ""));
+        
+        if (matcher.group(2).toLowerCase().contains("k")) {
             offset *= 1000;
         }
+        if (matcher.group(2).toLowerCase().contains("m")) {
+            offset *= 1000000;
+        }
+
 
         if (isRelative) {
             return origin + offset;


### PR DESCRIPTION
The commit is anything but special, and i dont know if the owners intended the way it was before as its a really simple "fix"

Basically it enables the use of different decimal units abreviations other than just the lowercase k in this case it allows K, m and M(the m is for million)

_If you are wondering why would i make this, i use impact and apparently on the version im using .goto -xk y zk apparently does not work, due to me using baritone directly and impact interchangibly i started to think it was a baritone issue but apparently it isnt any way i might as well add something to it_
<!-- No UwU's or OwO's allowed -->
