### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -124,7 +124,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             @Override
             public boolean partOfMask(int x, int y, int z, BlockState current) {
                 // partOfMask is only called inside the schematic so desiredState is not null
-                return !Baritone.settings().buildSkipBlocks.value.contains(this.desiredState(x, y, z, current, null).getBlock());
+                return !Baritone.settings().buildSkipBlocks.value.contains(this.desiredState(x, y, z, current, Collections.emptyList()).getBlock());
             }
         };
         int x = origin.getX();


### PR DESCRIPTION
Instantly hit a crash when testing on 1.20.4 but somehow managed to miss it multiple times on 1.19.4.
Like, seriously, how did this not crash two weeks ago?
<!-- No UwU's or OwO's allowed -->
