### PR TITLE
Add proper level height to GoalXZ rendering (1.18+)

### DIFF
--- a/src/main/java/baritone/utils/PathRenderer.java
+++ b/src/main/java/baritone/utils/PathRenderer.java
@@ -252,6 +252,8 @@ public final class PathRenderer implements IRenderer, Helper {
             }
         } else if (goal instanceof GoalXZ) {
             GoalXZ goalPos = (GoalXZ) goal;
+            minY = mc.level.getMinBuildHeight();
+            maxY = mc.level.getMaxBuildHeight();
 
             if (settings.renderGoalXZBeacon.value) {
                 glPushAttrib(GL_LIGHTING_BIT);
@@ -273,8 +275,8 @@ public final class PathRenderer implements IRenderer, Helper {
                         settings.renderGoalAnimated.value ? partialTicks : 0,
                         1.0F,
                         settings.renderGoalAnimated.value ? player.level.getGameTime() : 0,
-                        0,
-                        256,
+                        (int) minY,
+                        (int) maxY,
                         color.getColorComponents(null),
 
                         // Arguments filled by the private method lol
@@ -299,8 +301,8 @@ public final class PathRenderer implements IRenderer, Helper {
 
             y1 = 0;
             y2 = 0;
-            minY = 0 - renderPosY;
-            maxY = 256 - renderPosY;
+            minY -= renderPosY;
+            maxY -= renderPosY;
         } else if (goal instanceof GoalComposite) {
             for (Goal g : ((GoalComposite) goal).goals()) {
                 drawDankLitGoalBox(stack, player, g, partialTicks, color);


### PR DESCRIPTION
Minecraft version 1.18 introduced a change to the game's world height.

Baritone uses hardcoded values for minY and maxY when rendering the GoalXZ box, even in the newer game versions.
This pull request uses the minimum and maximum build height from the player's current level.

Before:
![image](https://github.com/cabaletta/baritone/assets/43681932/fbaea2c9-b19b-4088-9b4b-e15915fea019)

After:
![image](https://github.com/cabaletta/baritone/assets/43681932/2ba6cd92-f751-4d24-a978-829e8bcd566a)
