### PR TITLE
Improve version detection

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -28,7 +28,7 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle
-      run: ./gradlew build -Pmod_version="$(git describe --always --tags | cut -c2-)"
+      run: ./gradlew build -Pmod_version="$(git describe --always --tags --first-parent | cut -c2-)"
 
     - name: Archive Artifacts
       uses: actions/upload-artifact@v3

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
     apply plugin: "maven-publish"
 
     archivesBaseName = rootProject.archives_base_name
-    def vers = 'git describe --always --tags --dirty'.execute().text.trim()
+    def vers = 'git describe --always --tags --first-parent --dirty'.execute().text.trim()
     if (!vers.startsWith("v")) {
         println "git doesn't appear to be installed!"
         println "using version number: " + rootProject.mod_version

--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,18 @@ allprojects {
     apply plugin: "maven-publish"
 
     archivesBaseName = rootProject.archives_base_name
-    def vers = 'git describe --always --tags --first-parent --dirty'.execute().text.trim()
+    def vers = ""
+    try {
+        vers = 'git describe --always --tags --first-parent --dirty'.execute().text.trim()
+    } catch (Exception e) {
+        println "Version detection failed: " + e
+    }
     if (!vers.startsWith("v")) {
-        println "git doesn't appear to be installed!"
         println "using version number: " + rootProject.mod_version
         version = rootProject.mod_version
     } else {
         version = vers.substring(1)
+        println "Detected version " + version
     }
     group = rootProject.maven_group
 


### PR DESCRIPTION
1. No longer uses tags from merged-in branches. E.g. the head commit of this pr is "v1.9.2-22-g9accb2bfb" instead of "v1.2.19-572-g9accb2bfb". (Note: CI builds use "v1.9.3-something" because CI runs on a temporary merge commit)
2. No longer crashes if git is not installed.
<!-- No UwU's or OwO's allowed -->
