### PR TITLE
Batch Rendering

### DIFF
--- a/src/main/java/baritone/command/defaults/SelCommand.java
+++ b/src/main/java/baritone/command/defaults/SelCommand.java
@@ -72,7 +72,7 @@ public class SelCommand extends Command {
                 float lineWidth = Baritone.settings().selectionLineWidth.value;
                 boolean ignoreDepth = Baritone.settings().renderSelectionIgnoreDepth.value;
                 IRenderer.startLines(color, opacity, lineWidth, ignoreDepth);
-                IRenderer.drawAABB(new AxisAlignedBB(pos1, pos1.add(1, 1, 1)));
+                IRenderer.emitAABB(new AxisAlignedBB(pos1, pos1.add(1, 1, 1)));
                 IRenderer.endLines(ignoreDepth);
             }
         });

--- a/src/main/java/baritone/selection/SelectionRenderer.java
+++ b/src/main/java/baritone/selection/SelectionRenderer.java
@@ -23,27 +23,27 @@ public class SelectionRenderer implements IRenderer, AbstractGameEventListener {
         boolean ignoreDepth = settings.renderSelectionIgnoreDepth.value;
         float lineWidth = settings.selectionLineWidth.value;
 
-        if (!settings.renderSelection.value) {
+        if (!settings.renderSelection.value || selections.length == 0) {
             return;
         }
 
         IRenderer.startLines(settings.colorSelection.value, opacity, lineWidth, ignoreDepth);
 
         for (ISelection selection : selections) {
-            IRenderer.drawAABB(selection.aabb(), SELECTION_BOX_EXPANSION);
+            IRenderer.emitAABB(selection.aabb(), SELECTION_BOX_EXPANSION);
         }
 
         if (settings.renderSelectionCorners.value) {
             IRenderer.glColor(settings.colorSelectionPos1.value, opacity);
 
             for (ISelection selection : selections) {
-                IRenderer.drawAABB(new AxisAlignedBB(selection.pos1(), selection.pos1().add(1, 1, 1)));
+                IRenderer.emitAABB(new AxisAlignedBB(selection.pos1(), selection.pos1().add(1, 1, 1)));
             }
 
             IRenderer.glColor(settings.colorSelectionPos2.value, opacity);
 
             for (ISelection selection : selections) {
-                IRenderer.drawAABB(new AxisAlignedBB(selection.pos2(), selection.pos2().add(1, 1, 1)));
+                IRenderer.emitAABB(new AxisAlignedBB(selection.pos2(), selection.pos2().add(1, 1, 1)));
             }
         }
 

--- a/src/main/java/baritone/utils/IRenderer.java
+++ b/src/main/java/baritone/utils/IRenderer.java
@@ -54,6 +54,7 @@ public interface IRenderer {
         if (ignoreDepth) {
             GlStateManager.disableDepth();
         }
+        buffer.begin(GL_LINES, DefaultVertexFormats.POSITION);
     }
 
     static void startLines(Color color, float lineWidth, boolean ignoreDepth) {
@@ -61,6 +62,7 @@ public interface IRenderer {
     }
 
     static void endLines(boolean ignoredDepth) {
+        tessellator.draw();
         if (ignoredDepth) {
             GlStateManager.enableDepth();
         }
@@ -70,10 +72,9 @@ public interface IRenderer {
         GlStateManager.disableBlend();
     }
 
-    static void drawAABB(AxisAlignedBB aabb) {
+    static void emitAABB(AxisAlignedBB aabb) {
         AxisAlignedBB toDraw = aabb.offset(-renderManager.viewerPosX, -renderManager.viewerPosY, -renderManager.viewerPosZ);
 
-        buffer.begin(GL_LINES, DefaultVertexFormats.POSITION);
         // bottom
         buffer.pos(toDraw.minX, toDraw.minY, toDraw.minZ).endVertex();
         buffer.pos(toDraw.maxX, toDraw.minY, toDraw.minZ).endVertex();
@@ -101,10 +102,15 @@ public interface IRenderer {
         buffer.pos(toDraw.maxX, toDraw.maxY, toDraw.maxZ).endVertex();
         buffer.pos(toDraw.minX, toDraw.minY, toDraw.maxZ).endVertex();
         buffer.pos(toDraw.minX, toDraw.maxY, toDraw.maxZ).endVertex();
-        tessellator.draw();
     }
 
-    static void drawAABB(AxisAlignedBB aabb, double expand) {
-        drawAABB(aabb.grow(expand, expand, expand));
+    static void emitAABB(AxisAlignedBB aabb, double expand) {
+        emitAABB(aabb.grow(expand, expand, expand));
+    }
+
+    static void drawAABB(AxisAlignedBB aabb) {
+        buffer.begin(GL_LINES, DefaultVertexFormats.POSITION);
+        emitAABB(aabb);
+        tessellator.draw();
     }
 }

--- a/src/main/java/baritone/utils/PathRenderer.java
+++ b/src/main/java/baritone/utils/PathRenderer.java
@@ -29,7 +29,6 @@ import baritone.pathing.path.PathExecutor;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.tileentity.TileEntityBeaconRenderer;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -37,6 +36,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 
 import java.awt.*;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -76,7 +76,7 @@ public final class PathRenderer implements IRenderer {
         }
 
         if (goal != null && settings.renderGoal.value) {
-            drawDankLitGoalBox(renderView, goal, partialTicks, settings.colorGoalBox.value);
+            drawGoal(renderView, goal, partialTicks, settings.colorGoalBox.value);
         }
 
         if (!settings.renderPath.value) {
@@ -153,26 +153,28 @@ public final class PathRenderer implements IRenderer {
                 IRenderer.glColor(color, alpha);
             }
 
-            drawLine(start.x, start.y, start.z, end.x, end.y, end.z);
-
-            tessellator.draw();
+            emitLine(start.x, start.y, start.z, end.x, end.y, end.z);
         }
 
         IRenderer.endLines(settings.renderPathIgnoreDepth.value);
     }
 
-    public static void drawLine(double x1, double y1, double z1, double x2, double y2, double z2) {
+    public static void emitLine(double x1, double y1, double z1, double x2, double y2, double z2) {
         double vpX = renderManager.viewerPosX;
         double vpY = renderManager.viewerPosY;
         double vpZ = renderManager.viewerPosZ;
         boolean renderPathAsFrickinThingy = !settings.renderPathAsLine.value;
 
-        buffer.begin(renderPathAsFrickinThingy ? GL_LINE_STRIP : GL_LINES, DefaultVertexFormats.POSITION);
         buffer.pos(x1 + 0.5D - vpX, y1 + 0.5D - vpY, z1 + 0.5D - vpZ).endVertex();
         buffer.pos(x2 + 0.5D - vpX, y2 + 0.5D - vpY, z2 + 0.5D - vpZ).endVertex();
 
         if (renderPathAsFrickinThingy) {
+            buffer.pos(x2 + 0.5D - vpX, y2 + 0.5D - vpY, z2 + 0.5D - vpZ).endVertex();
             buffer.pos(x2 + 0.5D - vpX, y2 + 0.53D - vpY, z2 + 0.5D - vpZ).endVertex();
+
+            buffer.pos(x2 + 0.5D - vpX, y2 + 0.53D - vpY, z2 + 0.5D - vpZ).endVertex();
+            buffer.pos(x1 + 0.5D - vpX, y1 + 0.53D - vpY, z1 + 0.5D - vpZ).endVertex();
+
             buffer.pos(x1 + 0.5D - vpX, y1 + 0.53D - vpY, z1 + 0.5D - vpZ).endVertex();
             buffer.pos(x1 + 0.5D - vpX, y1 + 0.5D - vpY, z1 + 0.5D - vpZ).endVertex();
         }
@@ -194,13 +196,17 @@ public final class PathRenderer implements IRenderer {
                 toDraw = state.getSelectedBoundingBox(player.world, pos);
             }
 
-            IRenderer.drawAABB(toDraw, .002D);
+            IRenderer.emitAABB(toDraw, .002D);
         });
 
         IRenderer.endLines(settings.renderSelectionBoxesIgnoreDepth.value);
     }
 
-    public static void drawDankLitGoalBox(Entity player, Goal goal, float partialTicks, Color color) {
+    public static void drawGoal(Entity player, Goal goal, float partialTicks, Color color) {
+        drawGoal(player, goal, partialTicks, color, true);
+    }
+
+    public static void drawGoal(Entity player, Goal goal, float partialTicks, Color color, boolean setupRender) {
         double renderPosX = renderManager.viewerPosX;
         double renderPosY = renderManager.viewerPosY;
         double renderPosZ = renderManager.viewerPosZ;
@@ -232,6 +238,7 @@ public final class PathRenderer implements IRenderer {
                 y2 -= 0.5;
                 maxY--;
             }
+            drawDankLitGoalBox(color, minX, maxX, minZ, maxZ, minY, maxY, y1, y2, setupRender);
         } else if (goal instanceof GoalXZ) {
             GoalXZ goalPos = (GoalXZ) goal;
 
@@ -273,14 +280,22 @@ public final class PathRenderer implements IRenderer {
             y2 = 0;
             minY = 0 - renderPosY;
             maxY = 256 - renderPosY;
+            drawDankLitGoalBox(color, minX, maxX, minZ, maxZ, minY, maxY, y1, y2, setupRender);
         } else if (goal instanceof GoalComposite) {
-            for (Goal g : ((GoalComposite) goal).goals()) {
-                drawDankLitGoalBox(player, g, partialTicks, color);
+            // Simple way to determine if goals can be batched, without having some sort of GoalRenderer
+            boolean batch = Arrays.stream(((GoalComposite) goal).goals()).allMatch(IGoalRenderPos.class::isInstance);
+
+            if (batch) {
+                IRenderer.startLines(color, settings.goalRenderLineWidthPixels.value, settings.renderGoalIgnoreDepth.value);
             }
-            return;
+            for (Goal g : ((GoalComposite) goal).goals()) {
+                drawGoal(player, g, partialTicks, color, !batch);
+            }
+            if (batch) {
+                IRenderer.endLines(settings.renderGoalIgnoreDepth.value);
+            }
         } else if (goal instanceof GoalInverted) {
-            drawDankLitGoalBox(player, ((GoalInverted) goal).origin, partialTicks, settings.colorInvertedGoalBox.value);
-            return;
+            drawGoal(player, ((GoalInverted) goal).origin, partialTicks, settings.colorInvertedGoalBox.value);
         } else if (goal instanceof GoalYLevel) {
             GoalYLevel goalpos = (GoalYLevel) goal;
             minX = player.posX - settings.yLevelBoxSize.value - renderPosX;
@@ -291,16 +306,18 @@ public final class PathRenderer implements IRenderer {
             maxY = minY + 2;
             y1 = 1 + y + goalpos.level - renderPosY;
             y2 = 1 - y + goalpos.level - renderPosY;
-        } else {
-            return;
+            drawDankLitGoalBox(color, minX, maxX, minZ, maxZ, minY, maxY, y1, y2, setupRender);
         }
+    }
 
-        IRenderer.startLines(color, settings.goalRenderLineWidthPixels.value, settings.renderGoalIgnoreDepth.value);
+    private static void drawDankLitGoalBox(Color color, double minX, double maxX, double minZ, double maxZ, double minY, double maxY, double y1, double y2, boolean setupRender) {
+        if (setupRender) {
+            IRenderer.startLines(color, settings.goalRenderLineWidthPixels.value, settings.renderGoalIgnoreDepth.value);
+        }
 
         renderHorizontalQuad(minX, maxX, minZ, maxZ, y1);
         renderHorizontalQuad(minX, maxX, minZ, maxZ, y2);
 
-        buffer.begin(GL_LINES, DefaultVertexFormats.POSITION);
         buffer.pos(minX, minY, minZ).endVertex();
         buffer.pos(minX, maxY, minZ).endVertex();
         buffer.pos(maxX, minY, minZ).endVertex();
@@ -309,19 +326,25 @@ public final class PathRenderer implements IRenderer {
         buffer.pos(maxX, maxY, maxZ).endVertex();
         buffer.pos(minX, minY, maxZ).endVertex();
         buffer.pos(minX, maxY, maxZ).endVertex();
-        tessellator.draw();
 
-        IRenderer.endLines(settings.renderGoalIgnoreDepth.value);
+        if (setupRender) {
+            IRenderer.endLines(settings.renderGoalIgnoreDepth.value);
+        }
     }
 
     private static void renderHorizontalQuad(double minX, double maxX, double minZ, double maxZ, double y) {
         if (y != 0) {
-            buffer.begin(GL_LINE_LOOP, DefaultVertexFormats.POSITION);
             buffer.pos(minX, y, minZ).endVertex();
             buffer.pos(maxX, y, minZ).endVertex();
+
+            buffer.pos(maxX, y, minZ).endVertex();
+            buffer.pos(maxX, y, maxZ).endVertex();
+
             buffer.pos(maxX, y, maxZ).endVertex();
             buffer.pos(minX, y, maxZ).endVertex();
-            tessellator.draw();
+
+            buffer.pos(minX, y, maxZ).endVertex();
+            buffer.pos(minX, y, minZ).endVertex();
         }
     }
 }


### PR DESCRIPTION
Reduces the number of `draw()` calls every frame from upwards of a few hundred to <10

I'm thinking about creating a separate `GoalRenderer` API though so that batching can be done a little smarter, especially with `GoalComposite`. (Would also help with cleaning up the current `drawGoal` mess)