### PR TITLE
Allow blocking main for scanning

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -907,6 +907,13 @@ public final class Settings {
     public final Setting<Boolean> extendCacheOnThreshold = new Setting<>(false);
 
     /**
+     * When enabled the main thread will not be used for world scanning.
+     * This trades correctness for performance so do not enable this unless you
+     * really need it and do not report bugs if it causes problems.
+     */
+    public final Setting<Boolean> scanAsynchronously = new Setting<>(false);
+
+    /**
      * Don't consider the next layer in builder until the current one is done
      */
     public final Setting<Boolean> buildInLayers = new Setting<>(false);

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -907,11 +907,13 @@ public final class Settings {
     public final Setting<Boolean> extendCacheOnThreshold = new Setting<>(false);
 
     /**
-     * When enabled the main thread will not be used for world scanning.
-     * This trades correctness for performance so do not enable this unless you
-     * really need it and do not report bugs if it causes problems.
+     * When enabled the main thread will not participate in world scanning.
+     * <p>
+     * Rarely causes a race condition so if Baritone doesn't find blocks anymore
+     * and your log is full of {@code ArrayIndexOutOfBoundsException}s you might
+     * want to try turning this off.
      */
-    public final Setting<Boolean> scanAsynchronously = new Setting<>(false);
+    public final Setting<Boolean> scanAsynchronously = new Setting<>(true);
 
     /**
      * Don't consider the next layer in builder until the current one is done

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -235,4 +235,12 @@ public class Baritone implements IBaritone {
     public static Executor getExecutor() {
         return threadPool;
     }
+
+    public static void executeScan(Runnable func) {
+        if (settings().scanAsynchronously.value) {
+            getExecutor().execute(func);
+        } else {
+            func.run();
+        }
+    }
 }

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -58,7 +58,7 @@ public enum FasterWorldScanner implements IWorldScanner {
 
     @Override
     public List<BlockPos> scanChunk(IPlayerContext ctx, BlockOptionalMetaLookup filter, ChunkPos pos, int max, int yLevelThreshold) {
-        boolean isAsync = Minecraft.getMinecraft().isCallingFromMinecraftThread();
+        boolean isAsync = !Minecraft.getMinecraft().isCallingFromMinecraftThread();
         Stream<BlockPos> stream = scanChunkInternal(ctx, filter, pos, isAsync);
         if (max >= 0) {
             stream = stream.limit(max);
@@ -128,7 +128,7 @@ public enum FasterWorldScanner implements IWorldScanner {
     }
 
     private List<BlockPos> scanChunksInternal(IPlayerContext ctx, BlockOptionalMetaLookup lookup, List<ChunkPos> chunkPositions, int maxBlocks) {
-        boolean isAsync = Minecraft.getMinecraft().isCallingFromMinecraftThread();
+        boolean isAsync = !Minecraft.getMinecraft().isCallingFromMinecraftThread();
         assert ctx.world() != null;
         try {
             // p -> scanChunkInternal(ctx, lookup, p)

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -190,11 +190,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         }
 
         if (Baritone.settings().mineGoalUpdateInterval.value != 0 && tickCount++ % Baritone.settings().mineGoalUpdateInterval.value == 0) {
-            if (Baritone.settings().scanAsynchronously.value) {
-                Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
-            } else {
-                locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10);
-            }
+            Baritone.executeScan(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
         }
         if (locations == null) {
             return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -190,7 +190,11 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         }
 
         if (Baritone.settings().mineGoalUpdateInterval.value != 0 && tickCount++ % Baritone.settings().mineGoalUpdateInterval.value == 0) {
-            Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
+            if (Baritone.settings().scanAsynchronously.value) {
+                Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
+            } else {
+                locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10);
+            }
         }
         if (locations == null) {
             return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/process/GetToBlockProcess.java
+++ b/src/main/java/baritone/process/GetToBlockProcess.java
@@ -109,7 +109,11 @@ public final class GetToBlockProcess extends BaritoneProcessHelper implements IG
         if (mineGoalUpdateInterval != 0 && tickCount++ % mineGoalUpdateInterval == 0) { // big brain
             List<BlockPos> current = new ArrayList<>(knownLocations);
             CalculationContext context = new GetToBlockCalculationContext(true);
-            Baritone.getExecutor().execute(() -> rescan(current, context));
+            if (Baritone.settings().scanAsynchronously.value) {
+                Baritone.getExecutor().execute(() -> rescan(current, context));
+            } else {
+                rescan(current, context);
+            }
         }
         if (goal.isInGoal(ctx.playerFeet()) && goal.isInGoal(baritone.getPathingBehavior().pathStart()) && isSafeToCancel) {
             // we're there

--- a/src/main/java/baritone/process/GetToBlockProcess.java
+++ b/src/main/java/baritone/process/GetToBlockProcess.java
@@ -109,11 +109,7 @@ public final class GetToBlockProcess extends BaritoneProcessHelper implements IG
         if (mineGoalUpdateInterval != 0 && tickCount++ % mineGoalUpdateInterval == 0) { // big brain
             List<BlockPos> current = new ArrayList<>(knownLocations);
             CalculationContext context = new GetToBlockCalculationContext(true);
-            if (Baritone.settings().scanAsynchronously.value) {
-                Baritone.getExecutor().execute(() -> rescan(current, context));
-            } else {
-                rescan(current, context);
-            }
+            Baritone.executeScan(() -> rescan(current, context));
         }
         if (goal.isInGoal(ctx.playerFeet()) && goal.isInGoal(baritone.getPathingBehavior().pathStart()) && isSafeToCancel) {
             // we're there

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -109,7 +109,11 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
         List<BlockPos> curr = new ArrayList<>(knownOreLocations);
         if (mineGoalUpdateInterval != 0 && tickCount++ % mineGoalUpdateInterval == 0) { // big brain
             CalculationContext context = new CalculationContext(baritone, true);
-            Baritone.getExecutor().execute(() -> rescan(curr, context));
+            if (Baritone.settings().scanAsynchronously.value) {
+                Baritone.getExecutor().execute(() -> rescan(curr, context));
+            } else {
+                rescan(curr, context);
+            }
         }
         if (Baritone.settings().legitMine.value) {
             if (!addNearby()) {

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -109,11 +109,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
         List<BlockPos> curr = new ArrayList<>(knownOreLocations);
         if (mineGoalUpdateInterval != 0 && tickCount++ % mineGoalUpdateInterval == 0) { // big brain
             CalculationContext context = new CalculationContext(baritone, true);
-            if (Baritone.settings().scanAsynchronously.value) {
-                Baritone.getExecutor().execute(() -> rescan(curr, context));
-            } else {
-                rescan(curr, context);
-            }
+            Baritone.executeScan(() -> rescan(curr, context));
         }
         if (Baritone.settings().legitMine.value) {
             if (!addNearby()) {


### PR DESCRIPTION
I'm not happy with this but there's no progress anymore form my side so no point in waiting.
What I'd like to improve:
1. [x] Don't catch "concurrency errors" when main is actually blocked. I can't condition the catch on the setting because `IWorldScanner` itself actually has a sync api and the async part is just Baritone calling it from another thread. I also can't test whether the code is run on main because it runs on a thread pool which may or may not use main. 
2. [x] Maybe have a "maybe async executor" to reduce the amount of `if (<setting>) {<line>} else {<nearly identical line>}`? Where would that go? 
3. [ ] Name/documentation. This is a minor problem

closes #3917 
<!-- No UwU's or OwO's allowed -->
