### PR TITLE
Adds git to the Dockerfile apt install (Windows build functionality)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt update -y
 
 RUN apt install \
           openjdk-17-jdk \
+	  git \
           --assume-yes
 
 COPY . /code


### PR DESCRIPTION
I saw in setup.md "(if you have docker on Windows, I'd be grateful if you could let me know if it works there too)".  So I went to build it on Windows.

I use Windows Subsystem for Linux, which is mostly Ubuntu but not really (there's no init).  But Docker Desktop has an integration for WSL2.

For me, gradle wouldn't build the image without forcing git to install in the container.  I'll attach screenshots to the pull request.  It just looks like whatever ubuntu:focal my docker system grabbed doesn't have git installed by default.

Anyway, this fixes it, and shouldn't screw anything even if git is installed by default.  I tested it on my M1 Mac pro and it still works fine with this change.

And you can (somewhat) say building works on Windows, or at least WSL2.

1.19.4 trying to build:
![1 19 4](https://github.com/cabaletta/baritone/assets/6527846/0dc22d48-6a90-4d04-8001-94973db063bf)

this branch building:
![mybranch](https://github.com/cabaletta/baritone/assets/6527846/95bb79c7-e1b5-45c4-8eab-81b5eff6b111)

Docker desktop on Windows showing the image:
![image-on-win](https://github.com/cabaletta/baritone/assets/6527846/65b3a4ef-102c-446e-ab66-fba311486e9b)


<!-- No UwU's or OwO's allowed -->
