### PR TITLE
[WIP] attempt 2 at fixing multiple subregions in litematica schematic printer

### DIFF
--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -240,6 +240,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                     build(name, schematic2, correctedOrigin);
                 } catch (Exception e) {
                     logDirect("Schematic File could not be loaded.");
+                    e.printStackTrace();
                 }
             } else {
                 logDirect("No schematic currently loaded");

--- a/src/main/java/baritone/utils/schematic/format/defaults/LitematicaSchematic.java
+++ b/src/main/java/baritone/utils/schematic/format/defaults/LitematicaSchematic.java
@@ -59,7 +59,8 @@ public final class LitematicaSchematic extends StaticSchematic {
             this.x = Math.abs(nbt.getCompound("Metadata").getCompound("EnclosingSize").getInt("x"));
             this.z = Math.abs(nbt.getCompound("Metadata").getCompound("EnclosingSize").getInt("z"));
         }
-        this.states = new BlockState[this.x][this.z][this.y];
+        // for a rotation x/z needs to be large enough to hold the other dimension
+        this.states = new BlockState[Math.max(this.x,this.z)][Math.max(this.x,this.z)][this.y];
         fillInSchematic();
     }
 
@@ -158,6 +159,12 @@ public final class LitematicaSchematic extends StaticSchematic {
      */
     private static long[] getBlockStates(CompoundTag nbt, String subReg) {
         return nbt.getCompound("Regions").getCompound(subReg).getLongArray("BlockStates");
+    }
+
+
+    @Override
+    public boolean inSchematic(int x, int y, int z, BlockState currentState) {
+        return getDirect(x, y, z) != null;
     }
 
     /**


### PR DESCRIPTION
This PR makes the following changes

1. adds a stracktrace if baritone fails to load the litematica schematic file
2. overrides the inSchematic method
3. sizes the BlockState array to allow x and z BlockState dimension to be swapped in case of rotation