### PR TITLE
remove schematica command because it doesn't work anyway on 1.13+ 

### DIFF
--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -42,7 +42,7 @@ public final class DefaultCommands {
                 new VersionCommand(baritone),
                 new RepackCommand(baritone),
                 new BuildCommand(baritone),
-                new SchematicaCommand(baritone),
+                //new SchematicaCommand(baritone),
                 new ComeCommand(baritone),
                 new AxisCommand(baritone),
                 new ForceCancelCommand(baritone),


### PR DESCRIPTION
remove schematica command because it doesn't work anyway on 1.13+ 
since sechematica doesn't exist past 1.12.2

<!-- No UwU's or OwO's allowed -->
