### PR TITLE
replace the world scanner with a 500x faster one

### DIFF
--- a/src/api/java/baritone/api/utils/BlockOptionalMeta.java
+++ b/src/api/java/baritone/api/utils/BlockOptionalMeta.java
@@ -315,4 +315,8 @@ public final class BlockOptionalMeta {
 
         return null;
     }
+
+    public Set<IBlockState> getAllBlockStates() {
+        return blockstates;
+    }
 }

--- a/src/api/java/baritone/api/utils/BlockOptionalMeta.java
+++ b/src/api/java/baritone/api/utils/BlockOptionalMeta.java
@@ -41,8 +41,8 @@ public final class BlockOptionalMeta {
     private final int meta;
     private final boolean noMeta;
     private final Set<IBlockState> blockstates;
-    private final ImmutableSet<Integer> stateHashes;
-    private final ImmutableSet<Integer> stackHashes;
+    private final Set<Integer> stateHashes;
+    private final Set<Integer> stackHashes;
     private static final Pattern pattern = Pattern.compile("^(.+?)(?::(\\d+))?$");
     private static final Map<Object, Object> normalizations;
 
@@ -318,5 +318,9 @@ public final class BlockOptionalMeta {
 
     public Set<IBlockState> getAllBlockStates() {
         return blockstates;
+    }
+
+    public Set<Integer> stackHashes() {
+        return stackHashes;
     }
 }

--- a/src/api/java/baritone/api/utils/BlockOptionalMetaLookup.java
+++ b/src/api/java/baritone/api/utils/BlockOptionalMetaLookup.java
@@ -17,6 +17,7 @@
 
 package baritone.api.utils;
 
+import com.google.common.collect.ImmutableSet;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
@@ -28,34 +29,41 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public class BlockOptionalMetaLookup {
-    private final Set<Block> blockSet = new HashSet<>();
-    private final Set<IBlockState> blockStateSet = new HashSet<>();
+    private final Set<Block> blockSet;
+    private final Set<IBlockState> blockStateSet;
     private final BlockOptionalMeta[] boms;
 
     public BlockOptionalMetaLookup(BlockOptionalMeta... boms) {
         this.boms = boms;
+        Set<Block> blocks = new HashSet<>();
+        Set<IBlockState> blockStates = new HashSet<>();
+        Set<Integer> stacks = new HashSet<>();
         for (BlockOptionalMeta bom : boms) {
-            blockSet.add(bom.getBlock());
-            blockStateSet.addAll(bom.getAllBlockStates());
+            blocks.add(bom.getBlock());
+            blockStates.addAll(bom.getAllBlockStates());
+            stacks.addAll(bom.stackHashes());
         }
+        this.blockSet = ImmutableSet.copyOf(blocks);
+        this.blockStateSet = ImmutableSet.copyOf(blockStates);
     }
 
     public BlockOptionalMetaLookup(Block... blocks) {
-        this.boms = Stream.of(blocks)
+        this(Stream.of(blocks)
                 .map(BlockOptionalMeta::new)
-                .toArray(BlockOptionalMeta[]::new);
+                .toArray(BlockOptionalMeta[]::new));
+
     }
 
     public BlockOptionalMetaLookup(List<Block> blocks) {
-        this.boms = blocks.stream()
+        this(blocks.stream()
                 .map(BlockOptionalMeta::new)
-                .toArray(BlockOptionalMeta[]::new);
+                .toArray(BlockOptionalMeta[]::new));
     }
 
     public BlockOptionalMetaLookup(String... blocks) {
-        this.boms = Stream.of(blocks)
+        this(Stream.of(blocks)
                 .map(BlockOptionalMeta::new)
-                .toArray(BlockOptionalMeta[]::new);
+                .toArray(BlockOptionalMeta[]::new));
     }
 
     public boolean has(Block block) {

--- a/src/api/java/baritone/api/utils/BlockOptionalMetaLookup.java
+++ b/src/api/java/baritone/api/utils/BlockOptionalMetaLookup.java
@@ -22,15 +22,22 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class BlockOptionalMetaLookup {
-
+    private final Set<Block> blockSet = new HashSet<>();
+    private final Set<IBlockState> blockStateSet = new HashSet<>();
     private final BlockOptionalMeta[] boms;
 
     public BlockOptionalMetaLookup(BlockOptionalMeta... boms) {
         this.boms = boms;
+        for (BlockOptionalMeta bom : boms) {
+            blockSet.add(bom.getBlock());
+            blockStateSet.addAll(bom.getAllBlockStates());
+        }
     }
 
     public BlockOptionalMetaLookup(Block... blocks) {
@@ -52,23 +59,11 @@ public class BlockOptionalMetaLookup {
     }
 
     public boolean has(Block block) {
-        for (BlockOptionalMeta bom : boms) {
-            if (bom.getBlock() == block) {
-                return true;
-            }
-        }
-
-        return false;
+        return blockSet.contains(block);
     }
 
     public boolean has(IBlockState state) {
-        for (BlockOptionalMeta bom : boms) {
-            if (bom.matches(state)) {
-                return true;
-            }
-        }
-
-        return false;
+        return blockStateSet.contains(state);
     }
 
     public boolean has(ItemStack stack) {

--- a/src/launch/java/baritone/launch/mixins/MixinBitArray.java
+++ b/src/launch/java/baritone/launch/mixins/MixinBitArray.java
@@ -64,4 +64,14 @@ public abstract class MixinBitArray implements IBitArray {
 
         return out;
     }
+
+    @Override
+    public long getMaxEntryValue() {
+        return maxEntryValue;
+    }
+
+    @Override
+    public int getBitsPerEntry() {
+        return bitsPerEntry;
+    }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinBlockStateContainer.java
+++ b/src/launch/java/baritone/launch/mixins/MixinBlockStateContainer.java
@@ -36,6 +36,16 @@ public abstract class MixinBlockStateContainer implements IBlockStateContainer {
     protected IBlockStatePalette palette;
 
     @Override
+    public IBlockStatePalette getPalette() {
+        return palette;
+    }
+
+    @Override
+    public BitArray getStorage() {
+        return storage;
+    }
+
+    @Override
     public IBlockState getAtPalette(int index) {
         return palette.getBlockState(index);
     }

--- a/src/main/java/baritone/BaritoneProvider.java
+++ b/src/main/java/baritone/BaritoneProvider.java
@@ -22,6 +22,7 @@ import baritone.api.IBaritoneProvider;
 import baritone.api.cache.IWorldScanner;
 import baritone.api.command.ICommandSystem;
 import baritone.api.schematic.ISchematicSystem;
+import baritone.cache.FasterWorldScanner;
 import baritone.cache.WorldScanner;
 import baritone.command.CommandSystem;
 import baritone.command.ExampleBaritoneControl;
@@ -59,7 +60,7 @@ public final class BaritoneProvider implements IBaritoneProvider {
 
     @Override
     public IWorldScanner getWorldScanner() {
-        return WorldScanner.INSTANCE;
+        return FasterWorldScanner.INSTANCE;
     }
 
     @Override

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -93,6 +93,7 @@ public enum FasterWorldScanner implements IWorldScanner {
     }
 
     // for porting, see {@link https://github.com/JsMacros/JsMacros/blob/backport-1.12.2/common/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/worldscanner/WorldScanner.java}
+    // tho I did change some things...
     public static class WorldScannerContext {
         private final BlockOptionalMetaLookup filter;
         private final IPlayerContext ctx;

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -1,0 +1,270 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.cache;
+
+import baritone.api.cache.ICachedWorld;
+import baritone.api.cache.IWorldScanner;
+import baritone.api.utils.BetterBlockPos;
+import baritone.api.utils.BlockOptionalMetaLookup;
+import baritone.api.utils.IPlayerContext;
+import baritone.utils.accessor.IBitArray;
+import baritone.utils.accessor.IBlockStateContainer;
+import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.BitArray;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.*;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public enum FasterWorldScanner implements IWorldScanner {
+    INSTANCE;
+    @Override
+    public List<BlockPos> scanChunkRadius(IPlayerContext ctx, BlockOptionalMetaLookup filter, int max, int yLevelThreshold, int maxSearchRadius) {
+        return new WorldScannerContext(filter, ctx).scanAroundPlayerRange(maxSearchRadius);
+    }
+
+    @Override
+    public List<BlockPos> scanChunk(IPlayerContext ctx, BlockOptionalMetaLookup filter, ChunkPos pos, int max, int yLevelThreshold) {
+        return new WorldScannerContext(filter, ctx).scanAroundPlayerUntilCount(max);
+    }
+
+    @Override
+    public int repack(IPlayerContext ctx) {
+        return this.repack(ctx, 40);
+    }
+
+    @Override
+    public int repack(IPlayerContext ctx, int range) {
+        IChunkProvider chunkProvider = ctx.world().getChunkProvider();
+        ICachedWorld cachedWorld = ctx.worldData().getCachedWorld();
+
+        BetterBlockPos playerPos = ctx.playerFeet();
+
+        int playerChunkX = playerPos.getX() >> 4;
+        int playerChunkZ = playerPos.getZ() >> 4;
+
+        int minX = playerChunkX - range;
+        int minZ = playerChunkZ - range;
+        int maxX = playerChunkX + range;
+        int maxZ = playerChunkZ + range;
+
+        int queued = 0;
+        for (int x = minX; x <= maxX; x++) {
+            for (int z = minZ; z <= maxZ; z++) {
+                Chunk chunk = chunkProvider.getLoadedChunk(x, z);
+
+                if (chunk != null && !chunk.isEmpty()) {
+                    queued++;
+                    cachedWorld.queueForPacking(chunk);
+                }
+            }
+        }
+
+        return queued;
+    }
+
+    // for porting, see {@link https://github.com/JsMacros/JsMacros/blob/backport-1.12.2/common/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/worldscanner/WorldScanner.java}
+    public static class WorldScannerContext {
+        private final BlockOptionalMetaLookup filter;
+        private final IPlayerContext ctx;
+        private final Map<IBlockState, Boolean> cachedFilter = new ConcurrentHashMap<>();
+
+        public WorldScannerContext(BlockOptionalMetaLookup filter, IPlayerContext ctx) {
+            this.filter = filter;
+            this.ctx = ctx;
+        }
+
+        public List<ChunkPos> getChunkRange(int centerX, int centerZ, int chunkrange) {
+            List<ChunkPos> chunks = new ArrayList<>();
+            for (int x = centerX - chunkrange; x <= centerX + chunkrange; x++) {
+                for (int z = centerZ - chunkrange; z <= centerZ + chunkrange; z++) {
+                    chunks.add(new ChunkPos(x, z));
+                }
+            }
+            return chunks;
+        }
+
+        public List<BlockPos> scanAroundPlayerRange(int range) {
+            return scanAroundPlayer(range, -1);
+        }
+
+        public List<BlockPos> scanAroundPlayerUntilCount(int count) {
+            return scanAroundPlayer(32, count);
+        }
+
+        public List<BlockPos> scanAroundPlayer(int range, int maxCount) {
+            assert ctx.player() != null;
+            return scanChunkRange(ctx.playerFeet().x >> 4, ctx.playerFeet().z >> 4, range, maxCount);
+        }
+
+        public List<BlockPos> scanChunkRange(int centerX, int centerZ, int chunkRange, int maxBlocks) {
+            assert ctx.world() != null;
+            if (chunkRange < 0) {
+                throw new IllegalArgumentException("chunkRange must be >= 0");
+            }
+            return scanChunksInternal(getChunkRange(centerX, centerZ, chunkRange), maxBlocks);
+        }
+
+        private List<BlockPos> scanChunksInternal(List<ChunkPos> chunkPositions, int maxBlocks) {
+            assert ctx.world() != null;
+            return chunkPositions.parallelStream().flatMap(this::scanChunkInternal).limit(maxBlocks <= 0 ? Long.MAX_VALUE : maxBlocks).collect(Collectors.toList());
+        }
+        private Stream<BlockPos> scanChunkInternal(ChunkPos pos) {
+            IChunkProvider chunkProvider = ctx.world().getChunkProvider();
+            // if chunk is not loaded, return empty stream
+            if (!chunkProvider.isChunkGeneratedAt(pos.x, pos.z)) {
+                return Stream.empty();
+            }
+
+            long chunkX = (long) pos.x << 4;
+            long chunkZ = (long) pos.z << 4;
+
+            List<BlockPos> blocks = new ArrayList<>();
+
+            streamChunkSections(chunkProvider.getLoadedChunk(pos.x, pos.z), (section, isInFilter) -> {
+                int yOffset = section.getYLocation();
+                BitArray array = (BitArray) ((IBlockStateContainer) section.getData()).getStorage();
+                forEach(array, isInFilter, place -> blocks.add(new BlockPos(
+                        chunkX + ((place & 255) & 15),
+                        yOffset + (place >> 8),
+                        chunkZ + ((place & 255) >> 4)
+                )));
+            });
+            return blocks.stream();
+        }
+
+        private void streamChunkSections(Chunk chunk, BiConsumer<ExtendedBlockStorage, boolean[]> consumer) {
+            for (ExtendedBlockStorage section : chunk.getBlockStorageArray()) {
+                if (section == null || section.isEmpty()) {
+                    continue;
+                }
+
+                BlockStateContainer sectionContainer = section.getData();
+                //this won't work if the PaletteStorage is of the type EmptyPaletteStorage
+                if (((IBlockStateContainer) sectionContainer).getStorage() == null) {
+                    continue;
+                }
+
+                boolean[] isInFilter = getIncludedFilterIndices(((IBlockStateContainer) sectionContainer).getPalette());
+                if (isInFilter.length == 0) {
+                    continue;
+                }
+                consumer.accept(section, isInFilter);
+            }
+        }
+
+        private boolean getFilterResult(IBlockState state) {
+            Boolean v;
+            return (v = cachedFilter.get(state)) == null ? addCachedState(state) : v;
+        }
+
+        private boolean addCachedState(IBlockState state) {
+            boolean isInFilter = false;
+
+            if (filter != null) {
+                isInFilter = filter.has(state);
+            }
+
+            cachedFilter.put(state, isInFilter);
+            return isInFilter;
+        }
+
+        private boolean[] getIncludedFilterIndices(IBlockStatePalette palette) {
+            boolean commonBlockFound = false;
+            Int2ObjectOpenHashMap<IBlockState> paletteMap = getPalette(palette);
+            int size = paletteMap.size();
+
+            boolean[] isInFilter = new boolean[size];
+
+            for (int i = 0; i < size; i++) {
+                IBlockState state = paletteMap.get(i);
+                if (getFilterResult(state)) {
+                    isInFilter[i] = true;
+                    commonBlockFound = true;
+                } else {
+                    isInFilter[i] = false;
+                }
+            }
+
+            if (!commonBlockFound) {
+                return new boolean[0];
+            }
+            return isInFilter;
+        }
+
+        private static void forEach(BitArray array, boolean[] isInFilter, IntConsumer action) {
+            int counter = 0;
+            long[] storage = array.getBackingLongArray();
+            int arraySize = array.size();
+            int elementBits = ((IBitArray) array).getBitsPerEntry();
+            long maxValue = ((IBitArray) array).getMaxEntryValue();
+            int storageLength = storage.length;
+
+            if (storageLength != 0) {
+                int lastStorageIdx = 0;
+                long row = storage[0];
+                long nextRow = storageLength > 1 ? storage[1] : 0L;
+
+                for (int idx = 0; idx < arraySize; idx++) {
+                    int n = idx * elementBits;
+                    int storageIdx = n >> 6;
+                    int p = (idx + 1) * elementBits - 1 >> 6;
+                    int q = n ^ storageIdx << 6;
+                    if (storageIdx != lastStorageIdx) {
+                        row = nextRow;
+                        nextRow = storageIdx + 1 < storageLength ? storage[storageIdx + 1] : 0L;
+                        lastStorageIdx = storageIdx;
+                    }
+                    if (storageIdx == p) {
+                        if (isInFilter[(int) (row >>> q & maxValue)]) {
+                            action.accept(counter);
+                        } else {
+                            if (isInFilter[(int) ((row >>> q | nextRow << (64 - q)) & maxValue)]) {
+                                action.accept(counter);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static Int2ObjectOpenHashMap<IBlockState> getPalette(IBlockStatePalette palette) {
+            PacketBuffer buf = new PacketBuffer(Unpooled.buffer());
+            palette.write(buf);
+            int size = buf.readVarInt();
+            Int2ObjectOpenHashMap<IBlockState> paletteMap = new Int2ObjectOpenHashMap<>(size);
+            for (int i = 0; i < size; i++) {
+                paletteMap.put(i, Block.BLOCK_STATE_IDS.getByValue(buf.readVarInt()));
+            }
+            return paletteMap;
+        }
+    }
+}

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -193,40 +193,14 @@ public enum FasterWorldScanner implements IWorldScanner {
             return;
         }
 
-
-        int yOffset = section.getYLocation();
         BitArray array = ((IBlockStateContainer) section.getData()).getStorage();
-        collectBlockLocations(array, isInFilter, blocks, chunkX, chunkZ, yOffset);
-    }
-
-    private boolean[] getIncludedFilterIndices(BlockOptionalMetaLookup lookup, IBlockStatePalette palette) {
-        boolean commonBlockFound = false;
-        ObjectIntIdentityMap<IBlockState> paletteMap = getPalette(palette);
-        int size = paletteMap.size();
-
-        boolean[] isInFilter = new boolean[size];
-
-        for (int i = 0; i < size; i++) {
-            IBlockState state = paletteMap.getByValue(i);
-            if (lookup.has(state)) {
-                isInFilter[i] = true;
-                commonBlockFound = true;
-            } else {
-                isInFilter[i] = false;
-            }
-        }
-
-        if (!commonBlockFound) {
-            return new boolean[0];
-        }
-        return isInFilter;
-    }
-
-    private static void collectBlockLocations(BitArray array, boolean[] isInFilter, List<BlockPos> blocks, long chunkX, long chunkZ, int yOffset) {
         long[] longArray = array.getBackingLongArray();
         int arraySize = array.size();
         int bitsPerEntry = ((IBitArray) array).getBitsPerEntry();
         long maxEntryValue = ((IBitArray) array).getMaxEntryValue();
+
+
+        int yOffset = section.getYLocation();
 
         for (int idx = 0, kl = bitsPerEntry - 1; idx < arraySize; idx++, kl += bitsPerEntry) {
             final int i = idx * bitsPerEntry;
@@ -255,6 +229,29 @@ public enum FasterWorldScanner implements IWorldScanner {
                 }
             }
         }
+    }
+
+    private boolean[] getIncludedFilterIndices(BlockOptionalMetaLookup lookup, IBlockStatePalette palette) {
+        boolean commonBlockFound = false;
+        ObjectIntIdentityMap<IBlockState> paletteMap = getPalette(palette);
+        int size = paletteMap.size();
+
+        boolean[] isInFilter = new boolean[size];
+
+        for (int i = 0; i < size; i++) {
+            IBlockState state = paletteMap.getByValue(i);
+            if (lookup.has(state)) {
+                isInFilter[i] = true;
+                commonBlockFound = true;
+            } else {
+                isInFilter[i] = false;
+            }
+        }
+
+        if (!commonBlockFound) {
+            return new boolean[0];
+        }
+        return isInFilter;
     }
 
     /**

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -91,34 +91,38 @@ public enum FasterWorldScanner implements IWorldScanner {
         return queued;
     }
 
-    // for porting, see {@link https://github.com/JsMacros/JsMacros/blob/backport-1.12.2/common/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/worldscanner/WorldScanner.java}
-    // tho I did change some things...
+    // ordered in a way that the closest blocks are generally first
+    public List<ChunkPos> getChunkRange(int centerX, int centerZ, int chunkRadius) {
+        List<ChunkPos> chunks = new ArrayList<>();
+        // spiral out
+        chunks.add(new ChunkPos(centerX, centerZ));
+        for (int i = 1; i < chunkRadius; i++) {
+            for (int j = 0; j <= i; j++) {
+                chunks.add(new ChunkPos(centerX - j, centerZ - i));
+                chunks.add(new ChunkPos(centerX + j, centerZ - i));
+                chunks.add(new ChunkPos(centerX - j, centerZ + i));
+                chunks.add(new ChunkPos(centerX + j, centerZ + i));
+                if (j != 0 && j != i) {
+                    chunks.add(new ChunkPos(centerX - i, centerZ - j));
+                    chunks.add(new ChunkPos(centerX + i, centerZ - j));
+                    chunks.add(new ChunkPos(centerX - i, centerZ + j));
+                    chunks.add(new ChunkPos(centerX + i, centerZ + j));
+                }
+            }
+        }
+        return chunks;
+    }
+
     public static class WorldScannerContext {
         private final BlockOptionalMetaLookup filter;
         private final IPlayerContext ctx;
-        private final Map<IBlockState, Boolean> cachedFilter = new ConcurrentHashMap<>();
 
         public WorldScannerContext(BlockOptionalMetaLookup filter, IPlayerContext ctx) {
             this.filter = filter;
             this.ctx = ctx;
         }
 
-        public List<ChunkPos> getChunkRange(int centerX, int centerZ, int chunkRadius) {
-            List<ChunkPos> chunks = new ArrayList<>();
-            // spiral out
-            chunks.add(new ChunkPos(centerX, centerZ));
-            for (int i = 1; i < chunkRadius; i++) {
-                for (int x = centerX - i; x <= centerX + i; x++) {
-                    chunks.add(new ChunkPos(x, centerZ - i));
-                    chunks.add(new ChunkPos(x, centerZ + i));
-                }
-                for (int z = centerZ - i + 1; z <= centerZ + i - 1; z++) {
-                    chunks.add(new ChunkPos(centerX - i, z));
-                    chunks.add(new ChunkPos(centerX + i, z));
-                }
-            }
-            return chunks;
-        }
+
 
         public List<BlockPos> scanAroundPlayerRange(int range) {
             return scanAroundPlayer(range, -1);

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -106,11 +106,13 @@ public enum FasterWorldScanner implements IWorldScanner {
                     chunks.add(new ChunkPos(centerX - j, centerZ + i));
                 }
                 chunks.add(new ChunkPos(centerX + j, centerZ + i));
-                if (j != 0 && j != i) {
+                if (j != i) {
                     chunks.add(new ChunkPos(centerX - i, centerZ - j));
                     chunks.add(new ChunkPos(centerX + i, centerZ - j));
-                    chunks.add(new ChunkPos(centerX - i, centerZ + j));
-                    chunks.add(new ChunkPos(centerX + i, centerZ + j));
+                    if (j != 0) {
+                        chunks.add(new ChunkPos(centerX - i, centerZ + j));
+                        chunks.add(new ChunkPos(centerX + i, centerZ + j));
+                    }
                 }
             }
         }

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -105,24 +105,16 @@ public enum FasterWorldScanner implements IWorldScanner {
         public List<ChunkPos> getChunkRange(int centerX, int centerZ, int chunkRadius) {
             List<ChunkPos> chunks = new ArrayList<>();
             // spiral out
-            int x = centerX;
-            int z = centerZ;
-            int dx = 0;
-            int dz = -1;
-            int t = Math.max(chunkRadius, 1);
-            int maxI = t * t;
-            for (int i = 0; i < maxI; i++) {
-                if ((-chunkRadius / 2 <= x) && (x <= chunkRadius / 2) && (-chunkRadius / 2 <= z) && (z <= chunkRadius / 2)) {
-                    chunks.add(new ChunkPos(x, z));
+            chunks.add(new ChunkPos(centerX, centerZ));
+            for (int i = 1; i < chunkRadius; i++) {
+                for (int x = centerX - i; x <= centerX + i; x++) {
+                    chunks.add(new ChunkPos(x, centerZ - i));
+                    chunks.add(new ChunkPos(x, centerZ + i));
                 }
-                // idk how this works, copilot did it
-                if ((x == z) || ((x < 0) && (x == -z)) || ((x > 0) && (x == 1 - z))) {
-                    t = dx;
-                    dx = -dz;
-                    dz = t;
+                for (int z = centerZ - i + 1; z <= centerZ + i - 1; z++) {
+                    chunks.add(new ChunkPos(centerX - i, z));
+                    chunks.add(new ChunkPos(centerX + i, z));
                 }
-                x += dx;
-                z += dz;
             }
             return chunks;
         }

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -55,7 +55,11 @@ public enum FasterWorldScanner implements IWorldScanner {
 
     @Override
     public List<BlockPos> scanChunk(IPlayerContext ctx, BlockOptionalMetaLookup filter, ChunkPos pos, int max, int yLevelThreshold) {
-        return scanChunkInternal(ctx, filter, pos).limit(max).collect(Collectors.toList());
+        Stream<BlockPos> stream = scanChunkInternal(ctx, filter, pos);
+        if (max >= 0) {
+            stream = stream.limit(max);
+        }
+        return stream.collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -25,7 +25,6 @@ import baritone.api.utils.IPlayerContext;
 import baritone.utils.accessor.IBitArray;
 import baritone.utils.accessor.IBlockStateContainer;
 import io.netty.buffer.Unpooled;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.network.PacketBuffer;
@@ -49,12 +48,12 @@ public enum FasterWorldScanner implements IWorldScanner {
     INSTANCE;
     @Override
     public List<BlockPos> scanChunkRadius(IPlayerContext ctx, BlockOptionalMetaLookup filter, int max, int yLevelThreshold, int maxSearchRadius) {
-        return new WorldScannerContext(filter, ctx).scanAroundPlayerRange(maxSearchRadius);
+        return new WorldScannerContext(filter, ctx).scanAroundPlayer(maxSearchRadius, max);
     }
 
     @Override
     public List<BlockPos> scanChunk(IPlayerContext ctx, BlockOptionalMetaLookup filter, ChunkPos pos, int max, int yLevelThreshold) {
-        return new WorldScannerContext(filter, ctx).scanAroundPlayerUntilCount(max);
+        return new WorldScannerContext(filter, ctx).scanChunkInternal(pos).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/baritone/command/defaults/MineCommand.java
+++ b/src/main/java/baritone/command/defaults/MineCommand.java
@@ -17,6 +17,7 @@
 
 package baritone.command.defaults;
 
+import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.command.Command;
 import baritone.api.command.argument.IArgConsumer;
@@ -45,7 +46,7 @@ public class MineCommand extends Command {
         while (args.hasAny()) {
             boms.add(args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE));
         }
-        WorldScanner.INSTANCE.repack(ctx);
+        BaritoneAPI.getProvider().getWorldScanner().repack(ctx);
         logDirect(String.format("Mining %s", boms.toString()));
         baritone.getMineProcess().mine(quantity, boms.toArray(new BlockOptionalMeta[0]));
     }

--- a/src/main/java/baritone/command/defaults/PathCommand.java
+++ b/src/main/java/baritone/command/defaults/PathCommand.java
@@ -17,6 +17,7 @@
 
 package baritone.command.defaults;
 
+import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.command.Command;
 import baritone.api.command.argument.IArgConsumer;
@@ -38,7 +39,7 @@ public class PathCommand extends Command {
     public void execute(String label, IArgConsumer args) throws CommandException {
         ICustomGoalProcess customGoalProcess = baritone.getCustomGoalProcess();
         args.requireMax(0);
-        WorldScanner.INSTANCE.repack(ctx);
+        BaritoneAPI.getProvider().getWorldScanner().repack(ctx);
         customGoalProcess.path();
         logDirect("Now pathing");
     }

--- a/src/main/java/baritone/command/defaults/RepackCommand.java
+++ b/src/main/java/baritone/command/defaults/RepackCommand.java
@@ -17,6 +17,7 @@
 
 package baritone.command.defaults;
 
+import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.command.Command;
 import baritone.api.command.argument.IArgConsumer;
@@ -36,7 +37,7 @@ public class RepackCommand extends Command {
     @Override
     public void execute(String label, IArgConsumer args) throws CommandException {
         args.requireMax(0);
-        logDirect(String.format("Queued %d chunks for repacking", WorldScanner.INSTANCE.repack(ctx)));
+        logDirect(String.format("Queued %d chunks for repacking", BaritoneAPI.getProvider().getWorldScanner().repack(ctx)));
     }
 
     @Override

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -18,6 +18,7 @@
 package baritone.process;
 
 import baritone.Baritone;
+import baritone.api.BaritoneAPI;
 import baritone.api.pathing.goals.Goal;
 import baritone.api.pathing.goals.GoalBlock;
 import baritone.api.pathing.goals.GoalComposite;
@@ -189,7 +190,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         }
 
         if (Baritone.settings().mineGoalUpdateInterval.value != 0 && tickCount++ % Baritone.settings().mineGoalUpdateInterval.value == 0) {
-            Baritone.getExecutor().execute(() -> locations = WorldScanner.INSTANCE.scanChunkRadius(ctx, scan, 256, 10, 10));
+            Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
         }
         if (locations == null) {
             return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -18,6 +18,7 @@
 package baritone.process;
 
 import baritone.Baritone;
+import baritone.api.BaritoneAPI;
 import baritone.api.pathing.goals.*;
 import baritone.api.process.IMineProcess;
 import baritone.api.process.PathingCommand;
@@ -355,7 +356,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
         locs = prune(ctx, locs, filter, max, blacklist, dropped);
 
         if (!untracked.isEmpty() || (Baritone.settings().extendCacheOnThreshold.value && locs.size() < max)) {
-            locs.addAll(WorldScanner.INSTANCE.scanChunkRadius(
+            locs.addAll(BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(
                     ctx.getBaritone().getPlayerContext(),
                     filter,
                     max,

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -54,7 +54,7 @@ import static baritone.api.pathing.movement.ActionCosts.COST_INF;
  */
 public final class MineProcess extends BaritoneProcessHelper implements IMineProcess {
 
-    private static final int ORE_LOCATIONS_COUNT = 32;
+    private static final int ORE_LOCATIONS_COUNT = 64;
 
     private BlockOptionalMetaLookup filter;
     private List<BlockPos> knownOreLocations;

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -54,7 +54,7 @@ import static baritone.api.pathing.movement.ActionCosts.COST_INF;
  */
 public final class MineProcess extends BaritoneProcessHelper implements IMineProcess {
 
-    private static final int ORE_LOCATIONS_COUNT = 64;
+    private static final int ORE_LOCATIONS_COUNT = 32;
 
     private BlockOptionalMetaLookup filter;
     private List<BlockPos> knownOreLocations;

--- a/src/main/java/baritone/utils/accessor/IBitArray.java
+++ b/src/main/java/baritone/utils/accessor/IBitArray.java
@@ -3,4 +3,8 @@ package baritone.utils.accessor;
 public interface IBitArray {
 
     int[] toArray();
+
+    long getMaxEntryValue();
+
+    int getBitsPerEntry();
 }

--- a/src/main/java/baritone/utils/accessor/IBlockStateContainer.java
+++ b/src/main/java/baritone/utils/accessor/IBlockStateContainer.java
@@ -1,8 +1,14 @@
 package baritone.utils.accessor;
 
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.BitArray;
+import net.minecraft.world.chunk.IBlockStatePalette;
 
 public interface IBlockStateContainer {
+
+    IBlockStatePalette getPalette();
+
+    BitArray getStorage();
 
     IBlockState getAtPalette(int index);
 


### PR DESCRIPTION
to confirm my results, change `getWorldScanner` back in `BaritoneProvider`.
use max render distance on single player (32 chunks)
#### before
![image](https://user-images.githubusercontent.com/6234704/209413680-08db0a63-2e86-448d-b44e-6c0079ac203c.png)
#### after
![image](https://user-images.githubusercontent.com/6234704/209413683-d57a7919-aa60-4ec1-9e7e-ee71333b7c00.png)


thank you @Etheradon for the parts of the code I "borrowed" from the jsmacros implementation. which I now realize after having tested it in baritone, the 1.12 version is wrong... so I guess I'll have to fix that as well...

the real trick is that I'm cheating with parallelStream, caching block states for faster lookup, and (probably the biggest one) checking the subsection's pallete directly to see if it even exists instead of iterating over the contents