### PR TITLE
Update legitMineYLevel for 1.18 +

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -1017,7 +1017,7 @@ public final class Settings {
     /**
      * What Y level to go to for legit strip mining
      */
-    public final Setting<Integer> legitMineYLevel = new Setting<>(11);
+    public final Setting<Integer> legitMineYLevel = new Setting<>(-59);
 
     /**
      * Magically see ores that are separated diagonally from existing ores. Basically like mining around the ores that it finds


### PR DESCRIPTION
Update the legit mine default setting to work at the correct diamond level in 1.18+.

<!-- No UwU's or OwO's allowed -->
