### PR TITLE
don't apply block break delay to insta-breaks

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -387,7 +387,7 @@ public final class Settings {
 
     /**
      * How many ticks between breaking a block and starting to break the next block. Default in game is 6 ticks.
-     * Values under 2 will be clamped.
+     * Values under 1 will be clamped. The delay only applies to non-instant (1-tick) breaks.
      */
     public final Setting<Integer> blockBreakSpeed = new Setting<>(6);
 

--- a/src/api/java/baritone/api/utils/IPlayerController.java
+++ b/src/api/java/baritone/api/utils/IPlayerController.java
@@ -37,7 +37,7 @@ public interface IPlayerController {
 
     void syncHeldItem();
 
-    boolean hasBrokenBlock();
+    boolean isDestroyingBlock();
 
     boolean onPlayerDamageBlock(BlockPos pos, Direction side);
 
@@ -53,7 +53,9 @@ public interface IPlayerController {
 
     boolean clickBlock(BlockPos loc, Direction face);
 
-    void setHittingBlock(boolean hittingBlock);
+    void setDestroyingBlock(boolean hittingBlock);
+
+    void setDestroyDelay(int destroyDelay);
 
     default double getBlockReachDistance() {
         return this.getGameType().isCreative() ? 5.0F : BaritoneAPI.getSettings().blockReachDistance.value;

--- a/src/api/java/baritone/api/utils/IPlayerController.java
+++ b/src/api/java/baritone/api/utils/IPlayerController.java
@@ -37,7 +37,7 @@ public interface IPlayerController {
 
     void syncHeldItem();
 
-    boolean isDestroyingBlock();
+    boolean hasBrokenBlock();
 
     boolean onPlayerDamageBlock(BlockPos pos, Direction side);
 
@@ -53,9 +53,7 @@ public interface IPlayerController {
 
     boolean clickBlock(BlockPos loc, Direction face);
 
-    void setDestroyingBlock(boolean hittingBlock);
-
-    void setDestroyDelay(int destroyDelay);
+    void setHittingBlock(boolean hittingBlock);
 
     default double getBlockReachDistance() {
         return this.getGameType().isCreative() ? 5.0F : BaritoneAPI.getSettings().blockReachDistance.value;

--- a/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
+++ b/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
@@ -29,13 +29,17 @@ public abstract class MixinPlayerController implements IPlayerControllerMP {
 
     @Accessor("isDestroying")
     @Override
-    public abstract void setIsHittingBlock(boolean isHittingBlock);
+    public abstract void setIsDestroyingBlock(boolean isDestroyingBlock);
 
-    @Accessor("destroyBlockPos")
+    @Accessor("isDestroying")
     @Override
-    public abstract BlockPos getCurrentBlock();
+    public abstract boolean isDestroyingBlock();
 
     @Invoker("ensureHasSentCarriedItem")
     @Override
     public abstract void callSyncCurrentPlayItem();
+
+    @Accessor("destroyDelay")
+    @Override
+    public abstract void setDestroyDelay(int destroyDelay);
 }

--- a/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
+++ b/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
@@ -29,11 +29,15 @@ public abstract class MixinPlayerController implements IPlayerControllerMP {
 
     @Accessor("isDestroying")
     @Override
-    public abstract void setIsDestroyingBlock(boolean isDestroyingBlock);
+    public abstract void setIsHittingBlock(boolean isHittingBlock);
 
     @Accessor("isDestroying")
     @Override
-    public abstract boolean isDestroyingBlock();
+    public abstract boolean isHittingBlock();
+
+    @Accessor("destroyBlockPos")
+    @Override
+    public abstract BlockPos getCurrentBlock();
 
     @Invoker("ensureHasSentCarriedItem")
     @Override

--- a/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
+++ b/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
@@ -17,11 +17,15 @@
 
 package baritone.utils.accessor;
 
+import net.minecraft.core.BlockPos;
+
 public interface IPlayerControllerMP {
 
-    void setIsDestroyingBlock(boolean isDestroyingBlock);
+    void setIsHittingBlock(boolean isHittingBlock);
 
-    boolean isDestroyingBlock();
+    boolean isHittingBlock();
+
+    BlockPos getCurrentBlock();
 
     void callSyncCurrentPlayItem();
 

--- a/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
+++ b/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
@@ -17,13 +17,13 @@
 
 package baritone.utils.accessor;
 
-import net.minecraft.core.BlockPos;
-
 public interface IPlayerControllerMP {
 
-    void setIsHittingBlock(boolean isHittingBlock);
+    void setIsDestroyingBlock(boolean isDestroyingBlock);
 
-    BlockPos getCurrentBlock();
+    boolean isDestroyingBlock();
 
     void callSyncCurrentPlayItem();
+
+    void setDestroyDelay(int destroyDelay);
 }

--- a/src/main/java/baritone/utils/player/BaritonePlayerController.java
+++ b/src/main/java/baritone/utils/player/BaritonePlayerController.java
@@ -53,8 +53,13 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public boolean hasBrokenBlock() {
-        return ((IPlayerControllerMP) mc.gameMode).getCurrentBlock().getY() == -1;
+    public boolean isDestroyingBlock() {
+        return ((IPlayerControllerMP) mc.gameMode).isDestroyingBlock();
+    }
+
+    @Override
+    public void setDestroyDelay(int destroyDelay) {
+        ((IPlayerControllerMP) mc.gameMode).setDestroyDelay(destroyDelay);
     }
 
     @Override
@@ -94,7 +99,7 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public void setHittingBlock(boolean hittingBlock) {
-        ((IPlayerControllerMP) mc.gameMode).setIsHittingBlock(hittingBlock);
+    public void setDestroyingBlock(boolean destroyingBlock) {
+        ((IPlayerControllerMP) mc.gameMode).setIsDestroyingBlock(destroyingBlock);
     }
 }

--- a/src/main/java/baritone/utils/player/BaritonePlayerController.java
+++ b/src/main/java/baritone/utils/player/BaritonePlayerController.java
@@ -20,7 +20,6 @@ package baritone.utils.player;
 import baritone.api.utils.IPlayerController;
 import baritone.utils.accessor.IPlayerControllerMP;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -53,13 +52,8 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public boolean isDestroyingBlock() {
-        return ((IPlayerControllerMP) mc.gameMode).isDestroyingBlock();
-    }
-
-    @Override
-    public void setDestroyDelay(int destroyDelay) {
-        ((IPlayerControllerMP) mc.gameMode).setDestroyDelay(destroyDelay);
+    public boolean hasBrokenBlock() {
+        return !((IPlayerControllerMP) mc.gameMode).isHittingBlock();
     }
 
     @Override
@@ -99,7 +93,7 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public void setDestroyingBlock(boolean destroyingBlock) {
-        ((IPlayerControllerMP) mc.gameMode).setIsDestroyingBlock(destroyingBlock);
+    public void setHittingBlock(boolean hittingBlock) {
+        ((IPlayerControllerMP) mc.gameMode).setIsHittingBlock(hittingBlock);
     }
 }


### PR DESCRIPTION
A block break delay setting was added in https://github.com/cabaletta/baritone/pull/4291

This 6 tick delay is correct - but only for blocks that are broken in 1 + N ticks 

* 1 tick breaks send one START_DESTROY_BLOCK action packet per block which acts as both the start and end of the break. Any following START_DESTROY_BLOCK should not be delayed
* 1 + N tick breaks send a START_DESTROY_BLOCK packet followed by STOP_DESTROY_BLOCK when the break completes. Any following START_DESTROY_BLOCK should not be sent until the delay is completed

I've also updated the logic and method names here to fix some issues and align more with the 1.19+ mojmap names. 

The renames aren't required but imo helps for understanding the vanilla mc methods that are being called. If these need to be kept for backwards compatibility they can be reverted. 
