### PR TITLE
Fix nether-pathfinder version in subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ allprojects {
         // The following line declares the yarn mappings you may select this one as well.
         // mappings "net.fabricmc:yarn:1.17.1+build.32:v2"
         //launchImplementation('dev.babbaj:nether-pathfinder:1.3.0')
-        implementation 'dev.babbaj:nether-pathfinder:1.4.1'
+        implementation "dev.babbaj:nether-pathfinder:${nether_pathfinder_version}"
     }
 
     unimined.minecraft(sourceSets.main, true) {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         common sourceSet.output
         shadowCommon sourceSet.output
     }
-    include 'dev.babbaj:nether-pathfinder:1.3.0'
+    include "dev.babbaj:nether-pathfinder:${nether_pathfinder_version}"
 }
 
 processResources {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         common sourceSet.output
         shadowCommon sourceSet.output
     }
-    shadowCommon 'dev.babbaj:nether-pathfinder:1.3.0'
+    shadowCommon "dev.babbaj:nether-pathfinder:${nether_pathfinder_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ mod_version=1.9.3
 maven_group=baritone
 archives_base_name=baritone
 
+nether_pathfinder_version=1.4.1
+
 minecraft_version=1.19.4
 forge_version=45.0.43
 fabric_version=0.14.11


### PR DESCRIPTION
Looks like a1ac87f80dec9f5febf14b312373fd35a8e061e9 is the first failing commit, but that's just me looking at GitHub commit logs because I didn't want to wait for the build 5 minutes for every commit git bisect decides to check.

Probably fixes  #4215
<!-- No UwU's or OwO's allowed -->
