### PR TITLE
Make the world cache work even when mods break our world load hook

### DIFF
--- a/src/main/java/baritone/cache/WorldProvider.java
+++ b/src/main/java/baritone/cache/WorldProvider.java
@@ -142,6 +142,8 @@ public class WorldProvider implements IWorldProvider, Helper {
             if (mc.world != null) {
                 initWorld(mc.world.provider.getDimensionType().getId());
             }
+        } else if (currentWorld == null && mc.world != null) {
+            initWorld(mc.world.provider.getDimensionType().getId());
         }
     }
 }

--- a/src/main/java/baritone/cache/WorldProvider.java
+++ b/src/main/java/baritone/cache/WorldProvider.java
@@ -85,6 +85,7 @@ public class WorldProvider implements IWorldProvider, Helper {
                 folderName = mc.getCurrentServerData().serverIP;
             } else {
                 //replaymod causes null currentServerData and false singleplayer.
+                System.out.println("World seems to be a replay. Not loading Baritone cache.");
                 currentWorld = null;
                 mcWorld = mc.world;
                 return;
@@ -137,12 +138,15 @@ public class WorldProvider implements IWorldProvider, Helper {
     private final void detectAndHandleBrokenLoading() {
         if (this.mcWorld != mc.world) {
             if (this.currentWorld != null) {
+                System.out.println("mc.world unloaded unnoticed! Unloading Baritone cache now.");
                 closeWorld();
             }
             if (mc.world != null) {
+                System.out.println("mc.world loaded unnoticed! Loading Baritone cache now.");
                 initWorld(mc.world.provider.getDimensionType().getId());
             }
         } else if (currentWorld == null && mc.world != null) {
+            System.out.println("Retrying to load Baritone cache");
             initWorld(mc.world.provider.getDimensionType().getId());
         }
     }

--- a/src/main/java/baritone/cache/WorldProvider.java
+++ b/src/main/java/baritone/cache/WorldProvider.java
@@ -145,7 +145,7 @@ public class WorldProvider implements IWorldProvider, Helper {
                 System.out.println("mc.world loaded unnoticed! Loading Baritone cache now.");
                 initWorld(mc.world.provider.getDimensionType().getId());
             }
-        } else if (currentWorld == null && mc.world != null) {
+        } else if (currentWorld == null && mc.world != null && (mc.isSingleplayer() || mc.getCurrentServerData() != null)) {
             System.out.println("Retrying to load Baritone cache");
             initWorld(mc.world.provider.getDimensionType().getId());
         }


### PR DESCRIPTION
This checks whether `mc.world` changed on every access to the cached world.
Includes the check wagyourtail applied on 1.19.3 just in case.

closes #3031
closes #3603
closes #3141

<!-- No UwU's or OwO's allowed -->
