### PR TITLE
align rightClickSpeed setting with actual delay

### DIFF
--- a/src/main/java/baritone/utils/BlockPlaceHelper.java
+++ b/src/main/java/baritone/utils/BlockPlaceHelper.java
@@ -25,6 +25,8 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 
 public class BlockPlaceHelper {
+    // base ticks between places caused by tick logic
+    private static final int BASE_PLACE_DELAY = 1;
 
     private final IPlayerContext ctx;
     private int rightClickTimer;
@@ -42,7 +44,7 @@ public class BlockPlaceHelper {
         if (!rightClickRequested || ctx.player().isHandsBusy() || mouseOver == null || mouseOver.getType() != HitResult.Type.BLOCK) {
             return;
         }
-        rightClickTimer = Baritone.settings().rightClickSpeed.value;
+        rightClickTimer = Baritone.settings().rightClickSpeed.value - BASE_PLACE_DELAY;
         for (InteractionHand hand : InteractionHand.values()) {
             if (ctx.playerController().processRightClickBlock(ctx.player(), ctx.world(), hand, (BlockHitResult) mouseOver) == InteractionResult.SUCCESS) {
                 ctx.player().swing(hand);


### PR DESCRIPTION
Aligns ticks between place packets with the setting value. The default rightClickSpeed value of 4 ticks is the correct vanilla number as tested.

referenced in: https://github.com/cabaletta/baritone/pull/4291#issuecomment-1987408744
