### PR TITLE
Make every Vec3i use BetterBlockPos hash

### DIFF
--- a/src/api/java/baritone/api/utils/BetterBlockPos.java
+++ b/src/api/java/baritone/api/utils/BetterBlockPos.java
@@ -78,11 +78,6 @@ public final class BetterBlockPos extends BlockPos {
         return new BetterBlockPos(pos);
     }
 
-    @Override
-    public int hashCode() {
-        return (int) longHash(x, y, z);
-    }
-
     public static long longHash(BetterBlockPos pos) {
         return longHash(pos.x, pos.y, pos.z);
     }

--- a/src/launch/java/baritone/launch/mixins/MixinVec3i.java
+++ b/src/launch/java/baritone/launch/mixins/MixinVec3i.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+package baritone.launch.mixins;
+
+import baritone.api.utils.BetterBlockPos;
+import net.minecraft.core.Vec3i;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(Vec3i.class)
+public class MixinVec3i {
+
+    /**
+     * @author Babbaj
+     * @reason overriding hashCode with different behavior violates the general contract of hashCode.
+     * 2 BlockPos objects that are equal but give different hashCodes trolls hashmaps and causes duplicate entries.
+     */
+    @Overwrite
+    public int hashCode() {
+        Vec3i vec = (Vec3i) (Object) this;
+        return (int) BetterBlockPos.longHash(vec.getX(), vec.getY(), vec.getZ());
+    }
+}

--- a/src/launch/resources/mixins.baritone.json
+++ b/src/launch/resources/mixins.baritone.json
@@ -25,6 +25,7 @@
     "MixinPalettedContainer$Data",
     "MixinPlayerController",
     "MixinScreen",
-    "MixinWorldRenderer"
+    "MixinWorldRenderer",
+    "MixinVec3i"
   ]
 }


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->

BetterBlockPos returning a different hashCode than the superclasses is a massively stupid correctness problem and is currently causing my game to crash.
In theory this might also improve performance a bit if it allows the jvm to devirtualize calls to hashCode.