### PR TITLE
Setting Field Metadata

### DIFF
--- a/src/api/java/baritone/api/command/helpers/TabCompleteHelper.java
+++ b/src/api/java/baritone/api/command/helpers/TabCompleteHelper.java
@@ -253,7 +253,7 @@ public class TabCompleteHelper {
     public TabCompleteHelper addSettings() {
         return append(
                 BaritoneAPI.getSettings().allSettings.stream()
-                        .filter(s -> !SettingsUtil.javaOnlySetting(s))
+                        .filter(s -> !s.isJavaOnly())
                         .map(Settings.Setting::getName)
                         .sorted(String.CASE_INSENSITIVE_ORDER)
         );

--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -50,7 +50,6 @@ public class SettingsUtil {
 
     public static final String SETTINGS_DEFAULT_NAME = "settings.txt";
     private static final Pattern SETTING_PATTERN = Pattern.compile("^(?<setting>[^ ]+) +(?<value>.+)"); // key and value split by the first space
-    private static final String[] JAVA_ONLY_SETTINGS = {"logger", "notifier", "toaster"};
 
     private static boolean isComment(String line) {
         return line.startsWith("#") || line.startsWith("//");
@@ -116,7 +115,7 @@ public class SettingsUtil {
                 System.out.println("NULL SETTING?" + setting.getName());
                 continue;
             }
-            if (javaOnlySetting(setting)) {
+            if (setting.isJavaOnly()) {
                 continue; // NO
             }
             if (setting.value == setting.defaultValue) {
@@ -170,7 +169,7 @@ public class SettingsUtil {
     }
 
     public static String settingToString(Settings.Setting setting) throws IllegalStateException {
-        if (javaOnlySetting(setting)) {
+        if (setting.isJavaOnly()) {
             return setting.getName();
         }
 
@@ -178,18 +177,14 @@ public class SettingsUtil {
     }
 
     /**
-     * This should always be the same as whether the setting can be parsed from or serialized to a string
+     * Deprecated. Use {@link Settings.Setting#isJavaOnly()} instead.
      *
      * @param setting The Setting
      * @return true if the setting can not be set or read by the user
      */
+    @Deprecated
     public static boolean javaOnlySetting(Settings.Setting setting) {
-        for (String name : JAVA_ONLY_SETTINGS) { // no JAVA_ONLY_SETTINGS.contains(...) because that would be case sensitive
-            if (setting.getName().equalsIgnoreCase(name)) {
-                return true;
-            }
-        }
-        return false;
+        return setting.isJavaOnly();
     }
 
     public static void parseAndApply(Settings settings, String settingName, String settingValue) throws IllegalStateException, NumberFormatException {

--- a/src/main/java/baritone/command/ExampleBaritoneControl.java
+++ b/src/main/java/baritone/command/ExampleBaritoneControl.java
@@ -124,7 +124,7 @@ public class ExampleBaritoneControl implements Helper, AbstractGameEventListener
             }
         } else if (argc.hasExactlyOne()) {
             for (Settings.Setting setting : settings.allSettings) {
-                if (SettingsUtil.javaOnlySetting(setting)) {
+                if (setting.isJavaOnly()) {
                     continue;
                 }
                 if (setting.getName().equalsIgnoreCase(pair.getFirst())) {
@@ -177,7 +177,7 @@ public class ExampleBaritoneControl implements Helper, AbstractGameEventListener
                             .stream();
                 }
                 Settings.Setting setting = settings.byLowerName.get(argc.getString().toLowerCase(Locale.US));
-                if (setting != null && !SettingsUtil.javaOnlySetting(setting)) {
+                if (setting != null && !setting.isJavaOnly()) {
                     if (setting.getValueClass() == Boolean.class) {
                         TabCompleteHelper helper = new TabCompleteHelper();
                         if ((Boolean) setting.value) {

--- a/src/main/java/baritone/command/defaults/SetCommand.java
+++ b/src/main/java/baritone/command/defaults/SetCommand.java
@@ -77,7 +77,7 @@ public class SetCommand extends Command {
             args.requireMax(1);
             List<? extends Settings.Setting> toPaginate =
                     (viewModified ? SettingsUtil.modifiedSettings(Baritone.settings()) : Baritone.settings().allSettings).stream()
-                            .filter(s -> !javaOnlySetting(s))
+                            .filter(s -> !s.isJavaOnly())
                             .filter(s -> s.getName().toLowerCase(Locale.US).contains(search.toLowerCase(Locale.US)))
                             .sorted((s1, s2) -> String.CASE_INSENSITIVE_ORDER.compare(s1.getName(), s2.getName()))
                             .collect(Collectors.toList());
@@ -141,7 +141,7 @@ public class SetCommand extends Command {
         if (setting == null) {
             throw new CommandInvalidTypeException(args.consumed(), "a valid setting");
         }
-        if (javaOnlySetting(setting)) {
+        if (setting.isJavaOnly()) {
             // ideally it would act as if the setting didn't exist
             // but users will see it in Settings.java or its javadoc
             // so at some point we have to tell them or they will see it as a bug


### PR DESCRIPTION
Replaces the `JAVA_ONLY_SETTINGS` array with a `@JavaOnly` annotation on the fields themselves.

I don't think there's anything else that should be addressed with annotations atm so this PR should be good to go.