### PR TITLE
✨ Add maxYLevelWhileMining setting

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -854,6 +854,11 @@ public final class Settings {
     public final Setting<Integer> minYLevelWhileMining = new Setting<>(0);
 
     /**
+     * Sets the maximum y level to mine ores at.
+     */
+    public final Setting<Integer> maxYLevelWhileMining = new Setting<>(255); // 1.17+ defaults to maximum possible world height
+
+    /**
      * This will only allow baritone to mine exposed ores, can be used to stop ore obfuscators on servers that use them.
      */
     public final Setting<Boolean> allowOnlyExposedOres = new Setting<>(false);

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -437,6 +437,8 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
 
                 .filter(pos -> pos.getY() >= Baritone.settings().minYLevelWhileMining.value)
 
+                .filter(pos -> pos.getY() <= Baritone.settings().maxYLevelWhileMining.value)
+
                 .filter(pos -> !blacklist.contains(pos))
 
                 .sorted(Comparator.comparingDouble(ctx.getBaritone().getPlayerContext().player()::getDistanceSq))


### PR DESCRIPTION
Behavior on 1.12.2 is obvious, but I'm not sure what to do when updating.
The option I prefer is simply bumping the default value to be the maximum maximum build height (Baritone doesn't work in CubicChunks worlds, right?), but for consistency with `minYLevelWhileMining` we'd need to also offset it by the minimum build height.
@wagyourtail why is `minYLevelWhileMining` offset by the minimum y anyway? Just so the default can stay at 0 or is there another reason?

closes #1883
<!-- No UwU's or OwO's allowed -->
