### PR TITLE
proguard: get java from gradle runtime before JAVA_HOME

### DIFF
--- a/buildSrc/src/main/java/baritone/gradle/task/ProguardTask.java
+++ b/buildSrc/src/main/java/baritone/gradle/task/ProguardTask.java
@@ -114,6 +114,9 @@ public class ProguardTask extends BaritoneGradleTask {
             ex.printStackTrace();
         }
 
+        path = findJavaByGradleCurrentRuntime();
+        if (path != null) return path;
+
         try {
             path = findJavaByJavaHome();
             if (path != null) return path;
@@ -121,10 +124,6 @@ public class ProguardTask extends BaritoneGradleTask {
             System.err.println("Unable to find java by JAVA_HOME");
             ex.printStackTrace();
         }
-
-
-        path = findJavaByGradleCurrentRuntime();
-        if (path != null) return path;
 
         throw new Exception("Unable to find java to determine ProGuard libraryjars. Please specify forkOptions.executable in javaCompile," +
                 " JAVA_HOME environment variable, or make sure to run Gradle with the correct JDK (a v1.8 only)");


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->

because I can configure the gradle runtime for baritone in intellij