### PR TITLE
Improve handling spaces in paths during proguard pass

### DIFF
--- a/buildSrc/src/main/java/baritone/gradle/task/ProguardTask.java
+++ b/buildSrc/src/main/java/baritone/gradle/task/ProguardTask.java
@@ -209,8 +209,8 @@ public class ProguardTask extends BaritoneGradleTask {
 
         // Setup the template that will be used to derive the API and Standalone configs
         List<String> template = Files.readAllLines(getTemporaryFile(PROGUARD_CONFIG_DEST));
-        template.add(0, "-injars " + this.artifactPath.toString());
-        template.add(1, "-outjars " + this.getTemporaryFile(PROGUARD_EXPORT_PATH));
+        template.add(0, "-injars '" + this.artifactPath.toString() + "'");
+        template.add(1, "-outjars '" + this.getTemporaryFile(PROGUARD_EXPORT_PATH) + "'");
 
         // Acquire the RT jar using "java -verbose". This doesn't work on Java 9+
         Process p = new ProcessBuilder(this.getJavaBinPathForProguard(), "-verbose").start();
@@ -405,9 +405,15 @@ public class ProguardTask extends BaritoneGradleTask {
             Files.delete(this.proguardOut);
         }
 
-        Path proguardJar = getTemporaryFile(PROGUARD_JAR);
+        // Make paths relative to work directory; fixes spaces in path to config, @"" doesn't work
+        Path workingDirectory = getTemporaryFile("");
+        Path proguardJar = workingDirectory.relativize(getTemporaryFile(PROGUARD_JAR));
+        config = workingDirectory.relativize(config);
+        
+        // Honestly, if you still have spaces in your path at this point, you're SOL.
+
         Process p = new ProcessBuilder("java", "-jar", proguardJar.toString(), "@" + config.toString())
-                .directory(getTemporaryFile("").toFile()) // Set the working directory to the temporary folder]
+                .directory(workingDirectory.toFile()) // Set the working directory to the temporary folder]
                 .start();
 
         // We can't do output inherit process I/O with gradle for some reason and have it work, so we have to do this


### PR DESCRIPTION
Most of my development happens in numbered directories, so I ended up with a bunch of `D:\01 - Repositories\Baritone\...` everywhere. Proguard does not like that.

I also tried the windows escape thing, which is prefixing spaces by `^`, that didn't work either, in case you were wondering.

Tested on 1.2.15