### PR TITLE
IExecutionControl API class

### DIFF
--- a/src/api/java/baritone/api/IBaritone.java
+++ b/src/api/java/baritone/api/IBaritone.java
@@ -25,6 +25,7 @@ import baritone.api.event.listener.IEventBus;
 import baritone.api.pathing.calc.IPathingControlManager;
 import baritone.api.process.*;
 import baritone.api.selection.ISelectionManager;
+import baritone.api.utils.IExecutionControl;
 import baritone.api.utils.IInputOverrideHandler;
 import baritone.api.utils.IPlayerContext;
 
@@ -138,6 +139,15 @@ public interface IBaritone {
      * @see ICommandManager
      */
     ICommandManager getCommandManager();
+
+    /**
+     * @param name a user-friendly name for the underlying {@link IBaritoneProcess}
+     * @param priority the priority. Default for {@link IBaritoneProcess} instance is {@link IBaritoneProcess#DEFAULT_PRIORITY}.
+     *                 Any Baritone process with a higher priority will not be paused by this {@link IExecutionControl}.
+     * @return A newly created {@link IExecutionControl} instance
+     * @see IExecutionControl
+     */
+    IExecutionControl createExecutionControl(String name, double priority);
 
     /**
      * Open click

--- a/src/api/java/baritone/api/utils/IExecutionControl.java
+++ b/src/api/java/baritone/api/utils/IExecutionControl.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.utils;
+
+/**
+ * Wrapper around a {@link baritone.api.process.IBaritoneProcess} used exclusively for pausing the Baritone.
+ *
+ * @author Crosby
+ */
+public interface IExecutionControl {
+    /**
+     * Tells Baritone to temporarily stop whatever it's doing until you resume.
+     */
+    void pause();
+
+    /**
+     * Resumes Baritone, resuming what it was doing when it was paused.
+     */
+    void resume();
+
+    /**
+     * Whether this instance of {@link IExecutionControl} is currently blocking Baritone from executing lower priority processes.
+     *
+     * @return whether Baritone is currently paused by this {@link IExecutionControl}.
+     */
+    boolean paused();
+
+    /**
+     * Cancels whatever Baritone is currently doing.
+     */
+    void stop();
+}

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -24,6 +24,7 @@ import baritone.api.behavior.IBehavior;
 import baritone.api.event.listener.IEventBus;
 import baritone.api.process.IBaritoneProcess;
 import baritone.api.process.IElytraProcess;
+import baritone.api.utils.IExecutionControl;
 import baritone.api.utils.IPlayerContext;
 import baritone.behavior.*;
 import baritone.cache.WorldProvider;
@@ -31,10 +32,7 @@ import baritone.command.manager.CommandManager;
 import baritone.event.GameEventHandler;
 import baritone.process.*;
 import baritone.selection.SelectionManager;
-import baritone.utils.BlockStateInterface;
-import baritone.utils.GuiClick;
-import baritone.utils.InputOverrideHandler;
-import baritone.utils.PathingControlManager;
+import baritone.utils.*;
 import baritone.utils.player.BaritonePlayerContext;
 import net.minecraft.client.Minecraft;
 
@@ -233,6 +231,11 @@ public class Baritone implements IBaritone {
     @Override
     public CommandManager getCommandManager() {
         return this.commandManager;
+    }
+
+    @Override
+    public IExecutionControl createExecutionControl(String name, double priority) {
+        return new ExecutionControl(name, priority, this);
     }
 
     @Override

--- a/src/main/java/baritone/utils/ExecutionControl.java
+++ b/src/main/java/baritone/utils/ExecutionControl.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils;
+
+import baritone.api.IBaritone;
+import baritone.api.process.IBaritoneProcess;
+import baritone.api.process.PathingCommand;
+import baritone.api.process.PathingCommandType;
+import baritone.api.utils.IExecutionControl;
+
+public class ExecutionControl implements IExecutionControl {
+    private final IBaritone baritone;
+    private boolean active;
+
+    public ExecutionControl(String name, double priority, IBaritone baritone) {
+        this.baritone = baritone;
+        baritone.getPathingControlManager().registerProcess(new IBaritoneProcess() {
+            @Override
+            public boolean isActive() {
+                return active;
+            }
+
+            @Override
+            public PathingCommand onTick(boolean calcFailed, boolean isSafeToCancel) {
+                baritone.getInputOverrideHandler().clearAllKeys();
+                return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
+            }
+
+            @Override
+            public boolean isTemporary() {
+                return true;
+            }
+
+            @Override
+            public void onLostControl() {
+            }
+
+            @Override
+            public double priority() {
+                return priority;
+            }
+
+            @Override
+            public String displayName0() {
+                return name;
+            }
+        });
+    }
+
+    @Override
+    public void pause() {
+        active = true;
+    }
+
+    @Override
+    public void resume() {
+        active = false;
+    }
+
+    @Override
+    public boolean paused() {
+        return active;
+    }
+
+    @Override
+    public void stop() {
+        active = false;
+        baritone.getPathingBehavior().cancelEverything();
+    }
+}


### PR DESCRIPTION
- Adds the convenience method `IBaritone.createExecutionControl()` which returns an `IExecutionControl` for creating a Baritone process who's sole purpose is to pause/resume Baritone.
- Replaces the `IBaritoneProcess` in `ExecutionControlCommands` with an `IExecutionControl`, simplifying the class greatly.

The goal being to encourage 3rd party API users to employ proper methods for pausing/resuming Baritone as opposed to using the command system.

Pausing is simplified from:
```java
private static boolean paused = false;

static {
    BaritoneAPI.getProvider().getPrimaryBaritone().getPathingControlManager().registerProcess(new IBaritoneProcess() {
        @Override
        public boolean isActive() {
            return paused;
        }
    
        @Override
        public PathingCommand onTick(boolean b, boolean b1) {
            BaritoneAPI.getProvider().getPrimaryBaritone().getInputOverrideHandler().clearAllKeys();
            return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
        }
    
        @Override
        public boolean isTemporary() {
            return true;
       }

        @Override
        public void onLostControl() {}

        @Override
        public double priority() {
            return 0d;
        }

        @Override
        public String displayName0() {
            return "Pause Controls";
        }
    });
}

public static void pauseBaritone() {
    paused = true;
}
```
to
```java
private static final IExecutionControl EXECUTION_CONTROL = BaritoneAPI.getProvider().getPrimaryBaritone().createExecutionControl("Pause Controls", 0d);

public static void pauseBaritone() {
    EXECUTION_CONTROL.pause();
}
```