### PR TITLE
1.20.1 Use pose system for calculating the height of crouching instead of hardcoded values

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -51,6 +51,8 @@ import java.util.function.Consumer;
  */
 public final class Settings {
 
+    public final Setting<Double> expectedEyeHeight = new Setting<>(1.27D);
+
     /**
      * Allow Baritone to break blocks
      */

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -51,8 +51,6 @@ import java.util.function.Consumer;
  */
 public final class Settings {
 
-    public final Setting<Double> expectedEyeHeight = new Setting<>(1.27D);
-
     /**
      * Allow Baritone to break blocks
      */

--- a/src/api/java/baritone/api/utils/IPlayerContext.java
+++ b/src/api/java/baritone/api/utils/IPlayerContext.java
@@ -99,16 +99,6 @@ public interface IPlayerContext {
         return new Rotation(player().getYRot(), player().getXRot());
     }
 
-    static double eyeHeight(boolean ifSneaking) {
-        //final double baseHeight = 1.62;
-        final double baseHeight = 0.65;
-        //sneaking is 24.2215% lower than standing
-        return ifSneaking ? baseHeight * 0.757785 : baseHeight;
-        //return ifSneaking ? Baritone.settings().expectedEyeHeight.value * 0.757785 : Baritone.settings().expectedEyeHeight.value;
-        //return player().getEyeHeight();
-        //return ifSneaking ? 1.27 : 1.62;
-    }
-
     /**
      * Returns the block that the crosshair is currently placed over. Updated once per tick.
      *

--- a/src/api/java/baritone/api/utils/IPlayerContext.java
+++ b/src/api/java/baritone/api/utils/IPlayerContext.java
@@ -17,7 +17,6 @@
 
 package baritone.api.utils;
 
-import baritone.Baritone;
 import baritone.api.cache.IWorldData;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -101,8 +100,11 @@ public interface IPlayerContext {
     }
 
     static double eyeHeight(boolean ifSneaking) {
+        //final double baseHeight = 1.62;
+        final double baseHeight = 0.65;
         //sneaking is 24.2215% lower than standing
-        return ifSneaking ? Baritone.settings().expectedEyeHeight.value * 0.757785 : Baritone.settings().expectedEyeHeight.value;
+        return ifSneaking ? baseHeight * 0.757785 : baseHeight;
+        //return ifSneaking ? Baritone.settings().expectedEyeHeight.value * 0.757785 : Baritone.settings().expectedEyeHeight.value;
         //return player().getEyeHeight();
         //return ifSneaking ? 1.27 : 1.62;
     }

--- a/src/api/java/baritone/api/utils/IPlayerContext.java
+++ b/src/api/java/baritone/api/utils/IPlayerContext.java
@@ -100,6 +100,18 @@ public interface IPlayerContext {
     }
 
     /**
+     * Returns the player's eye height, taking into account whether or not the player is sneaking.
+     *
+     * @param ifSneaking Whether or not the player is sneaking
+     * @return The player's eye height
+     * @deprecated Use entity.getEyeHeight(Pose.CROUCHING) instead
+     */
+    @Deprecated
+    static double eyeHeight(boolean ifSneaking) {
+        return ifSneaking ? 1.27 : 1.62;
+    }
+
+    /**
      * Returns the block that the crosshair is currently placed over. Updated once per tick.
      *
      * @return The position of the highlighted block

--- a/src/api/java/baritone/api/utils/IPlayerContext.java
+++ b/src/api/java/baritone/api/utils/IPlayerContext.java
@@ -99,8 +99,9 @@ public interface IPlayerContext {
         return new Rotation(player().getYRot(), player().getXRot());
     }
 
-    static double eyeHeight(boolean ifSneaking) {
-        return ifSneaking ? 1.27 : 1.62;
+    default double eyeHeight(boolean ifSneaking) {
+        return player().getEyeHeight();
+        //return ifSneaking ? 1.27 : 1.62;
     }
 
     /**

--- a/src/api/java/baritone/api/utils/IPlayerContext.java
+++ b/src/api/java/baritone/api/utils/IPlayerContext.java
@@ -17,6 +17,7 @@
 
 package baritone.api.utils;
 
+import baritone.Baritone;
 import baritone.api.cache.IWorldData;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -99,8 +100,10 @@ public interface IPlayerContext {
         return new Rotation(player().getYRot(), player().getXRot());
     }
 
-    default double eyeHeight(boolean ifSneaking) {
-        return player().getEyeHeight();
+    static double eyeHeight(boolean ifSneaking) {
+        //sneaking is 24.2215% lower than standing
+        return ifSneaking ? Baritone.settings().expectedEyeHeight.value * 0.757785 : Baritone.settings().expectedEyeHeight.value;
+        //return player().getEyeHeight();
         //return ifSneaking ? 1.27 : 1.62;
     }
 

--- a/src/api/java/baritone/api/utils/RayTraceUtils.java
+++ b/src/api/java/baritone/api/utils/RayTraceUtils.java
@@ -62,6 +62,6 @@ public final class RayTraceUtils {
     }
 
     public static Vec3 inferSneakingEyePosition(Entity entity) {
-        return new Vec3(entity.getX(), entity.getY() + IPlayerContext.eyeHeight(true), entity.getZ());
+        return new Vec3(entity.getX(), entity.getY() + (entity.getEyePosition(1.0F) * 0.757785), entity.getZ());
     }
 }

--- a/src/api/java/baritone/api/utils/RayTraceUtils.java
+++ b/src/api/java/baritone/api/utils/RayTraceUtils.java
@@ -18,6 +18,7 @@
 package baritone.api.utils;
 
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
@@ -62,6 +63,6 @@ public final class RayTraceUtils {
     }
 
     public static Vec3 inferSneakingEyePosition(Entity entity) {
-        return new Vec3(entity.getX(), entity.getY() + (entity.getEyeHeight() * 0.757785), entity.getZ());
+        return new Vec3(entity.getX(), entity.getY() + (entity.getEyeHeight(Pose.CROUCHING)), entity.getZ());
     }
 }

--- a/src/api/java/baritone/api/utils/RayTraceUtils.java
+++ b/src/api/java/baritone/api/utils/RayTraceUtils.java
@@ -62,6 +62,6 @@ public final class RayTraceUtils {
     }
 
     public static Vec3 inferSneakingEyePosition(Entity entity) {
-        return new Vec3(entity.getX(), entity.getY() + (entity.getEyePosition(1.0F) * 0.757785), entity.getZ());
+        return new Vec3(entity.getX(), entity.getY() + (entity.getEyeHeight() * 0.757785), entity.getZ());
     }
 }


### PR DESCRIPTION
instead of using hardcoded crouching values, just use the built in method for geting a entitys eye height with a specific pose. Should close #4484 from personal testing

closes #4484 