### PR TITLE
Fix yet another cave air bug

### DIFF
--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -603,7 +603,7 @@ public interface MovementHelper extends ActionCosts, Helper {
 
     static boolean isTransparent(Block b) {
 
-        return b == Blocks.AIR ||
+        return b instanceof AirBlock ||
                 b == Blocks.LAVA ||
                 b == Blocks.WATER;
     }


### PR DESCRIPTION
Only affects `allowOnlyExposedOres` because nothing else uses that method.

Fixes #3637

<!-- No UwU's or OwO's allowed -->
