### PR TITLE
Fix NPE in break time calculation

### DIFF
--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -177,7 +177,13 @@ public class ToolSet {
      * @return how long it would take in ticks
      */
     public static double calculateSpeedVsBlock(ItemStack item, BlockState state) {
-        float hardness = state.getDestroySpeed(null, null);
+        float hardness;
+        try {
+            hardness = state.getDestroySpeed(null, null);
+        } catch (NullPointerException npe) {
+            // can't easily determine the hardness so treat it as unbreakable
+            return -1;
+        }
         if (hardness < 0) {
             return -1;
         }


### PR DESCRIPTION
Basically c&p from #4037 
Slight catch with this solution: It is easy to disallow breaking blocks incorrectly determined to be breakable, but if Baritone thinks a block is unbreakable when it really isn't that's a dead end.

Fixes #3945 
<!-- No UwU's or OwO's allowed -->
