### PR TITLE
Fix forge 1.20.1 crash

### DIFF
--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
@@ -26,8 +26,6 @@ import baritone.behavior.LookBehavior;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.player.Abilities;
-import net.minecraft.world.item.ElytraItem;
-import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -112,14 +110,14 @@ public class MixinClientPlayerEntity {
             method = "aiStep",
             at = @At(
                     value = "INVOKE",
-                    target = "net/minecraft/world/item/ElytraItem.isFlyEnabled(Lnet/minecraft/world/item/ItemStack;)Z"
+                    target = "Lnet/minecraft/client/player/LocalPlayer;tryToStartFallFlying()Z"
             )
     )
-    private boolean isFlyEnabled(ItemStack stack) {
-        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
+    private boolean tryToStartFallFlying(final LocalPlayer instance) {
+        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(instance);
         if (baritone != null && baritone.getPathingBehavior().isPathing()) {
             return false;
         }
-        return ElytraItem.isFlyEnabled(stack);
+        return instance.tryToStartFallFlying();
     }
 }


### PR DESCRIPTION
Crash log on game launch:

```log
Caused by: org.spongepowered.asm.mixin.injection.throwables.InjectionError: Critical injection failure: Redirector isFlyEnabled(Lnet/minecraft/world/item/ItemStack;)Z in mixins.baritone.json:MixinClientPlayerEntity failed injection check, (0/1) succeeded. Scanned 1 target(s). Using refmap baritone.refmap.json 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.injection.struct.InjectionInfo.postInject(InjectionInfo.java:468) 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinTargetContext.applyInjections(MixinTargetContext.java:1362) 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyInjections(MixinApplicatorStandard.java:1051) 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyMixin(MixinApplicatorStandard.java:400) 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.apply(MixinApplicatorStandard.java:325) 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.TargetClassContext.apply(TargetClassContext.java:383) 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.TargetClassContext.applyMixins(TargetClassContext.java:365) 	
at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:363) 	... 37 more
```

I am guessing its due to a bug in the old mixin version used by Forge. Fabric has its own mixin fork that fixes many issues like this.