### PR TITLE
Mine ice when prefersilktouch is true (temporary fix for #735)

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -784,6 +784,9 @@ public final class Settings {
     /**
      * Always prefer silk touch tools over regular tools. This will not sacrifice speed, but it will always prefer silk
      * touch tools over other tools of the same speed. This includes always choosing ANY silk touch tool over your hand.
+     *
+     * As a stop-gap fix for #735, this option also serves as a switch to control whether Baritone will mine ice. By
+     * default, ice is not mined to prevent water from being produced.
      */
     public final Setting<Boolean> preferSilkTouch = new Setting<>(false);
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -193,7 +193,7 @@ public final class Settings {
     ));
 
     /**
-     * Blocks that Baritone is not allowed to break
+     * Blocks that Baritone is not allowed to break (Ice avoidance is always on unless preferSilkTouch is set)
      */
     public final Setting<List<Block>> blocksToDisallowBreaking = new Setting<>(new ArrayList<>(
         // Leave Empty by Default

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -54,7 +54,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         }
         Block b = state.getBlock();
         return Baritone.settings().blocksToDisallowBreaking.value.contains(b)
-                || b == Blocks.ICE // ice becomes water, and water can mess up the path
+                || (!BaritoneAPI.getSettings().preferSilkTouch.value && b == Blocks.ICE) // ice becomes water, and water can mess up the path
                 || b instanceof BlockSilverfish // obvious reasons
                 // call context.get directly with x,y,z. no need to make 5 new BlockPos for no reason
                 || avoidAdjacentBreaking(bsi, x, y + 1, z, true)

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -54,7 +54,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         }
         Block b = state.getBlock();
         return Baritone.settings().blocksToDisallowBreaking.value.contains(b)
-                || (!BaritoneAPI.getSettings().preferSilkTouch.value && b == Blocks.ICE) // ice becomes water, and water can mess up the path
+                || (!Baritone.settings().preferSilkTouch.value && b == Blocks.ICE) // ice becomes water, and water can mess up the path
                 || b instanceof BlockSilverfish // obvious reasons
                 // call context.get directly with x,y,z. no need to make 5 new BlockPos for no reason
                 || avoidAdjacentBreaking(bsi, x, y + 1, z, true)


### PR DESCRIPTION
This is a very, very stupid fix for #735. It will break if the user changes the hot bar to a state where no silk touch tools are available, but look, I am just here to trigger a CI build and grab the binary for some ice highway project. (Oh how did I not consider the approval my evil plan is shattered. Back to Java bytecode disassembling-editing for my not-wanting-to-run-a-proper-build lazy self)

Wrote an extra paragraph of documentation to describe this behavior, just in case people want it enough to get it merged.