### PR TITLE
Deobf build task to allow mods building against baritone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,23 +144,32 @@ task proguard(type: ProguardTask) {
 
 task createDist(type: CreateDistTask, dependsOn: proguard)
 
+task deobfJar(type: Jar) {
+    from sourceSets.api.output, sourceSets.main.output, sourceSets.launch.output
+    baseName += "-deobf"
+}
+
+build.dependsOn(deobfJar)
 build.finalizedBy(createDist)
 
 install {
     def jarApiName = String.format("%s-api-%s", rootProject.name, version.toString())
     def jarApiForgeName = String.format("%s-api-forge-%s", rootProject.name, version.toString())
+    def jarApiDeobfName = String.format("%s-deobf-%s", rootProject.name, version.toString())
     def jarSAName = String.format("%s-standalone-%s", rootProject.name, version.toString())
     def jarSAForgeName = String.format("%s-standalone-forge-%s", rootProject.name, version.toString())
 
     artifacts {
         archives file("$buildDir/libs/"+jarApiName+".jar")
         archives file("$buildDir/libs/"+jarApiForgeName+".jar")
+        archives file("$buildDir/libs/"+jarApiDeobfName+".jar")
         archives file("$buildDir/libs/"+jarSAName+".jar")
         archives file("$buildDir/libs/"+jarSAForgeName+".jar")
     }
     repositories.mavenInstaller {
 		addFilter('api') { artifact, file -> artifact.name == "baritone-api" }
 		addFilter('api-forge') { artifact, file -> artifact.name == "baritone-api-forge" }
+        addFilter('deobf') { artifact, file -> artifact.name == "baritone-deobf" }
 		addFilter('standalone') { artifact, file -> artifact.name == "baritone-standalone" }
 		addFilter('standalone-forge') { artifact, file -> artifact.name == "baritone-standalone-forge" }
     }

--- a/buildSrc/src/main/java/baritone/gradle/task/BaritoneGradleTask.java
+++ b/buildSrc/src/main/java/baritone/gradle/task/BaritoneGradleTask.java
@@ -45,12 +45,13 @@ class BaritoneGradleTask extends DefaultTask {
             ARTIFACT_STANDARD         = "%s-%s.jar",
             ARTIFACT_UNOPTIMIZED      = "%s-unoptimized-%s.jar",
             ARTIFACT_API              = "%s-api-%s.jar",
+            ARTIFACT_DEOBF            = "%s-deobf-%s.jar",
             ARTIFACT_STANDALONE       = "%s-standalone-%s.jar",
             ARTIFACT_FORGE_API        = "%s-api-forge-%s.jar",
             ARTIFACT_FORGE_STANDALONE = "%s-standalone-forge-%s.jar";
 
     protected String artifactName, artifactVersion;
-    protected Path artifactPath, artifactUnoptimizedPath, artifactApiPath, artifactStandalonePath, artifactForgeApiPath, artifactForgeStandalonePath, proguardOut;
+    protected Path artifactPath, artifactUnoptimizedPath, artifactApiPath, artifactDeobfPath, artifactStandalonePath, artifactForgeApiPath, artifactForgeStandalonePath, proguardOut;
 
     protected void verifyArtifacts() throws IllegalStateException {
         this.artifactName = getProject().getName();
@@ -59,6 +60,7 @@ class BaritoneGradleTask extends DefaultTask {
         this.artifactPath                = this.getBuildFile(formatVersion(ARTIFACT_STANDARD));
         this.artifactUnoptimizedPath     = this.getBuildFile(formatVersion(ARTIFACT_UNOPTIMIZED));
         this.artifactApiPath             = this.getBuildFile(formatVersion(ARTIFACT_API));
+        this.artifactDeobfPath           = this.getBuildFile(formatVersion(ARTIFACT_DEOBF));
         this.artifactStandalonePath      = this.getBuildFile(formatVersion(ARTIFACT_STANDALONE));
         this.artifactForgeApiPath        = this.getBuildFile(formatVersion(ARTIFACT_FORGE_API));
         this.artifactForgeStandalonePath = this.getBuildFile(formatVersion(ARTIFACT_FORGE_STANDALONE));

--- a/buildSrc/src/main/java/baritone/gradle/task/CreateDistTask.java
+++ b/buildSrc/src/main/java/baritone/gradle/task/CreateDistTask.java
@@ -43,6 +43,7 @@ public class CreateDistTask extends BaritoneGradleTask {
 
         // Define the distribution file paths
         Path api             = getRelativeFile("dist/" + formatVersion(ARTIFACT_API));
+        Path deobf           = getRelativeFile("dist/" + formatVersion(ARTIFACT_DEOBF));
         Path standalone      = getRelativeFile("dist/" + formatVersion(ARTIFACT_STANDALONE));
         Path unoptimized     = getRelativeFile("dist/" + formatVersion(ARTIFACT_UNOPTIMIZED));
         Path forgeApi        = getRelativeFile("dist/" + formatVersion(ARTIFACT_FORGE_API));
@@ -56,13 +57,14 @@ public class CreateDistTask extends BaritoneGradleTask {
 
         // Copy build jars to dist/
         Files.copy(this.artifactApiPath,             api,             REPLACE_EXISTING);
+        Files.copy(this.artifactDeobfPath,           deobf,           REPLACE_EXISTING);
         Files.copy(this.artifactStandalonePath,      standalone,      REPLACE_EXISTING);
         Files.copy(this.artifactUnoptimizedPath,     unoptimized,     REPLACE_EXISTING);
         Files.copy(this.artifactForgeApiPath,        forgeApi,        REPLACE_EXISTING);
         Files.copy(this.artifactForgeStandalonePath, forgeStandalone, REPLACE_EXISTING);
 
         // Calculate all checksums and format them like "shasum"
-        List<String> shasum = Stream.of(api, forgeApi, standalone, forgeStandalone, unoptimized)
+        List<String> shasum = Stream.of(api, deobf, forgeApi, standalone, forgeStandalone, unoptimized)
                 .map(path -> sha1(path) + "  " + path.getFileName().toString())
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
Mods like Lambda (and previously kami blue) that bundle Baritone have been [stuck on 1.2.15 for years](https://github.com/lambda-client/lambda/blob/7b505a34362e31c91b6f53ce07e355091a918598/build.gradle#L111-L115). The baritone in `ImpactDevelopment/maven` [is also still on 1.2.15](https://github.com/ImpactDevelopment/maven/tree/master/cabaletta/baritone-api/1.2).

If mods build against [com.github.cabaletta.baritone:baritone-api:v1.2.17](https://jitpack.io/#cabaletta/baritone/v1.2.17), Baritone's API classes reference obfuscated MC classes which need to not be obf to reference against at compile steps of the build. 

This PR adds an explicit `deobf` jar that baritone builds. 

[Example of how this PR can be used by dependent mods](https://github.com/rfresh2/lambda/commit/5d9c9e11694c0eb8e0fdcd0f4507f7a74baff8aa)

Definitely open to alternate solutions, I opted not to touch existing baritone artifacts to not break consumers that depend on them as they are. 

