### PR TITLE
Block break delay setting

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -385,6 +385,13 @@ public final class Settings {
      */
     public final Setting<Float> blockReachDistance = new Setting<>(4.5f);
 
+
+    /**
+     * Delay between breaking a block and starting to break the next block. The vanilla delay is 6 ticks.
+     * Baritone waits an additional 2 ticks on top of this setting value.
+     */
+    public final Setting<Integer> blockBreakDelay = new Setting<>(4);
+
     /**
      * How many degrees to randomize the pitch and yaw every tick. Set to 0 to disable
      */

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -385,12 +385,11 @@ public final class Settings {
      */
     public final Setting<Float> blockReachDistance = new Setting<>(4.5f);
 
-
     /**
-     * Delay between breaking a block and starting to break the next block. The vanilla delay is 6 ticks.
-     * Baritone waits an additional 2 ticks on top of this setting value.
+     * How many ticks between breaking a block and starting to break the next block. Default in game is 6 ticks.
+     * Values under 2 will be clamped.
      */
-    public final Setting<Integer> blockBreakDelay = new Setting<>(4);
+    public final Setting<Integer> blockBreakSpeed = new Setting<>(6);
 
     /**
      * How many degrees to randomize the pitch and yaw every tick. Set to 0 to disable

--- a/src/main/java/baritone/utils/BlockBreakHelper.java
+++ b/src/main/java/baritone/utils/BlockBreakHelper.java
@@ -17,6 +17,7 @@
 
 package baritone.utils;
 
+import baritone.api.BaritoneAPI;
 import baritone.api.utils.IPlayerContext;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.phys.BlockHitResult;
@@ -30,6 +31,7 @@ public final class BlockBreakHelper {
 
     private final IPlayerContext ctx;
     private boolean didBreakLastTick;
+    private int breakDelay = 0;
 
     BlockBreakHelper(IPlayerContext ctx) {
         this.ctx = ctx;
@@ -48,6 +50,11 @@ public final class BlockBreakHelper {
     }
 
     public void tick(boolean isLeftClick) {
+        if (breakDelay > 0) {
+            breakDelay--;
+            return;
+        }
+
         HitResult trace = ctx.objectMouseOver();
         boolean isBlockTrace = trace != null && trace.getType() == HitResult.Type.BLOCK;
 
@@ -68,6 +75,7 @@ public final class BlockBreakHelper {
             didBreakLastTick = true;
         } else if (didBreakLastTick) {
             stopBreakingBlock();
+            breakDelay = BaritoneAPI.getSettings().blockBreakDelay.value;
             didBreakLastTick = false;
         }
     }

--- a/src/main/java/baritone/utils/BlockBreakHelper.java
+++ b/src/main/java/baritone/utils/BlockBreakHelper.java
@@ -28,10 +28,12 @@ import net.minecraft.world.phys.HitResult;
  * @since 8/25/2018
  */
 public final class BlockBreakHelper {
+    // base ticks between block breaks caused by tick logic
+    private static final int BASE_BREAK_DELAY = 2;
 
     private final IPlayerContext ctx;
     private boolean didBreakLastTick;
-    private int breakDelay = 0;
+    private int breakDelayTimer = 0;
 
     BlockBreakHelper(IPlayerContext ctx) {
         this.ctx = ctx;
@@ -50,11 +52,10 @@ public final class BlockBreakHelper {
     }
 
     public void tick(boolean isLeftClick) {
-        if (breakDelay > 0) {
-            breakDelay--;
+        if (breakDelayTimer > 0) {
+            breakDelayTimer--;
             return;
         }
-
         HitResult trace = ctx.objectMouseOver();
         boolean isBlockTrace = trace != null && trace.getType() == HitResult.Type.BLOCK;
 
@@ -75,7 +76,7 @@ public final class BlockBreakHelper {
             didBreakLastTick = true;
         } else if (didBreakLastTick) {
             stopBreakingBlock();
-            breakDelay = BaritoneAPI.getSettings().blockBreakDelay.value;
+            breakDelayTimer = BaritoneAPI.getSettings().blockBreakSpeed.value - BASE_BREAK_DELAY;
             didBreakLastTick = false;
         }
     }


### PR DESCRIPTION
Fixes baritone flagging [FastBreak](https://github.com/GrimAnticheat/Grim/blob/2.0/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java#L80-L92), causing it to get stuck in an endless loop sending stop break packets.

Due to how baritone calls start break slightly different (more direct) from vanilla, there is only 2 ticks from stop break to start break instead of vanilla's 6 ticks. 