### PR TITLE
Add partial support for multiple #goto targets

### DIFF
--- a/src/api/java/baritone/api/process/IGetToBlockProcess.java
+++ b/src/api/java/baritone/api/process/IGetToBlockProcess.java
@@ -19,17 +19,21 @@ package baritone.api.process;
 
 import baritone.api.utils.BlockOptionalMeta;
 import net.minecraft.block.Block;
+import java.util.List;
+import java.util.Arrays;
 
 /**
  * but it rescans the world every once in a while so it doesn't get fooled by its cache
  */
 public interface IGetToBlockProcess extends IBaritoneProcess {
 
-    void getToBlock(BlockOptionalMeta block);
-
+    default void getToBlock(BlockOptionalMeta block) {
+        getToBlock(Arrays.asList(block));
+    }
     default void getToBlock(Block block) {
         getToBlock(new BlockOptionalMeta(block));
     }
+    void getToBlock(List<BlockOptionalMeta> blocks);
 
     boolean blacklistClosest();
 }

--- a/src/main/java/baritone/command/defaults/GotoCommand.java
+++ b/src/main/java/baritone/command/defaults/GotoCommand.java
@@ -29,6 +29,7 @@ import baritone.api.utils.BetterBlockPos;
 import baritone.api.utils.BlockOptionalMeta;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -51,9 +52,11 @@ public class GotoCommand extends Command {
             baritone.getCustomGoalProcess().setGoalAndPath(goal);
             return;
         }
-        args.requireMax(1);
-        BlockOptionalMeta destination = args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE);
-        baritone.getGetToBlockProcess().getToBlock(destination);
+        List<BlockOptionalMeta> destinations = new ArrayList<BlockOptionalMeta>();
+        while(args.hasAny()) {
+            destinations.add(args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE));
+        }
+        baritone.getGetToBlockProcess().getToBlock(destinations);
     }
 
     @Override


### PR DESCRIPTION
Goto will work with multiple block arguments.
Special actions (ex. right click on arrival) will only trigger if they apply to all arguments.
(enhancement requested in #3599 )
