### PR TITLE
Move `BaritoneTweaker` to its own package

### DIFF
--- a/buildSrc/src/main/java/baritone/gradle/util/Determinizer.java
+++ b/buildSrc/src/main/java/baritone/gradle/util/Determinizer.java
@@ -71,10 +71,10 @@ public class Determinizer {
                     ByteArrayOutputStream cancer = new ByteArrayOutputStream();
                     copy(jarFile.getInputStream(entry), cancer);
                     String manifest = new String(cancer.toByteArray());
-                    if (!manifest.contains("baritone.launch.BaritoneTweaker")) {
+                    if (!manifest.contains("baritone.launch.tweaker.BaritoneTweaker")) {
                         throw new IllegalStateException("unable to replace");
                     }
-                    manifest = manifest.replace("baritone.launch.BaritoneTweaker", "org.spongepowered.asm.launch.MixinTweaker");
+                    manifest = manifest.replace("baritone.launch.tweaker.BaritoneTweaker", "org.spongepowered.asm.launch.MixinTweaker");
                     jos.write(manifest.getBytes());
                 } else {
                     copy(jarFile.getInputStream(entry), jos);

--- a/tweaker/build.gradle
+++ b/tweaker/build.gradle
@@ -26,7 +26,7 @@ plugins {
 unimined.minecraft {
     runs.client = {
         mainClass = "net.minecraft.launchwrapper.Launch"
-        args.addAll(["--tweakClass", "baritone.launch.BaritoneTweaker"])
+        args.addAll(["--tweakClass", "baritone.launch.tweaker.BaritoneTweaker"])
     }
 }
 

--- a/tweaker/src/main/java/baritone/launch/tweaker/BaritoneTweaker.java
+++ b/tweaker/src/main/java/baritone/launch/tweaker/BaritoneTweaker.java
@@ -15,7 +15,7 @@
  * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package baritone.launch;
+package baritone.launch.tweaker;
 
 import io.github.impactdevelopment.simpletweaker.SimpleTweaker;
 import net.minecraft.launchwrapper.Launch;


### PR DESCRIPTION
For some reason launch wrapper doesn't transform anything sharing package with a tweak class so having our tweaker directly in the launch package unintentionally made it skip all out mixins.

<!-- No UwU's or OwO's allowed -->
