### PR TITLE
Merge 1.20.5 into 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,13 @@ allprojects {
     }
     group = rootProject.maven_group
 
-    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = targetCompatibility = JavaVersion.toVersion(project.java_version)
+    
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(sourceCompatibility.majorVersion.toInteger()))
+        }
+    }
 
     repositories {
         maven {
@@ -93,7 +99,7 @@ allprojects {
     tasks.withType(JavaCompile).configureEach {
         it.options.encoding = "UTF-8"
 
-        def targetVersion = 17
+        def targetVersion = project.java_version.toInteger()
         if (JavaVersion.current().isJava9Compatible()) {
             it.options.release = targetVersion
         }

--- a/buildSrc/src/main/java/baritone/gradle/task/BaritoneGradleTask.java
+++ b/buildSrc/src/main/java/baritone/gradle/task/BaritoneGradleTask.java
@@ -36,8 +36,8 @@ import java.nio.file.Paths;
 class BaritoneGradleTask extends DefaultTask {
 
     protected static final String
-            PROGUARD_ZIP                    = "proguard.zip",
-            PROGUARD_JAR                    = "proguard.jar",
+            PROGUARD_ZIP                    = "proguard-%s.zip",
+            PROGUARD_JAR                    = "proguard-%s.jar",
             PROGUARD_CONFIG_TEMPLATE        = "scripts/proguard.pro",
             PROGUARD_CONFIG_DEST            = "template.pro",
             PROGUARD_API_CONFIG             = "api.pro",

--- a/buildSrc/src/main/java/baritone/gradle/util/Determinizer.java
+++ b/buildSrc/src/main/java/baritone/gradle/util/Determinizer.java
@@ -71,10 +71,10 @@ public class Determinizer {
                     ByteArrayOutputStream cancer = new ByteArrayOutputStream();
                     copy(jarFile.getInputStream(entry), cancer);
                     String manifest = new String(cancer.toByteArray());
-                    if (!manifest.contains("baritone.launch.BaritoneTweaker")) {
+                    if (!manifest.contains("baritone.launch.tweaker.BaritoneTweaker")) {
                         throw new IllegalStateException("unable to replace");
                     }
-                    manifest = manifest.replace("baritone.launch.BaritoneTweaker", "org.spongepowered.asm.launch.MixinTweaker");
+                    manifest = manifest.replace("baritone.launch.tweaker.BaritoneTweaker", "org.spongepowered.asm.launch.MixinTweaker");
                     jos.write(manifest.getBytes());
                 } else {
                     copy(jarFile.getInputStream(entry), jos);

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -78,8 +78,7 @@ components.java {
 }
 
 task proguard(type: ProguardTask) {
-    url 'https://github.com/Guardsquare/proguard/releases/download/v7.2.1/proguard-7.2.1.zip'
-    extract 'proguard-7.2.1/lib/proguard.jar'
+    proguardVersion "7.2.1"
     compType "fabric"
 }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -99,8 +99,7 @@ components.java {
 }
 
 task proguard(type: ProguardTask) {
-    url 'https://github.com/Guardsquare/proguard/releases/download/v7.2.1/proguard-7.2.1.zip'
-    extract 'proguard-7.2.1/lib/proguard.jar'
+    proguardVersion "7.2.1"
     compType "forge"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,12 @@ mod_version=1.9.3
 maven_group=baritone
 archives_base_name=baritone
 
+java_version=17
+
 minecraft_version=1.19.4
+
 forge_version=45.0.43
+
 fabric_version=0.14.11
 
 nether_pathfinder_version=1.4.1

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -387,7 +387,7 @@ public final class Settings {
 
     /**
      * How many ticks between breaking a block and starting to break the next block. Default in game is 6 ticks.
-     * Values under 2 will be clamped.
+     * Values under 1 will be clamped. The delay only applies to non-instant (1-tick) breaks.
      */
     public final Setting<Integer> blockBreakSpeed = new Setting<>(6);
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -974,6 +974,11 @@ public final class Settings {
     public final Setting<Boolean> replantNetherWart = new Setting<>(false);
 
     /**
+     * Farming will scan for at most this many blocks.
+     */
+    public final Setting<Integer> farmMaxScanSize = new Setting<>(256);
+
+    /**
      * When the cache scan gives less blocks than the maximum threshold (but still above zero), scan the main world too.
      * <p>
      * Only if you have a beefy CPU and automatically mine blocks that are in cache

--- a/src/api/java/baritone/api/utils/IPlayerController.java
+++ b/src/api/java/baritone/api/utils/IPlayerController.java
@@ -37,7 +37,7 @@ public interface IPlayerController {
 
     void syncHeldItem();
 
-    boolean hasBrokenBlock();
+    boolean isDestroyingBlock();
 
     boolean onPlayerDamageBlock(BlockPos pos, Direction side);
 
@@ -53,7 +53,9 @@ public interface IPlayerController {
 
     boolean clickBlock(BlockPos loc, Direction face);
 
-    void setHittingBlock(boolean hittingBlock);
+    void setDestroyingBlock(boolean hittingBlock);
+
+    void setDestroyDelay(int destroyDelay);
 
     default double getBlockReachDistance() {
         return this.getGameType().isCreative() ? 5.0F : BaritoneAPI.getSettings().blockReachDistance.value;

--- a/src/api/java/baritone/api/utils/IPlayerController.java
+++ b/src/api/java/baritone/api/utils/IPlayerController.java
@@ -37,7 +37,7 @@ public interface IPlayerController {
 
     void syncHeldItem();
 
-    boolean isDestroyingBlock();
+    boolean hasBrokenBlock();
 
     boolean onPlayerDamageBlock(BlockPos pos, Direction side);
 
@@ -53,9 +53,7 @@ public interface IPlayerController {
 
     boolean clickBlock(BlockPos loc, Direction face);
 
-    void setDestroyingBlock(boolean hittingBlock);
-
-    void setDestroyDelay(int destroyDelay);
+    void setHittingBlock(boolean hittingBlock);
 
     default double getBlockReachDistance() {
         return this.getGameType().isCreative() ? 5.0F : BaritoneAPI.getSettings().blockReachDistance.value;

--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -149,7 +149,7 @@ public class SettingsUtil {
             throw new IllegalStateException("Missing " + setting.getValueClass() + " " + setting.getName());
         }
 
-        return io.toString(new ParserContext(setting), value);
+        return io.toString(setting.getType(), value);
     }
 
     public static String settingValueToString(Settings.Setting setting) throws IllegalArgumentException {
@@ -196,7 +196,7 @@ public class SettingsUtil {
         }
         Class intendedType = setting.getValueClass();
         ISettingParser ioMethod = Parser.getParser(setting.getType());
-        Object parsed = ioMethod.parse(new ParserContext(setting), settingValue);
+        Object parsed = ioMethod.parse(setting.getType(), settingValue);
         if (!intendedType.isInstance(parsed)) {
             throw new IllegalStateException(ioMethod + " parser returned incorrect type, expected " + intendedType + " got " + parsed + " which is " + parsed.getClass());
         }
@@ -205,24 +205,11 @@ public class SettingsUtil {
 
     private interface ISettingParser<T> {
 
-        T parse(ParserContext context, String raw);
+        T parse(Type type, String raw);
 
-        String toString(ParserContext context, T value);
+        String toString(Type type, T value);
 
         boolean accepts(Type type);
-    }
-
-    private static class ParserContext {
-
-        private final Settings.Setting<?> setting;
-
-        private ParserContext(Settings.Setting<?> setting) {
-            this.setting = setting;
-        }
-
-        private Settings.Setting<?> getSetting() {
-            return this.setting;
-        }
     }
 
     private enum Parser implements ISettingParser {
@@ -256,21 +243,21 @@ public class SettingsUtil {
         ),
         LIST() {
             @Override
-            public Object parse(ParserContext context, String raw) {
-                Type type = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[0];
-                Parser parser = Parser.getParser(type);
+            public Object parse(Type type, String raw) {
+                Type elementType = ((ParameterizedType) type).getActualTypeArguments()[0];
+                Parser parser = Parser.getParser(elementType);
                 return Stream.of(raw.split(","))
-                        .map(s -> parser.parse(context, s))
+                        .map(s -> parser.parse(elementType, s))
                         .collect(Collectors.toList());
             }
 
             @Override
-            public String toString(ParserContext context, Object value) {
-                Type type = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[0];
-                Parser parser = Parser.getParser(type);
+            public String toString(Type type, Object value) {
+                Type elementType = ((ParameterizedType) type).getActualTypeArguments()[0];
+                Parser parser = Parser.getParser(elementType);
 
                 return ((List<?>) value).stream()
-                        .map(o -> parser.toString(context, o))
+                        .map(o -> parser.toString(elementType, o))
                         .collect(Collectors.joining(","));
             }
 
@@ -281,26 +268,26 @@ public class SettingsUtil {
         },
         MAPPING() {
             @Override
-            public Object parse(ParserContext context, String raw) {
-                Type keyType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[0];
-                Type valueType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[1];
+            public Object parse(Type type, String raw) {
+                Type keyType = ((ParameterizedType) type).getActualTypeArguments()[0];
+                Type valueType = ((ParameterizedType) type).getActualTypeArguments()[1];
                 Parser keyParser = Parser.getParser(keyType);
                 Parser valueParser = Parser.getParser(valueType);
 
                 return Stream.of(raw.split(",(?=[^,]*->)"))
                         .map(s -> s.split("->"))
-                        .collect(Collectors.toMap(s -> keyParser.parse(context, s[0]), s -> valueParser.parse(context, s[1])));
+                        .collect(Collectors.toMap(s -> keyParser.parse(keyType, s[0]), s -> valueParser.parse(valueType, s[1])));
             }
 
             @Override
-            public String toString(ParserContext context, Object value) {
-                Type keyType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[0];
-                Type valueType = ((ParameterizedType) context.getSetting().getType()).getActualTypeArguments()[1];
+            public String toString(Type type, Object value) {
+                Type keyType = ((ParameterizedType) type).getActualTypeArguments()[0];
+                Type valueType = ((ParameterizedType) type).getActualTypeArguments()[1];
                 Parser keyParser = Parser.getParser(keyType);
                 Parser valueParser = Parser.getParser(valueType);
 
                 return ((Map<?, ?>) value).entrySet().stream()
-                        .map(o -> keyParser.toString(context, o.getKey()) + "->" + valueParser.toString(context, o.getValue()))
+                        .map(o -> keyParser.toString(keyType, o.getKey()) + "->" + valueParser.toString(valueType, o.getValue()))
                         .collect(Collectors.joining(","));
             }
 
@@ -331,14 +318,14 @@ public class SettingsUtil {
         }
 
         @Override
-        public Object parse(ParserContext context, String raw) {
+        public Object parse(Type type, String raw) {
             Object parsed = this.parser.apply(raw);
             Objects.requireNonNull(parsed);
             return parsed;
         }
 
         @Override
-        public String toString(ParserContext context, Object value) {
+        public String toString(Type type, Object value) {
             return this.toString.apply(value);
         }
 

--- a/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
+++ b/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
@@ -29,13 +29,17 @@ public abstract class MixinPlayerController implements IPlayerControllerMP {
 
     @Accessor("isDestroying")
     @Override
-    public abstract void setIsHittingBlock(boolean isHittingBlock);
+    public abstract void setIsDestroyingBlock(boolean isDestroyingBlock);
 
-    @Accessor("destroyBlockPos")
+    @Accessor("isDestroying")
     @Override
-    public abstract BlockPos getCurrentBlock();
+    public abstract boolean isDestroyingBlock();
 
     @Invoker("ensureHasSentCarriedItem")
     @Override
     public abstract void callSyncCurrentPlayItem();
+
+    @Accessor("destroyDelay")
+    @Override
+    public abstract void setDestroyDelay(int destroyDelay);
 }

--- a/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
+++ b/src/launch/java/baritone/launch/mixins/MixinPlayerController.java
@@ -29,11 +29,15 @@ public abstract class MixinPlayerController implements IPlayerControllerMP {
 
     @Accessor("isDestroying")
     @Override
-    public abstract void setIsDestroyingBlock(boolean isDestroyingBlock);
+    public abstract void setIsHittingBlock(boolean isHittingBlock);
 
     @Accessor("isDestroying")
     @Override
-    public abstract boolean isDestroyingBlock();
+    public abstract boolean isHittingBlock();
+
+    @Accessor("destroyBlockPos")
+    @Override
+    public abstract BlockPos getCurrentBlock();
 
     @Invoker("ensureHasSentCarriedItem")
     @Override

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -359,6 +359,14 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
                 }
             }
         }
+        if (goalz.isEmpty()) {
+            logDirect("Farm failed");
+            if (Baritone.settings().notificationOnFarmFail.value) {
+                logNotification("Farm failed", true);
+            }
+            onLostControl();
+            return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
+        }
         return new PathingCommand(new GoalComposite(goalz.toArray(new Goal[0])), PathingCommandType.SET_GOAL_AND_PATH);
     }
 

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -191,19 +191,19 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
 
     @Override
     public PathingCommand onTick(boolean calcFailed, boolean isSafeToCancel) {
-        ArrayList<Block> scan = new ArrayList<>();
-        for (Harvest harvest : Harvest.values()) {
-            scan.add(harvest.block);
-        }
-        if (Baritone.settings().replantCrops.value) {
-            scan.add(Blocks.FARMLAND);
-            scan.add(Blocks.JUNGLE_LOG);
-            if (Baritone.settings().replantNetherWart.value) {
-                scan.add(Blocks.SOUL_SAND);
-            }
-        }
-
         if (Baritone.settings().mineGoalUpdateInterval.value != 0 && tickCount++ % Baritone.settings().mineGoalUpdateInterval.value == 0) {
+            ArrayList<Block> scan = new ArrayList<>();
+            for (Harvest harvest : Harvest.values()) {
+                scan.add(harvest.block);
+            }
+            if (Baritone.settings().replantCrops.value) {
+                scan.add(Blocks.FARMLAND);
+                scan.add(Blocks.JUNGLE_LOG);
+                if (Baritone.settings().replantNetherWart.value) {
+                    scan.add(Blocks.SOUL_SAND);
+                }
+            }
+
             Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
         }
         if (locations == null) {

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -204,7 +204,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
                 }
             }
 
-            Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, 256, 10, 10));
+            Baritone.getExecutor().execute(() -> locations = BaritoneAPI.getProvider().getWorldScanner().scanChunkRadius(ctx, scan, Baritone.settings().farmMaxScanSize.value, 10, 10));
         }
         if (locations == null) {
             return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -42,6 +42,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AirBlock;
+import net.minecraft.world.level.block.BambooStalkBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BonemealableBlock;
@@ -95,6 +96,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             Items.NETHER_WART,
             Items.COCOA_BEANS,
             Blocks.SUGAR_CANE.asItem(),
+            Blocks.BAMBOO.asItem(),
             Blocks.CACTUS.asItem()
     );
 
@@ -133,6 +135,15 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             public boolean readyToHarvest(Level world, BlockPos pos, BlockState state) {
                 if (Baritone.settings().replantCrops.value) {
                     return world.getBlockState(pos.below()).getBlock() instanceof SugarCaneBlock;
+                }
+                return true;
+            }
+        },
+        BAMBOO(Blocks.BAMBOO, null) {
+            @Override
+            public boolean readyToHarvest(Level world, BlockPos pos, BlockState state) {
+                if (Baritone.settings().replantCrops.value) {
+                    return world.getBlockState(pos.below()).getBlock() instanceof BambooStalkBlock;
                 }
                 return true;
             }

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -256,7 +256,12 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         }
 
         baritone.getInputOverrideHandler().clearAllKeys();
+        BetterBlockPos playerPos = ctx.playerFeet();
+        double blockReachDistance = ctx.playerController().getBlockReachDistance();
         for (BlockPos pos : toBreak) {
+            if (playerPos.distSqr(pos) > blockReachDistance * blockReachDistance) {
+                continue;
+            }
             Optional<Rotation> rot = RotationUtils.reachable(ctx, pos);
             if (rot.isPresent() && isSafeToCancel) {
                 baritone.getLookBehavior().updateTarget(rot.get(), true);
@@ -270,10 +275,13 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         ArrayList<BlockPos> both = new ArrayList<>(openFarmland);
         both.addAll(openSoulsand);
         for (BlockPos pos : both) {
+            if (playerPos.distSqr(pos) > blockReachDistance * blockReachDistance) {
+                continue;
+            }
             boolean soulsand = openSoulsand.contains(pos);
-            Optional<Rotation> rot = RotationUtils.reachableOffset(ctx, pos, new Vec3(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5), ctx.playerController().getBlockReachDistance(), false);
+            Optional<Rotation> rot = RotationUtils.reachableOffset(ctx, pos, new Vec3(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5), blockReachDistance, false);
             if (rot.isPresent() && isSafeToCancel && baritone.getInventoryBehavior().throwaway(true, soulsand ? this::isNetherWart : this::isPlantable)) {
-                HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), rot.get(), ctx.playerController().getBlockReachDistance());
+                HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), rot.get(), blockReachDistance);
                 if (result instanceof BlockHitResult && ((BlockHitResult) result).getDirection() == Direction.UP) {
                     baritone.getLookBehavior().updateTarget(rot.get(), true);
                     if (ctx.isLookingAt(pos)) {
@@ -284,14 +292,17 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             }
         }
         for (BlockPos pos : openLog) {
+            if (playerPos.distSqr(pos) > blockReachDistance * blockReachDistance) {
+                continue;
+            }
             for (Direction dir : Direction.Plane.HORIZONTAL) {
                 if (!(ctx.world().getBlockState(pos.relative(dir)).getBlock() instanceof AirBlock)) {
                     continue;
                 }
                 Vec3 faceCenter = Vec3.atCenterOf(pos).add(Vec3.atLowerCornerOf(dir.getNormal()).scale(0.5));
-                Optional<Rotation> rot = RotationUtils.reachableOffset(ctx, pos, faceCenter, ctx.playerController().getBlockReachDistance(), false);
+                Optional<Rotation> rot = RotationUtils.reachableOffset(ctx, pos, faceCenter, blockReachDistance, false);
                 if (rot.isPresent() && isSafeToCancel && baritone.getInventoryBehavior().throwaway(true, this::isCocoa)) {
-                    HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), rot.get(), ctx.playerController().getBlockReachDistance());
+                    HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), rot.get(), blockReachDistance);
                     if (result instanceof BlockHitResult && ((BlockHitResult) result).getDirection() == dir) {
                         baritone.getLookBehavior().updateTarget(rot.get(), true);
                         if (ctx.isLookingAt(pos)) {
@@ -303,6 +314,9 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             }
         }
         for (BlockPos pos : bonemealable) {
+            if (playerPos.distSqr(pos) > blockReachDistance * blockReachDistance) {
+                continue;
+            }
             Optional<Rotation> rot = RotationUtils.reachable(ctx, pos);
             if (rot.isPresent() && isSafeToCancel && baritone.getInventoryBehavior().throwaway(true, this::isBoneMeal)) {
                 baritone.getLookBehavior().updateTarget(rot.get(), true);

--- a/src/main/java/baritone/utils/GuiClick.java
+++ b/src/main/java/baritone/utils/GuiClick.java
@@ -73,13 +73,11 @@ public class GuiClick extends Screen implements Helper {
         Vec3 far = toWorld(mx, my, 1); // "Use 0.945 that's what stack overflow says" - leijurv
 
         if (near != null && far != null) {
-            ///
             Vec3 viewerPos = new Vec3(PathRenderer.posX(), PathRenderer.posY(), PathRenderer.posZ());
             LocalPlayer player = BaritoneAPI.getProvider().getPrimaryBaritone().getPlayerContext().player();
             HitResult result = player.level.clip(new ClipContext(near.add(viewerPos), far.add(viewerPos), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player));
             if (result != null && result.getType() == HitResult.Type.BLOCK) {
                 currentMouseOver = ((BlockHitResult) result).getBlockPos();
-                System.out.println("currentMouseOver = " + currentMouseOver);
             }
         }
     }

--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -177,7 +177,13 @@ public class ToolSet {
      * @return how long it would take in ticks
      */
     public static double calculateSpeedVsBlock(ItemStack item, BlockState state) {
-        float hardness = state.getDestroySpeed(null, null);
+        float hardness;
+        try {
+            hardness = state.getDestroySpeed(null, null);
+        } catch (NullPointerException npe) {
+            // can't easily determine the hardness so treat it as unbreakable
+            return -1;
+        }
         if (hardness < 0) {
             return -1;
         }

--- a/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
+++ b/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
@@ -17,11 +17,15 @@
 
 package baritone.utils.accessor;
 
+import net.minecraft.core.BlockPos;
+
 public interface IPlayerControllerMP {
 
-    void setIsDestroyingBlock(boolean isDestroyingBlock);
+    void setIsHittingBlock(boolean isHittingBlock);
 
-    boolean isDestroyingBlock();
+    boolean isHittingBlock();
+
+    BlockPos getCurrentBlock();
 
     void callSyncCurrentPlayItem();
 

--- a/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
+++ b/src/main/java/baritone/utils/accessor/IPlayerControllerMP.java
@@ -17,13 +17,13 @@
 
 package baritone.utils.accessor;
 
-import net.minecraft.core.BlockPos;
-
 public interface IPlayerControllerMP {
 
-    void setIsHittingBlock(boolean isHittingBlock);
+    void setIsDestroyingBlock(boolean isDestroyingBlock);
 
-    BlockPos getCurrentBlock();
+    boolean isDestroyingBlock();
 
     void callSyncCurrentPlayItem();
+
+    void setDestroyDelay(int destroyDelay);
 }

--- a/src/main/java/baritone/utils/player/BaritonePlayerController.java
+++ b/src/main/java/baritone/utils/player/BaritonePlayerController.java
@@ -53,8 +53,13 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public boolean hasBrokenBlock() {
-        return ((IPlayerControllerMP) mc.gameMode).getCurrentBlock().getY() == -1;
+    public boolean isDestroyingBlock() {
+        return ((IPlayerControllerMP) mc.gameMode).isDestroyingBlock();
+    }
+
+    @Override
+    public void setDestroyDelay(int destroyDelay) {
+        ((IPlayerControllerMP) mc.gameMode).setDestroyDelay(destroyDelay);
     }
 
     @Override
@@ -94,7 +99,7 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public void setHittingBlock(boolean hittingBlock) {
-        ((IPlayerControllerMP) mc.gameMode).setIsHittingBlock(hittingBlock);
+    public void setDestroyingBlock(boolean destroyingBlock) {
+        ((IPlayerControllerMP) mc.gameMode).setIsDestroyingBlock(destroyingBlock);
     }
 }

--- a/src/main/java/baritone/utils/player/BaritonePlayerController.java
+++ b/src/main/java/baritone/utils/player/BaritonePlayerController.java
@@ -20,7 +20,6 @@ package baritone.utils.player;
 import baritone.api.utils.IPlayerController;
 import baritone.utils.accessor.IPlayerControllerMP;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -53,13 +52,8 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public boolean isDestroyingBlock() {
-        return ((IPlayerControllerMP) mc.gameMode).isDestroyingBlock();
-    }
-
-    @Override
-    public void setDestroyDelay(int destroyDelay) {
-        ((IPlayerControllerMP) mc.gameMode).setDestroyDelay(destroyDelay);
+    public boolean hasBrokenBlock() {
+        return !((IPlayerControllerMP) mc.gameMode).isHittingBlock();
     }
 
     @Override
@@ -99,7 +93,7 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public void setDestroyingBlock(boolean destroyingBlock) {
-        ((IPlayerControllerMP) mc.gameMode).setIsDestroyingBlock(destroyingBlock);
+    public void setHittingBlock(boolean hittingBlock) {
+        ((IPlayerControllerMP) mc.gameMode).setIsHittingBlock(hittingBlock);
     }
 }

--- a/tweaker/build.gradle
+++ b/tweaker/build.gradle
@@ -26,7 +26,7 @@ plugins {
 unimined.minecraft {
     runs.client = {
         mainClass = "net.minecraft.launchwrapper.Launch"
-        args.addAll(["--tweakClass", "baritone.launch.BaritoneTweaker"])
+        args.addAll(["--tweakClass", "baritone.launch.tweaker.BaritoneTweaker"])
     }
 }
 

--- a/tweaker/build.gradle
+++ b/tweaker/build.gradle
@@ -95,8 +95,7 @@ jar {
 }
 
 task proguard(type: ProguardTask) {
-    url 'https://github.com/Guardsquare/proguard/releases/download/v7.2.1/proguard-7.2.1.zip'
-    extract 'proguard-7.2.1/lib/proguard.jar'
+    proguardVersion "7.2.1"
 }
 
 task createDist(type: CreateDistTask, dependsOn: proguard)

--- a/tweaker/src/main/java/baritone/launch/tweaker/BaritoneTweaker.java
+++ b/tweaker/src/main/java/baritone/launch/tweaker/BaritoneTweaker.java
@@ -15,7 +15,7 @@
  * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package baritone.launch;
+package baritone.launch.tweaker;
 
 import io.github.impactdevelopment.simpletweaker.SimpleTweaker;
 import net.minecraft.launchwrapper.Launch;


### PR DESCRIPTION
Includes
* Fix crash when calculating breaking time for some blocks (#4333)
* Fix block break delay mistakenly applying to insta breaks (#4320)
* Fix using the wrong parser for nested generic setting types (#4324)
* Fix printing debug output every frame the click gui is open (#4374)
* Make scan limit for farming configurable (#4385)
* Cleanup build process (#4395)
* Make bamboo farmable (#4430)
* Fix tweak class sharing package with unrelated classes/packages (#4432)
<!-- No UwU's or OwO's allowed -->
