### PR TITLE
Fix for infinite loop in water

### DIFF
--- a/src/main/java/baritone/pathing/movement/Movement.java
+++ b/src/main/java/baritone/pathing/movement/Movement.java
@@ -123,7 +123,7 @@ public abstract class Movement implements IMovement, MovementHelper {
     public MovementStatus update() {
         ctx.player().getAbilities().flying = false;
         currentState = updateState(currentState);
-        if (MovementHelper.isLiquid(ctx, ctx.playerFeet())) {
+        if (MovementHelper.isLiquid(ctx, ctx.playerFeet()) && ctx.player().position().y < dest.y + 0.6) {
             currentState.setInput(Input.JUMP, true);
         }
         if (ctx.player().isInWall()) {

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -70,7 +70,7 @@ public class MovementTraverse extends Movement {
 
     @Override
     protected Set<BetterBlockPos> calculateValidPositions() {
-        return ImmutableSet.of(src, src.above(), dest); // src.above means that we don't get caught in an infinite loop in water
+        return ImmutableSet.of(src, dest); // src.above means that we don't get caught in an infinite loop in water
     }
 
     public static double cost(CalculationContext context, int x, int y, int z, int destX, int destZ) {
@@ -237,6 +237,7 @@ public class MovementTraverse extends Movement {
         if (feet.getY() != dest.getY() && !ladder) {
             logDebug("Wrong Y coordinate");
             if (feet.getY() < dest.getY()) {
+                System.out.println("In movement traverse");
                 return state.setInput(Input.JUMP, true);
             }
             return state;

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -70,7 +70,7 @@ public class MovementTraverse extends Movement {
 
     @Override
     protected Set<BetterBlockPos> calculateValidPositions() {
-        return ImmutableSet.of(src, dest);
+        return ImmutableSet.of(src, src.above(), dest); // src.above means that we don't get caught in an infinite loop in water
     }
 
     public static double cost(CalculationContext context, int x, int y, int z, int destX, int destZ) {


### PR DESCRIPTION
This is a slightly dodgy solution, however it is the simplest one I could think of.

# Description of issue

When a fall into more than 2 block deep water occurs baritone enters an infinite loop as we swim up, to the surface, and end the movement when we "jump" above the water, this means that our position isn't in the valid positions of a traverse movement. And thus some of the lag protection jumps in and resets us to the fall (as this is a valid position for during the fall), entering an infinite loop.

Closes #3200.

If anyone can think of a better solution to this please let me know