### PR TITLE
Don't call `partOfMask` out of bounds in `BinaryOperatorMask`

### DIFF
--- a/src/api/java/baritone/api/schematic/mask/operator/BinaryOperatorMask.java
+++ b/src/api/java/baritone/api/schematic/mask/operator/BinaryOperatorMask.java
@@ -33,7 +33,7 @@ public final class BinaryOperatorMask extends AbstractMask {
     private final BooleanBinaryOperator operator;
 
     public BinaryOperatorMask(Mask a, Mask b, BooleanBinaryOperator operator) {
-        super(a.widthX(), a.heightY(), a.lengthZ());
+        super(Math.max(a.widthX(), b.widthX()), Math.max(a.heightY(), b.heightY()), Math.max(a.lengthZ(), b.lengthZ()));
         this.a = a;
         this.b = b;
         this.operator = operator;
@@ -42,9 +42,13 @@ public final class BinaryOperatorMask extends AbstractMask {
     @Override
     public boolean partOfMask(int x, int y, int z, IBlockState currentState) {
         return this.operator.applyAsBoolean(
-                this.a.partOfMask(x, y, z, currentState),
-                this.b.partOfMask(x, y, z, currentState)
+                partOfMask(a, x, y, z, currentState),
+                partOfMask(b, x, y, z, currentState)
         );
+    }
+
+    private static boolean partOfMask(Mask mask, int x, int y, int z, IBlockState currentState) {
+        return x < mask.widthX() && y < mask.heightY() && z < mask.lengthZ() && mask.partOfMask(x, y, z, currentState);
     }
 
     public static final class Static extends AbstractMask implements StaticMask {
@@ -54,7 +58,7 @@ public final class BinaryOperatorMask extends AbstractMask {
         private final BooleanBinaryOperator operator;
 
         public Static(StaticMask a, StaticMask b, BooleanBinaryOperator operator) {
-            super(a.widthX(), a.heightY(), a.lengthZ());
+            super(Math.max(a.widthX(), b.widthX()), Math.max(a.heightY(), b.heightY()), Math.max(a.lengthZ(), b.lengthZ()));
             this.a = a;
             this.b = b;
             this.operator = operator;
@@ -63,9 +67,13 @@ public final class BinaryOperatorMask extends AbstractMask {
         @Override
         public boolean partOfMask(int x, int y, int z) {
             return this.operator.applyAsBoolean(
-                    this.a.partOfMask(x, y, z),
-                    this.b.partOfMask(x, y, z)
+                    partOfMask(a, x, y, z),
+                    partOfMask(b, x, y, z)
             );
+        }
+
+        private static boolean partOfMask(StaticMask mask, int x, int y, int z) {
+            return x < mask.widthX() && y < mask.heightY() && z < mask.lengthZ() && mask.partOfMask(x, y, z);
         }
     }
 }


### PR DESCRIPTION
It still doesn't check `x >= 0 && y >= 0 && z >= 0` because caller has to check that anyway.

Also changes `BinaryOperatorMask` to be as big as the bigger of the two component masks.
<!-- No UwU's or OwO's allowed -->
