### PR TITLE
Interpolated Looking implementation

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -757,20 +757,40 @@ public final class Settings {
      */
     public final Setting<Boolean> elytraFreeLook = new Setting<>(true);
 
-    /**
-     * Forces the client-sided yaw rotation to an average of the last {@link #smoothLookTicks} of server-sided rotations.
-     */
-    public final Setting<Boolean> smoothLook = new Setting<>(false);
+    ///**
+    // * Forces the client-sided yaw rotation to an average of the last {@link #smoothLookTicks} of server-sided rotations.
+    // */
+    //public final Setting<Boolean> smoothLook = new Setting<>(false);
+    //
+    ///**
+    // * Same as {@link #smoothLook} but for elytra flying.
+    // */
+    //public final Setting<Boolean> elytraSmoothLook = new Setting<>(false);
+    //
+    ///**
+    // * The number of ticks to average across for {@link #smoothLook};
+    // */
+    //public final Setting<Integer> smoothLookTicks = new Setting<>(5);
+
+    // Old implementation settings...
 
     /**
-     * Same as {@link #smoothLook} but for elytra flying.
+     * Forces global player rotation in both axis to follow a "path" from source looking position(rotation) to target, removing jittering when, for instance, mining blocks.
+     * Uses {@link #interpolatedLookLength} to determine the amount of ticks it takes to complete the path
+     * <p>
+     * TODO: It might be better to use some kind of angular speed instead of a fixed duration for all angles.
+     * <p>
+     * it WILL hinder mining speed, but the main goal here is that neither the client nor the server sees the default jittery-ness of baritone
      */
-    public final Setting<Boolean> elytraSmoothLook = new Setting<>(false);
+    public final Setting<Boolean> interpolatedLook = new Setting<>(false);
 
     /**
-     * The number of ticks to average across for {@link #smoothLook};
+     * Controls time it takes to complete an {@link #interpolatedLook} "cycle".
+     * <p>
+     * In ticks.
      */
-    public final Setting<Integer> smoothLookTicks = new Setting<>(5);
+    public final Setting<Integer> interpolatedLookLength = new Setting<>(10);
+
 
     /**
      * When true, the player will remain with its existing look direction as often as possible.

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -793,13 +793,14 @@ public final class Settings {
     /**
      * Interpolates player rotation from the current look direction to the target direction.
      * <p>
-     * This uses {@link #interpolatedLookLength} to determine how many ticks one
-     * interpolation cycle takes.
+     * This uses {@link #interpolatedLookLength} as a maximum angular speed, so larger
+     * turns take more ticks than smaller turns.
      */
     public final Setting<Boolean> interpolatedLook = new Setting<>(false);
 
     /**
-     * Time, in ticks, to complete one {@link #interpolatedLook} cycle.
+     * Maximum angular speed, in degrees per tick, for {@link #interpolatedLook}.
+     * The historical name is retained for config compatibility.
      */
     public final Setting<Integer> interpolatedLookLength = new Setting<>(10);
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -774,20 +774,40 @@ public final class Settings {
      */
     public final Setting<Boolean> elytraFreeLook = new Setting<>(true);
 
-    /**
-     * Forces the client-sided yaw rotation to an average of the last {@link #smoothLookTicks} of server-sided rotations.
-     */
-    public final Setting<Boolean> smoothLook = new Setting<>(false);
+    ///**
+    // * Forces the client-sided yaw rotation to an average of the last {@link #smoothLookTicks} of server-sided rotations.
+    // */
+    //public final Setting<Boolean> smoothLook = new Setting<>(false);
+    //
+    ///**
+    // * Same as {@link #smoothLook} but for elytra flying.
+    // */
+    //public final Setting<Boolean> elytraSmoothLook = new Setting<>(false);
+    //
+    ///**
+    // * The number of ticks to average across for {@link #smoothLook};
+    // */
+    //public final Setting<Integer> smoothLookTicks = new Setting<>(5);
+
+    // Old implementation settings...
 
     /**
-     * Same as {@link #smoothLook} but for elytra flying.
+     * Forces global player rotation in both axis to follow a "path" from source looking position(rotation) to target, removing jittering when, for instance, mining blocks.
+     * Uses {@link #interpolatedLookLength} to determine the amount of ticks it takes to complete the path
+     * <p>
+     * TODO: It might be better to use some kind of angular speed instead of a fixed duration for all angles.
+     * <p>
+     * it WILL hinder mining speed, but the main goal here is that neither the client nor the server sees the default jittery-ness of baritone
      */
-    public final Setting<Boolean> elytraSmoothLook = new Setting<>(false);
+    public final Setting<Boolean> interpolatedLook = new Setting<>(false);
 
     /**
-     * The number of ticks to average across for {@link #smoothLook};
+     * Controls time it takes to complete an {@link #interpolatedLook} "cycle".
+     * <p>
+     * In ticks.
      */
-    public final Setting<Integer> smoothLookTicks = new Setting<>(5);
+    public final Setting<Integer> interpolatedLookLength = new Setting<>(10);
+
 
     /**
      * When true, the player will remain with its existing look direction as often as possible.

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -775,7 +775,8 @@ public final class Settings {
     public final Setting<Boolean> elytraFreeLook = new Setting<>(true);
 
     /**
-     * Forces the client-sided yaw rotation to an average of the last {@link #smoothLookTicks} of server-sided rotations.
+     * Forces the client-sided yaw rotation to an average of the last
+     * {@link #smoothLookTicks} server-sided rotations.
      */
     public final Setting<Boolean> smoothLook = new Setting<>(false);
 
@@ -790,19 +791,15 @@ public final class Settings {
     public final Setting<Integer> smoothLookTicks = new Setting<>(5);
 
     /**
-     * Forces global player rotation in both axis to follow a "path" from source looking position(rotation) to target, removing jittering when, for instance, mining blocks.
-     * Uses {@link #interpolatedLookLength} to determine the amount of ticks it takes to complete the path
+     * Interpolates player rotation from the current look direction to the target direction.
      * <p>
-     * TODO: It might be better to use some kind of angular speed instead of a fixed duration for all angles.
-     * <p>
-     * it WILL hinder mining speed, but the main goal here is that neither the client nor the server sees the default jittery-ness of baritone
+     * This uses {@link #interpolatedLookLength} to determine how many ticks one
+     * interpolation cycle takes.
      */
     public final Setting<Boolean> interpolatedLook = new Setting<>(false);
 
     /**
-     * Controls time it takes to complete an {@link #interpolatedLook} "cycle".
-     * <p>
-     * In ticks.
+     * Time, in ticks, to complete one {@link #interpolatedLook} cycle.
      */
     public final Setting<Integer> interpolatedLookLength = new Setting<>(10);
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -774,22 +774,20 @@ public final class Settings {
      */
     public final Setting<Boolean> elytraFreeLook = new Setting<>(true);
 
-    ///**
-    // * Forces the client-sided yaw rotation to an average of the last {@link #smoothLookTicks} of server-sided rotations.
-    // */
-    //public final Setting<Boolean> smoothLook = new Setting<>(false);
-    //
-    ///**
-    // * Same as {@link #smoothLook} but for elytra flying.
-    // */
-    //public final Setting<Boolean> elytraSmoothLook = new Setting<>(false);
-    //
-    ///**
-    // * The number of ticks to average across for {@link #smoothLook};
-    // */
-    //public final Setting<Integer> smoothLookTicks = new Setting<>(5);
+    /**
+     * Forces the client-sided yaw rotation to an average of the last {@link #smoothLookTicks} of server-sided rotations.
+     */
+    public final Setting<Boolean> smoothLook = new Setting<>(false);
 
-    // Old implementation settings...
+    /**
+     * Same as {@link #smoothLook} but for elytra flying.
+     */
+    public final Setting<Boolean> elytraSmoothLook = new Setting<>(false);
+
+    /**
+     * The number of ticks to average across for {@link #smoothLook};
+     */
+    public final Setting<Integer> smoothLookTicks = new Setting<>(5);
 
     /**
      * Forces global player rotation in both axis to follow a "path" from source looking position(rotation) to target, removing jittering when, for instance, mining blocks.

--- a/src/api/java/baritone/api/behavior/ILookBehavior.java
+++ b/src/api/java/baritone/api/behavior/ILookBehavior.java
@@ -52,6 +52,23 @@ public interface ILookBehavior extends IBehavior {
     }
 
     /**
+     * Updates the current {@link ILookBehavior} target and optionally uses it without aim processing.
+     *
+     * @param rotation             The target rotations
+     * @param blockInteract        Whether the target rotations are needed for a block interaction
+     * @param restartInterpolation Whether active interpolation should restart from its current sample
+     * @param exactRotation        Whether the target rotation should skip aim processing
+     * @see #updateTarget(Rotation, boolean, boolean)
+     */
+    default void updateTarget(
+            Rotation rotation,
+            boolean blockInteract,
+            boolean restartInterpolation,
+            boolean exactRotation) {
+        updateTarget(rotation, blockInteract, restartInterpolation);
+    }
+
+    /**
      * The aim processor instance for this {@link ILookBehavior}, which is responsible for applying additional,
      * deterministic transformations to the target rotation set by {@link #updateTarget}.
      *

--- a/src/api/java/baritone/api/behavior/ILookBehavior.java
+++ b/src/api/java/baritone/api/behavior/ILookBehavior.java
@@ -40,6 +40,18 @@ public interface ILookBehavior extends IBehavior {
     void updateTarget(Rotation rotation, boolean blockInteract);
 
     /**
+     * Updates the current {@link ILookBehavior} target and optionally restarts any active interpolation.
+     *
+     * @param rotation             The target rotations
+     * @param blockInteract        Whether the target rotations are needed for a block interaction
+     * @param restartInterpolation Whether active interpolation should restart from its current sample
+     * @see #updateTarget(Rotation, boolean)
+     */
+    default void updateTarget(Rotation rotation, boolean blockInteract, boolean restartInterpolation) {
+        updateTarget(rotation, blockInteract);
+    }
+
+    /**
      * The aim processor instance for this {@link ILookBehavior}, which is responsible for applying additional,
      * deterministic transformations to the target rotation set by {@link #updateTarget}.
      *

--- a/src/api/java/baritone/api/behavior/ILookBehavior.java
+++ b/src/api/java/baritone/api/behavior/ILookBehavior.java
@@ -40,23 +40,30 @@ public interface ILookBehavior extends IBehavior {
     void updateTarget(Rotation rotation, boolean blockInteract);
 
     /**
-     * Updates the current {@link ILookBehavior} target and optionally restarts any active interpolation.
+     * Updates the current {@link ILookBehavior} target and optionally restarts
+     * any active interpolation.
      *
      * @param rotation             The target rotations
      * @param blockInteract        Whether the target rotations are needed for a block interaction
-     * @param restartInterpolation Whether active interpolation should restart from its current sample
+     * @param restartInterpolation Whether active interpolation should restart
+     *                             from its current sample
      * @see #updateTarget(Rotation, boolean)
      */
-    default void updateTarget(Rotation rotation, boolean blockInteract, boolean restartInterpolation) {
+    default void updateTarget(
+            Rotation rotation,
+            boolean blockInteract,
+            boolean restartInterpolation) {
         updateTarget(rotation, blockInteract);
     }
 
     /**
-     * Updates the current {@link ILookBehavior} target and optionally uses it without aim processing.
+     * Updates the current {@link ILookBehavior} target and optionally uses it
+     * without aim processing.
      *
      * @param rotation             The target rotations
      * @param blockInteract        Whether the target rotations are needed for a block interaction
-     * @param restartInterpolation Whether active interpolation should restart from its current sample
+     * @param restartInterpolation Whether active interpolation should restart
+     *                             from its current sample
      * @param exactRotation        Whether the target rotation should skip aim processing
      * @see #updateTarget(Rotation, boolean, boolean)
      */

--- a/src/api/java/baritone/api/utils/IInputOverrideHandler.java
+++ b/src/api/java/baritone/api/utils/IInputOverrideHandler.java
@@ -19,6 +19,7 @@ package baritone.api.utils;
 
 import baritone.api.behavior.IBehavior;
 import baritone.api.utils.input.Input;
+import net.minecraft.core.BlockPos;
 
 /**
  * @author Brady
@@ -31,4 +32,8 @@ public interface IInputOverrideHandler extends IBehavior {
     void setInputForceState(Input input, boolean forced);
 
     void clearAllKeys();
+
+    default boolean isBreakingBlock(BlockPos pos) {
+        return false;
+    }
 }

--- a/src/api/java/baritone/api/utils/IInputOverrideHandler.java
+++ b/src/api/java/baritone/api/utils/IInputOverrideHandler.java
@@ -39,8 +39,10 @@ public interface IInputOverrideHandler extends IBehavior {
     }
 
     default void setBlockBreakTarget(BlockPos pos) {
+        // Optional hook for handlers that support targeted block breaking.
     }
 
     default void setBlockPlaceTarget(BlockPos pos, Direction side) {
+        // Optional hook for handlers that support targeted block placing.
     }
 }

--- a/src/api/java/baritone/api/utils/IInputOverrideHandler.java
+++ b/src/api/java/baritone/api/utils/IInputOverrideHandler.java
@@ -38,7 +38,9 @@ public interface IInputOverrideHandler extends IBehavior {
         return false;
     }
 
-    default void setBlockBreakTarget(BlockPos pos) {}
+    default void setBlockBreakTarget(BlockPos pos) {
+    }
 
-    default void setBlockPlaceTarget(BlockPos pos, Direction side) {}
+    default void setBlockPlaceTarget(BlockPos pos, Direction side) {
+    }
 }

--- a/src/api/java/baritone/api/utils/IInputOverrideHandler.java
+++ b/src/api/java/baritone/api/utils/IInputOverrideHandler.java
@@ -20,6 +20,7 @@ package baritone.api.utils;
 import baritone.api.behavior.IBehavior;
 import baritone.api.utils.input.Input;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 
 /**
  * @author Brady
@@ -36,4 +37,8 @@ public interface IInputOverrideHandler extends IBehavior {
     default boolean isBreakingBlock(BlockPos pos) {
         return false;
     }
+
+    default void setBlockBreakTarget(BlockPos pos) {}
+
+    default void setBlockPlaceTarget(BlockPos pos, Direction side) {}
 }

--- a/src/api/java/baritone/api/utils/IPlayerContext.java
+++ b/src/api/java/baritone/api/utils/IPlayerContext.java
@@ -22,6 +22,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.SlabBlock;
@@ -116,15 +117,26 @@ public interface IPlayerContext {
      *
      * @return The position of the highlighted block
      */
-    default Optional<BlockPos> getSelectedBlock() {
+    default Optional<BlockHitResult> getSelectedBlockHitResult() {
         HitResult result = objectMouseOver();
         if (result != null && result.getType() == HitResult.Type.BLOCK) {
-            return Optional.of(((BlockHitResult) result).getBlockPos());
+            return Optional.of((BlockHitResult) result);
         }
         return Optional.empty();
     }
 
+    default Optional<BlockPos> getSelectedBlock() {
+        return getSelectedBlockHitResult().map(BlockHitResult::getBlockPos);
+    }
+
     default boolean isLookingAt(BlockPos pos) {
         return getSelectedBlock().equals(Optional.of(pos));
+    }
+
+    default boolean isLookingAt(BlockPos pos, Direction side) {
+        return getSelectedBlockHitResult()
+                .filter(hit -> hit.getBlockPos().equals(pos))
+                .filter(hit -> hit.getDirection() == side)
+                .isPresent();
     }
 }

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -310,6 +310,53 @@ public final class RotationUtils {
         return center.add(new Vec3(radius, radius, radius).multiply(arcDirection));
     }
 
+    public static final class RotationArc {
+
+        private final Rotation startRotation;
+        private final Rotation targetRotation;
+        private final int length;
+        private int stage;
+
+        public RotationArc(Rotation startRotation, Rotation targetRotation, int length) {
+            this.startRotation = startRotation;
+            this.targetRotation = targetRotation;
+            this.length = Math.max(1, length);
+        }
+
+        public Rotation getCurrentRotation() {
+            return this.arcAt(this.stage / (double) this.length);
+        }
+
+        public Rotation advance() {
+            if (this.stage < this.length) {
+                this.stage++;
+            }
+            return this.getCurrentRotation();
+        }
+
+        public boolean isComplete() {
+            return this.stage >= this.length;
+        }
+
+        public Rotation arcAt(double t) {
+            if (t <= 0) {
+                return this.startRotation;
+            }
+            if (t >= 1) {
+                return this.targetRotation;
+            }
+            final Vec3 source = calcLookDirectionFromRotation(this.startRotation);
+            final Vec3 target = calcLookDirectionFromRotation(this.targetRotation);
+            if (source.distanceToSqr(target) < 1.0E-8) {
+                return this.targetRotation;
+            }
+            return calcRotationFromVec3d(
+                    Vec3.ZERO,
+                    alerp(source, target, Vec3.ZERO, t),
+                    new Rotation(0, 0));
+        }
+    }
+
     @Deprecated
     public static Optional<Rotation> reachable(LocalPlayer entity, BlockPos pos, double blockReachDistance) {
         return reachable(entity, pos, blockReachDistance, false);

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -19,6 +19,7 @@ package baritone.api.utils;
 
 import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
+import baritone.api.utils.VecUtils;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -264,6 +265,76 @@ public final class RotationUtils {
     public static Optional<Rotation> reachableCenter(IPlayerContext ctx, BlockPos pos, double blockReachDistance, boolean wouldSneak) {
         return reachableOffset(ctx, pos, VecUtils.calculateBlockCenter(ctx.world(), pos), blockReachDistance, wouldSneak);
     }
+
+    /**
+     * Arc interpolator, creates a radius with a center as near as possible from "origin" which touches
+     * both A and B.
+     * <p>
+     * It's an alternative to normal lerp, where if A is in front of origin and B opposite or
+     * near opposite to the former, the line would pass straight through origin
+     *
+     * @param A         Location to return at t = 0
+     * @param B         Location to return at t = 1
+     * @param Origin    Location the center should approximate
+     * @param t         Interpolator value
+     * @return Range of locations forming an arc outwards from Origin, controlled by t
+     */
+    public static Vec3 alerp(Vec3 A, Vec3 B, Vec3 Origin, double t) {
+        Vec3 midpoint = VecUtils.vDivide(A.add(B), new Vec3(2, 2, 2));
+
+        Vec3 normal = ((A.subtract(Origin)).cross(B.subtract(Origin))).normalize();
+
+        Vec3 AB = (B.subtract(A)).normalize();
+
+        Vec3 toCenter = (AB.cross(normal)).normalize();
+
+        Vec3 originToMid = midpoint.subtract(Origin);
+        double projectionLength = originToMid.dot(toCenter);
+
+        Vec3 center = midpoint.subtract(new Vec3(projectionLength, projectionLength, projectionLength).multiply(toCenter));
+
+        double radius = A.distanceTo(center);
+
+        Vec3 vecToA = A.subtract(center);
+        Vec3 vecToB = B.subtract(center);
+
+        double angleA = Mth.atan2(vecToA.dot(toCenter), vecToA.dot(AB));
+        double angleB = Mth.atan2(vecToB.dot(toCenter), vecToB.dot(AB));
+
+        // Ensure we're using the shorter arc
+        if (Mth.abs((float) (angleB - angleA)) > Mth.PI) {
+            if (angleA < angleB) {
+                angleA += 2 * Mth.PI;
+            } else {
+                angleB += 2 * Mth.PI;
+            }
+        }
+
+        // Interpolate the angle
+        double angle = (1 - t) * angleA + t * angleB;
+
+        // Calculate the interpolated point
+        Vec3 asdainside = (new Vec3(Mth.cos((float) angle), Mth.cos((float) angle), Mth.cos((float) angle)).multiply(AB)).add(new Vec3(Mth.sin((float) angle), Mth.sin((float) angle), Mth.sin((float) angle)).multiply(toCenter));
+
+        return center.add((new Vec3(radius, radius, radius)).multiply(asdainside));
+    }
+    /*
+    Using Slerp is also possible, but might be slightly more prone to doing a neck break, and IDK how to implement it lol
+    btw it uses quaternions, so doing a translation back and forth might be more expensive than just using the position to rotation function already implemented here.
+    I might be wrong in a lot of things though, I come from c++, and java is not exactly different, but it's also not exactly the same; I literally have 0 java
+    expertise, and I'm just rawdogging this without tutorials...
+     */
+
+    /*
+    didn't realize that in lookBehavior values in the Target struct and the current lookpos of the player were already angles with no trace of the original position until
+    after I wrote this function; at least if anything happens it should be un-pair proof (if somehow the distance between A, B and the origin is different it will still work as intended)
+     */
+
+    /*
+    also funny story, I created a whole library of vector operations in VecUtils and used them for this function until I realized that the Vec3 library already had
+    most of them, so I undid all that work except for vDivide, which was NOT on Vec3.class, although I do think my implementation did make it all a bit more understandable
+    but that's very subjective.
+     */
 
     @Deprecated
     public static Optional<Rotation> reachable(LocalPlayer entity, BlockPos pos, double blockReachDistance) {

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -19,7 +19,7 @@ package baritone.api.utils;
 
 import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
-import baritone.api.utils.VecUtils;
+import java.util.Optional;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -32,8 +32,6 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-
-import java.util.Optional;
 
 /**
  * @author Brady
@@ -267,74 +265,50 @@ public final class RotationUtils {
     }
 
     /**
-     * Arc interpolator, creates a radius with a center as near as possible from "origin" which touches
-     * both A and B.
-     * <p>
-     * It's an alternative to normal lerp, where if A is in front of origin and B opposite or
-     * near opposite to the former, the line would pass straight through origin
-     *
-     * @param A         Location to return at t = 0
-     * @param B         Location to return at t = 1
-     * @param Origin    Location the center should approximate
-     * @param t         Interpolator value
-     * @return Range of locations forming an arc outwards from Origin, controlled by t
+     * Interpolates along an arc from {@code start} to {@code end} around {@code origin}.
      */
-    public static Vec3 alerp(Vec3 A, Vec3 B, Vec3 Origin, double t) {
-        Vec3 midpoint = VecUtils.vDivide(A.add(B), new Vec3(2, 2, 2));
-
-        Vec3 normal = ((A.subtract(Origin)).cross(B.subtract(Origin))).normalize();
-
-        Vec3 AB = (B.subtract(A)).normalize();
-
-        Vec3 toCenter = (AB.cross(normal)).normalize();
-
-        Vec3 originToMid = midpoint.subtract(Origin);
+    public static Vec3 alerp(Vec3 start, Vec3 end, Vec3 origin, double t) {
+        Vec3 midpoint = start.add(end).scale(0.5);
+        Vec3 normal = start.subtract(origin).cross(end.subtract(origin)).normalize();
+        Vec3 pathDirection = end.subtract(start).normalize();
+        Vec3 toCenter = pathDirection.cross(normal).normalize();
+        Vec3 originToMid = midpoint.subtract(origin);
         double projectionLength = originToMid.dot(toCenter);
-
-        Vec3 center = midpoint.subtract(new Vec3(projectionLength, projectionLength, projectionLength).multiply(toCenter));
-
-        double radius = A.distanceTo(center);
-
-        Vec3 vecToA = A.subtract(center);
-        Vec3 vecToB = B.subtract(center);
-
-        double angleA = Mth.atan2(vecToA.dot(toCenter), vecToA.dot(AB));
-        double angleB = Mth.atan2(vecToB.dot(toCenter), vecToB.dot(AB));
+        Vec3 center = midpoint.subtract(
+                new Vec3(projectionLength, projectionLength, projectionLength).multiply(toCenter));
+        double radius = start.distanceTo(center);
+        Vec3 centerToStart = start.subtract(center);
+        Vec3 centerToEnd = end.subtract(center);
+        double angleStart = Mth.atan2(
+                centerToStart.dot(toCenter),
+                centerToStart.dot(pathDirection));
+        double angleEnd = Mth.atan2(
+                centerToEnd.dot(toCenter),
+                centerToEnd.dot(pathDirection));
 
         // Ensure we're using the shorter arc
-        if (Mth.abs((float) (angleB - angleA)) > Mth.PI) {
-            if (angleA < angleB) {
-                angleA += 2 * Mth.PI;
+        if (Mth.abs((float) (angleEnd - angleStart)) > Mth.PI) {
+            if (angleStart < angleEnd) {
+                angleStart += 2 * Mth.PI;
             } else {
-                angleB += 2 * Mth.PI;
+                angleEnd += 2 * Mth.PI;
             }
         }
 
-        // Interpolate the angle
-        double angle = (1 - t) * angleA + t * angleB;
+        double angle = (1 - t) * angleStart + t * angleEnd;
+        Vec3 arcDirection = new Vec3(
+                Mth.cos((float) angle),
+                Mth.cos((float) angle),
+                Mth.cos((float) angle))
+                .multiply(pathDirection)
+                .add(new Vec3(
+                        Mth.sin((float) angle),
+                        Mth.sin((float) angle),
+                        Mth.sin((float) angle))
+                        .multiply(toCenter));
 
-        // Calculate the interpolated point
-        Vec3 asdainside = (new Vec3(Mth.cos((float) angle), Mth.cos((float) angle), Mth.cos((float) angle)).multiply(AB)).add(new Vec3(Mth.sin((float) angle), Mth.sin((float) angle), Mth.sin((float) angle)).multiply(toCenter));
-
-        return center.add((new Vec3(radius, radius, radius)).multiply(asdainside));
+        return center.add(new Vec3(radius, radius, radius).multiply(arcDirection));
     }
-    /*
-    Using Slerp is also possible, but might be slightly more prone to doing a neck break, and IDK how to implement it lol
-    btw it uses quaternions, so doing a translation back and forth might be more expensive than just using the position to rotation function already implemented here.
-    I might be wrong in a lot of things though, I come from c++, and java is not exactly different, but it's also not exactly the same; I literally have 0 java
-    expertise, and I'm just rawdogging this without tutorials...
-     */
-
-    /*
-    didn't realize that in lookBehavior values in the Target struct and the current lookpos of the player were already angles with no trace of the original position until
-    after I wrote this function; at least if anything happens it should be un-pair proof (if somehow the distance between A, B and the origin is different it will still work as intended)
-     */
-
-    /*
-    also funny story, I created a whole library of vector operations in VecUtils and used them for this function until I realized that the Vec3 library already had
-    most of them, so I undid all that work except for vDivide, which was NOT on Vec3.class, although I do think my implementation did make it all a bit more understandable
-    but that's very subjective.
-     */
 
     @Deprecated
     public static Optional<Rotation> reachable(LocalPlayer entity, BlockPos pos, double blockReachDistance) {

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -317,7 +317,8 @@ public final class RotationUtils {
                 centerToEnd.dot(toCenter),
                 centerToEnd.dot(pathDirection));
         double angle = angleStart + wrapRadians(angleEnd - angleStart) * t;
-        Vec3 arcDirection = pathDirection.scale(Math.cos(angle)).add(toCenter.scale(Math.sin(angle)));
+        Vec3 arcDirection = pathDirection.scale(Math.cos(angle))
+                .add(toCenter.scale(Math.sin(angle)));
 
         return center.add(arcDirection.scale(radius));
     }
@@ -343,7 +344,8 @@ public final class RotationUtils {
         double endRadius = endOffset.length();
         double radius = startRadius + (endRadius - startRadius) * t;
         double angle = Math.PI * t;
-        Vec3 arcDirection = startDirection.scale(Math.cos(angle)).add(perpendicular.scale(Math.sin(angle)));
+        Vec3 arcDirection = startDirection.scale(Math.cos(angle))
+                .add(perpendicular.scale(Math.sin(angle)));
 
         return origin.add(arcDirection.scale(radius));
     }
@@ -438,7 +440,10 @@ public final class RotationUtils {
                     this.startRotation);
         }
 
-        private static int ticksForAngularSpeed(Rotation startRotation, Rotation targetRotation, double degreesPerTick) {
+        private static int ticksForAngularSpeed(
+                Rotation startRotation,
+                Rotation targetRotation,
+                double degreesPerTick) {
             if (degreesPerTick <= ARC_EPSILON) {
                 return 1;
             }
@@ -461,8 +466,11 @@ public final class RotationUtils {
             return Math.toDegrees(angularDistance(source, target));
         }
 
-        private static double latitudeAngularDistance(Rotation startRotation, Rotation targetRotation) {
-            double yawDelta = Rotation.normalizeYaw(targetRotation.getYaw() - startRotation.getYaw());
+        private static double latitudeAngularDistance(
+                Rotation startRotation,
+                Rotation targetRotation) {
+            double yawDelta = Rotation.normalizeYaw(
+                    targetRotation.getYaw() - startRotation.getYaw());
             double pitchDelta = targetRotation.getPitch() - startRotation.getPitch();
             int segments = Math.max(1, (int) Math.ceil(
                     Math.max(Math.abs(yawDelta), Math.abs(pitchDelta)) / LATITUDE_DISTANCE_STEP));
@@ -478,8 +486,12 @@ public final class RotationUtils {
             return Math.toDegrees(distance);
         }
 
-        private static Rotation latitudeArcAt(Rotation startRotation, Rotation targetRotation, double t) {
-            double yawDelta = Rotation.normalizeYaw(targetRotation.getYaw() - startRotation.getYaw());
+        private static Rotation latitudeArcAt(
+                Rotation startRotation,
+                Rotation targetRotation,
+                double t) {
+            double yawDelta = Rotation.normalizeYaw(
+                    targetRotation.getYaw() - startRotation.getYaw());
             double pitchDelta = targetRotation.getPitch() - startRotation.getPitch();
             return new Rotation(
                     (float) (startRotation.getYaw() + yawDelta * t),
@@ -487,7 +499,9 @@ public final class RotationUtils {
             ).clamp();
         }
 
-        private static boolean shouldUseLatitudeArc(Rotation startRotation, Rotation targetRotation) {
+        private static boolean shouldUseLatitudeArc(
+                Rotation startRotation,
+                Rotation targetRotation) {
             Vec3 source = calcLookDirectionFromRotation(startRotation);
             Vec3 target = calcLookDirectionFromRotation(targetRotation);
             if (source.distanceToSqr(target) < ARC_EPSILON) {

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -364,6 +364,10 @@ public final class RotationUtils {
         return wrapped;
     }
 
+    private static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
     public static final class RotationArc {
 
         private final Rotation startRotation;
@@ -379,6 +383,10 @@ public final class RotationUtils {
 
         public Rotation getCurrentRotation() {
             return this.arcAt(this.stage / (double) this.length);
+        }
+
+        public Rotation getCurrentRotation(float partialTicks) {
+            return this.arcAt((this.stage - 1 + clamp(partialTicks, 0, 1)) / (double) this.length);
         }
 
         public Rotation advance() {

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -52,7 +52,12 @@ public final class RotationUtils {
     public static final float RAD_TO_DEG_F = (float) RAD_TO_DEG;
 
     private static final double ARC_EPSILON = 1.0E-8;
+    private static final double POLE_AVOIDANCE_PITCH = 85.0;
+    private static final double POLE_AVOIDANCE_MARGIN = 1.0;
+    private static final double LATITUDE_DISTANCE_STEP = 5.0;
+    private static final double MINOR_ARC_EPSILON = 1.0E-4;
     private static final double TWO_PI = Math.PI * 2.0;
+    private static final Vec3 UP = new Vec3(0, 1, 0);
 
     /**
      * Offsets from the root block position to the center of each side.
@@ -373,12 +378,14 @@ public final class RotationUtils {
         private final Rotation startRotation;
         private final Rotation targetRotation;
         private final int length;
+        private final boolean latitudeArc;
         private int stage;
 
         public RotationArc(Rotation startRotation, Rotation targetRotation, int length) {
             this.startRotation = startRotation;
             this.targetRotation = targetRotation;
             this.length = Math.max(1, length);
+            this.latitudeArc = shouldUseLatitudeArc(startRotation, targetRotation);
         }
 
         public static RotationArc fromAngularSpeed(
@@ -422,6 +429,9 @@ public final class RotationUtils {
             if (source.distanceToSqr(target) < 1.0E-8) {
                 return this.targetRotation;
             }
+            if (this.latitudeArc) {
+                return latitudeArcAt(this.startRotation, this.targetRotation, t);
+            }
             return calcRotationFromVec3d(
                     Vec3.ZERO,
                     alerp(source, target, Vec3.ZERO, t),
@@ -433,15 +443,98 @@ public final class RotationUtils {
                 return 1;
             }
 
-            Vec3 source = calcLookDirectionFromRotation(startRotation);
-            Vec3 target = calcLookDirectionFromRotation(targetRotation);
-            double dot = clamp(source.dot(target), -1, 1);
-            double angularDistance = Math.toDegrees(Math.acos(dot));
+            double angularDistance = angularDistance(startRotation, targetRotation);
 
             if (angularDistance < ARC_EPSILON) {
                 return 1;
             }
             return Math.max(1, (int) Math.ceil(angularDistance / degreesPerTick));
+        }
+
+        private static double angularDistance(Rotation startRotation, Rotation targetRotation) {
+            if (shouldUseLatitudeArc(startRotation, targetRotation)) {
+                return latitudeAngularDistance(startRotation, targetRotation);
+            }
+
+            Vec3 source = calcLookDirectionFromRotation(startRotation);
+            Vec3 target = calcLookDirectionFromRotation(targetRotation);
+            return Math.toDegrees(angularDistance(source, target));
+        }
+
+        private static double latitudeAngularDistance(Rotation startRotation, Rotation targetRotation) {
+            double yawDelta = Rotation.normalizeYaw(targetRotation.getYaw() - startRotation.getYaw());
+            double pitchDelta = targetRotation.getPitch() - startRotation.getPitch();
+            int segments = Math.max(1, (int) Math.ceil(
+                    Math.max(Math.abs(yawDelta), Math.abs(pitchDelta)) / LATITUDE_DISTANCE_STEP));
+
+            Vec3 previous = calcLookDirectionFromRotation(startRotation);
+            double distance = 0;
+            for (int i = 1; i <= segments; i++) {
+                Vec3 current = calcLookDirectionFromRotation(
+                        latitudeArcAt(startRotation, targetRotation, i / (double) segments));
+                distance += angularDistance(previous, current);
+                previous = current;
+            }
+            return Math.toDegrees(distance);
+        }
+
+        private static Rotation latitudeArcAt(Rotation startRotation, Rotation targetRotation, double t) {
+            double yawDelta = Rotation.normalizeYaw(targetRotation.getYaw() - startRotation.getYaw());
+            double pitchDelta = targetRotation.getPitch() - startRotation.getPitch();
+            return new Rotation(
+                    (float) (startRotation.getYaw() + yawDelta * t),
+                    (float) (startRotation.getPitch() + pitchDelta * t)
+            ).clamp();
+        }
+
+        private static boolean shouldUseLatitudeArc(Rotation startRotation, Rotation targetRotation) {
+            Vec3 source = calcLookDirectionFromRotation(startRotation);
+            Vec3 target = calcLookDirectionFromRotation(targetRotation);
+            if (source.distanceToSqr(target) < ARC_EPSILON) {
+                return false;
+            }
+
+            // With roll locked, yaw becomes unstable when a great-circle arc crosses a view pole.
+            double endpointPitch = Math.max(
+                    Math.abs(startRotation.getPitch()),
+                    Math.abs(targetRotation.getPitch()));
+            double polePitch = maxPolePitchOnGreatCircle(source, target);
+            return polePitch >= POLE_AVOIDANCE_PITCH
+                    && polePitch > endpointPitch + POLE_AVOIDANCE_MARGIN;
+        }
+
+        private static double maxPolePitchOnGreatCircle(Vec3 source, Vec3 target) {
+            double maxY = Math.max(Math.abs(source.y), Math.abs(target.y));
+            Vec3 normal = source.cross(target);
+            if (normal.lengthSqr() < ARC_EPSILON) {
+                return Math.toDegrees(Math.asin(clamp(maxY, -1, 1)));
+            }
+
+            normal = normal.normalize();
+            Vec3 poleProjection = UP.subtract(normal.scale(UP.dot(normal)));
+            if (poleProjection.lengthSqr() < ARC_EPSILON) {
+                return Math.toDegrees(Math.asin(clamp(maxY, -1, 1)));
+            }
+
+            Vec3 poleward = poleProjection.normalize();
+            if (isOnMinorArc(source, target, poleward)) {
+                maxY = Math.max(maxY, Math.abs(poleward.y));
+            }
+            Vec3 oppositePoleward = poleward.scale(-1);
+            if (isOnMinorArc(source, target, oppositePoleward)) {
+                maxY = Math.max(maxY, Math.abs(oppositePoleward.y));
+            }
+            return Math.toDegrees(Math.asin(clamp(maxY, -1, 1)));
+        }
+
+        private static boolean isOnMinorArc(Vec3 source, Vec3 target, Vec3 sample) {
+            double total = angularDistance(source, target);
+            double split = angularDistance(source, sample) + angularDistance(sample, target);
+            return Math.abs(split - total) < MINOR_ARC_EPSILON;
+        }
+
+        private static double angularDistance(Vec3 source, Vec3 target) {
+            return Math.acos(clamp(source.dot(target), -1, 1));
         }
     }
 

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -381,6 +381,16 @@ public final class RotationUtils {
             this.length = Math.max(1, length);
         }
 
+        public static RotationArc fromAngularSpeed(
+                Rotation startRotation,
+                Rotation targetRotation,
+                double degreesPerTick) {
+            return new RotationArc(
+                    startRotation,
+                    targetRotation,
+                    ticksForAngularSpeed(startRotation, targetRotation, degreesPerTick));
+        }
+
         public Rotation getCurrentRotation() {
             return this.arcAt(this.stage / (double) this.length);
         }
@@ -416,6 +426,22 @@ public final class RotationUtils {
                     Vec3.ZERO,
                     alerp(source, target, Vec3.ZERO, t),
                     this.startRotation);
+        }
+
+        private static int ticksForAngularSpeed(Rotation startRotation, Rotation targetRotation, double degreesPerTick) {
+            if (degreesPerTick <= ARC_EPSILON) {
+                return 1;
+            }
+
+            Vec3 source = calcLookDirectionFromRotation(startRotation);
+            Vec3 target = calcLookDirectionFromRotation(targetRotation);
+            double dot = clamp(source.dot(target), -1, 1);
+            double angularDistance = Math.toDegrees(Math.acos(dot));
+
+            if (angularDistance < ARC_EPSILON) {
+                return 1;
+            }
+            return Math.max(1, (int) Math.ceil(angularDistance / degreesPerTick));
         }
     }
 

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -51,6 +51,9 @@ public final class RotationUtils {
     public static final double RAD_TO_DEG = 180.0 / Math.PI;
     public static final float RAD_TO_DEG_F = (float) RAD_TO_DEG;
 
+    private static final double ARC_EPSILON = 1.0E-8;
+    private static final double TWO_PI = Math.PI * 2.0;
+
     /**
      * Offsets from the root block position to the center of each side.
      */
@@ -268,46 +271,97 @@ public final class RotationUtils {
      * Interpolates along an arc from {@code start} to {@code end} around {@code origin}.
      */
     public static Vec3 alerp(Vec3 start, Vec3 end, Vec3 origin, double t) {
+        if (t <= 0) {
+            return start;
+        }
+        if (t >= 1) {
+            return end;
+        }
+        if (start.distanceToSqr(end) < ARC_EPSILON) {
+            return start;
+        }
+
+        Vec3 startOffset = start.subtract(origin);
+        Vec3 endOffset = end.subtract(origin);
+        if (startOffset.lengthSqr() < ARC_EPSILON || endOffset.lengthSqr() < ARC_EPSILON) {
+            return lerp(start, end, t);
+        }
+
+        Vec3 normal = startOffset.cross(endOffset);
+        if (normal.lengthSqr() < ARC_EPSILON) {
+            return colinearAlerp(start, end, origin, t, startOffset, endOffset);
+        }
+
         Vec3 midpoint = start.add(end).scale(0.5);
-        Vec3 normal = start.subtract(origin).cross(end.subtract(origin)).normalize();
+        normal = normal.normalize();
         Vec3 pathDirection = end.subtract(start).normalize();
         Vec3 toCenter = pathDirection.cross(normal).normalize();
         Vec3 originToMid = midpoint.subtract(origin);
         double projectionLength = originToMid.dot(toCenter);
-        Vec3 center = midpoint.subtract(
-                new Vec3(projectionLength, projectionLength, projectionLength).multiply(toCenter));
+        Vec3 center = midpoint.subtract(toCenter.scale(projectionLength));
         double radius = start.distanceTo(center);
+        if (radius < ARC_EPSILON) {
+            return lerp(start, end, t);
+        }
         Vec3 centerToStart = start.subtract(center);
         Vec3 centerToEnd = end.subtract(center);
-        double angleStart = Mth.atan2(
+        double angleStart = Math.atan2(
                 centerToStart.dot(toCenter),
                 centerToStart.dot(pathDirection));
-        double angleEnd = Mth.atan2(
+        double angleEnd = Math.atan2(
                 centerToEnd.dot(toCenter),
                 centerToEnd.dot(pathDirection));
+        double angle = angleStart + wrapRadians(angleEnd - angleStart) * t;
+        Vec3 arcDirection = pathDirection.scale(Math.cos(angle)).add(toCenter.scale(Math.sin(angle)));
 
-        // Ensure we're using the shorter arc
-        if (Mth.abs((float) (angleEnd - angleStart)) > Mth.PI) {
-            if (angleStart < angleEnd) {
-                angleStart += 2 * Mth.PI;
-            } else {
-                angleEnd += 2 * Mth.PI;
-            }
+        return center.add(arcDirection.scale(radius));
+    }
+
+    private static Vec3 lerp(Vec3 start, Vec3 end, double t) {
+        return start.add(end.subtract(start).scale(t));
+    }
+
+    private static Vec3 colinearAlerp(
+            Vec3 start,
+            Vec3 end,
+            Vec3 origin,
+            double t,
+            Vec3 startOffset,
+            Vec3 endOffset) {
+        if (startOffset.dot(endOffset) >= 0) {
+            return lerp(start, end, t);
         }
 
-        double angle = (1 - t) * angleStart + t * angleEnd;
-        Vec3 arcDirection = new Vec3(
-                Mth.cos((float) angle),
-                Mth.cos((float) angle),
-                Mth.cos((float) angle))
-                .multiply(pathDirection)
-                .add(new Vec3(
-                        Mth.sin((float) angle),
-                        Mth.sin((float) angle),
-                        Mth.sin((float) angle))
-                        .multiply(toCenter));
+        Vec3 startDirection = startOffset.normalize();
+        Vec3 perpendicular = perpendicular(startDirection);
+        double startRadius = startOffset.length();
+        double endRadius = endOffset.length();
+        double radius = startRadius + (endRadius - startRadius) * t;
+        double angle = Math.PI * t;
+        Vec3 arcDirection = startDirection.scale(Math.cos(angle)).add(perpendicular.scale(Math.sin(angle)));
 
-        return center.add(new Vec3(radius, radius, radius).multiply(arcDirection));
+        return origin.add(arcDirection.scale(radius));
+    }
+
+    private static Vec3 perpendicular(Vec3 vector) {
+        Vec3 axis = Math.abs(vector.x) < Math.abs(vector.y)
+                ? new Vec3(1, 0, 0)
+                : new Vec3(0, 1, 0);
+        Vec3 perpendicular = vector.cross(axis);
+        if (perpendicular.lengthSqr() < ARC_EPSILON) {
+            perpendicular = vector.cross(new Vec3(0, 0, 1));
+        }
+        return perpendicular.normalize();
+    }
+
+    private static double wrapRadians(double angle) {
+        double wrapped = angle % TWO_PI;
+        if (wrapped <= -Math.PI) {
+            wrapped += TWO_PI;
+        } else if (wrapped > Math.PI) {
+            wrapped -= TWO_PI;
+        }
+        return wrapped;
     }
 
     public static final class RotationArc {
@@ -353,7 +407,7 @@ public final class RotationUtils {
             return calcRotationFromVec3d(
                     Vec3.ZERO,
                     alerp(source, target, Vec3.ZERO, t),
-                    new Rotation(0, 0));
+                    this.startRotation);
         }
     }
 

--- a/src/api/java/baritone/api/utils/VecUtils.java
+++ b/src/api/java/baritone/api/utils/VecUtils.java
@@ -19,6 +19,7 @@ package baritone.api.utils;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseFireBlock;
@@ -119,5 +120,9 @@ public final class VecUtils {
      */
     public static double entityFlatDistanceToCenter(Entity entity, BlockPos pos) {
         return distanceToCenter(pos, entity.position().x, pos.getY() + 0.5, entity.position().z);
+    }
+
+    public static Vec3 vDivide (Vec3 A, Vec3 B) {
+        return new Vec3(A.x / B.x, A.y / B.y, A.z / B.z);
     }
 }

--- a/src/api/java/baritone/api/utils/VecUtils.java
+++ b/src/api/java/baritone/api/utils/VecUtils.java
@@ -19,7 +19,6 @@ package baritone.api.utils;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseFireBlock;
@@ -124,9 +123,5 @@ public final class VecUtils {
      */
     public static double entityFlatDistanceToCenter(Entity entity, BlockPos pos) {
         return distanceToCenter(pos, entity.position().x, pos.getY() + 0.5, entity.position().z);
-    }
-
-    public static Vec3 vDivide (Vec3 A, Vec3 B) {
-        return new Vec3(A.x / B.x, A.y / B.y, A.z / B.z);
     }
 }

--- a/src/api/java/baritone/api/utils/VecUtils.java
+++ b/src/api/java/baritone/api/utils/VecUtils.java
@@ -19,6 +19,7 @@ package baritone.api.utils;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseFireBlock;
@@ -123,5 +124,9 @@ public final class VecUtils {
      */
     public static double entityFlatDistanceToCenter(Entity entity, BlockPos pos) {
         return distanceToCenter(pos, entity.position().x, pos.getY() + 0.5, entity.position().z);
+    }
+
+    public static Vec3 vDivide (Vec3 A, Vec3 B) {
+        return new Vec3(A.x / B.x, A.y / B.y, A.z / B.z);
     }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
@@ -22,15 +22,18 @@ import baritone.api.IBaritone;
 import baritone.api.event.events.PlayerUpdateEvent;
 import baritone.api.event.events.SprintStateEvent;
 import baritone.api.event.events.type.EventState;
+import baritone.api.utils.Rotation;
 import baritone.behavior.LookBehavior;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.player.Abilities;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * @author Brady
@@ -51,6 +54,30 @@ public class MixinClientPlayerEntity {
         IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
         if (baritone != null) {
             baritone.getGameEventHandler().onPlayerUpdate(new PlayerUpdateEvent(EventState.PRE));
+        }
+    }
+
+    @Inject(
+            method = "getViewYRot",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void getViewYRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
+        Rotation visualRotation = this.getVisualRotation(partialTicks);
+        if (visualRotation != null) {
+            cir.setReturnValue(visualRotation.getYaw());
+        }
+    }
+
+    @Inject(
+            method = "getViewXRot",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void getViewXRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
+        Rotation visualRotation = this.getVisualRotation(partialTicks);
+        if (visualRotation != null) {
+            cir.setReturnValue(visualRotation.getPitch());
         }
     }
 
@@ -119,5 +146,14 @@ public class MixinClientPlayerEntity {
             return false;
         }
         return instance.tryToStartFallFlying();
+    }
+
+    @Unique
+    private Rotation getVisualRotation(float partialTicks) {
+        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
+        if (baritone == null) {
+            return null;
+        }
+        return ((LookBehavior) baritone.getLookBehavior()).getVisualRotation(partialTicks);
     }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
@@ -62,6 +62,7 @@ public class MixinClientPlayerEntity {
             at = @At("HEAD"),
             cancellable = true
     )
+    @SuppressWarnings({"unused", "PMD.UnusedPrivateMethod"})
     private void getViewYRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
         Rotation visualRotation = this.getVisualRotation(partialTicks);
         if (visualRotation != null) {
@@ -74,6 +75,7 @@ public class MixinClientPlayerEntity {
             at = @At("HEAD"),
             cancellable = true
     )
+    @SuppressWarnings({"unused", "PMD.UnusedPrivateMethod"})
     private void getViewXRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
         Rotation visualRotation = this.getVisualRotation(partialTicks);
         if (visualRotation != null) {

--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
@@ -150,7 +150,8 @@ public class MixinClientPlayerEntity {
 
     @Unique
     private Rotation getVisualRotation(float partialTicks) {
-        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
+        IBaritone baritone = BaritoneAPI.getProvider()
+                .getBaritoneForPlayer((LocalPlayer) (Object) this);
         if (baritone == null) {
             return null;
         }

--- a/src/launch/java/baritone/launch/mixins/MixinEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinEntity.java
@@ -18,10 +18,7 @@
 package baritone.launch.mixins;
 
 import baritone.api.BaritoneAPI;
-import baritone.api.IBaritone;
 import baritone.api.event.events.RotationMoveEvent;
-import baritone.api.utils.Rotation;
-import baritone.behavior.LookBehavior;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -30,7 +27,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
 public class MixinEntity {
@@ -69,41 +65,5 @@ public class MixinEntity {
             this.xRot = this.motionUpdateRotationEvent.getOriginal().getPitch();
             this.motionUpdateRotationEvent = null;
         }
-    }
-
-    @Inject(
-            method = "getViewYRot",
-            at = @At("HEAD"),
-            cancellable = true
-    )
-    private void getViewYRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
-        Rotation visualRotation = this.getVisualRotation(partialTicks);
-        if (visualRotation != null) {
-            cir.setReturnValue(visualRotation.getYaw());
-        }
-    }
-
-    @Inject(
-            method = "getViewXRot",
-            at = @At("HEAD"),
-            cancellable = true
-    )
-    private void getViewXRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
-        Rotation visualRotation = this.getVisualRotation(partialTicks);
-        if (visualRotation != null) {
-            cir.setReturnValue(visualRotation.getPitch());
-        }
-    }
-
-    @Unique
-    private Rotation getVisualRotation(float partialTicks) {
-        if (!LocalPlayer.class.isInstance(this)) {
-            return null;
-        }
-        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
-        if (baritone == null) {
-            return null;
-        }
-        return ((LookBehavior) baritone.getLookBehavior()).getVisualRotation(partialTicks);
     }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinEntity.java
@@ -18,7 +18,10 @@
 package baritone.launch.mixins;
 
 import baritone.api.BaritoneAPI;
+import baritone.api.IBaritone;
 import baritone.api.event.events.RotationMoveEvent;
+import baritone.api.utils.Rotation;
+import baritone.behavior.LookBehavior;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,6 +30,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
 public class MixinEntity {
@@ -65,5 +69,41 @@ public class MixinEntity {
             this.xRot = this.motionUpdateRotationEvent.getOriginal().getPitch();
             this.motionUpdateRotationEvent = null;
         }
+    }
+
+    @Inject(
+            method = "getViewYRot",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void getViewYRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
+        Rotation visualRotation = this.getVisualRotation(partialTicks);
+        if (visualRotation != null) {
+            cir.setReturnValue(visualRotation.getYaw());
+        }
+    }
+
+    @Inject(
+            method = "getViewXRot",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void getViewXRot(float partialTicks, CallbackInfoReturnable<Float> cir) {
+        Rotation visualRotation = this.getVisualRotation(partialTicks);
+        if (visualRotation != null) {
+            cir.setReturnValue(visualRotation.getPitch());
+        }
+    }
+
+    @Unique
+    private Rotation getVisualRotation(float partialTicks) {
+        if (!LocalPlayer.class.isInstance(this)) {
+            return null;
+        }
+        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
+        if (baritone == null) {
+            return null;
+        }
+        return ((LookBehavior) baritone.getLookBehavior()).getVisualRotation(partialTicks);
     }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinMinecraft.java
+++ b/src/launch/java/baritone/launch/mixins/MixinMinecraft.java
@@ -23,6 +23,7 @@ import baritone.api.event.events.PlayerUpdateEvent;
 import baritone.api.event.events.TickEvent;
 import baritone.api.event.events.WorldEvent;
 import baritone.api.event.events.type.EventState;
+import baritone.utils.PlayerControlGuard;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -172,7 +173,9 @@ public class MixinMinecraft {
     )
     private boolean passEvents(Screen screen) {
         // allow user input is only the primary baritone
-        return (BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().isPathing() && player != null) || screen.passEvents;
+        return (BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().isPathing()
+                && PlayerControlGuard.canControl(player, screen))
+                || screen.passEvents;
     }
 
     // TODO

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -65,8 +65,8 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private static Vec3 Destiny;
     private static Vec3 Center;
 
-    //private final Deque<Float> smoothYawBuffer;
-    //private final Deque<Float> smoothPitchBuffer;
+    private final Deque<Float> smoothYawBuffer;
+    private final Deque<Float> smoothPitchBuffer;
 
     public LookBehavior(Baritone baritone) {
         super(baritone);
@@ -99,7 +99,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             return;
         }
 
-        if (Baritone.settings().interpolatedLook.value = false) {
+        if (!Baritone.settings().interpolatedLook.value) {
             switch (event.getState()) {
                 //PRE: onPlayerUpdate was called before rotation data was sent to the server
                 case PRE: {
@@ -118,16 +118,23 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 case POST: {
                     // Reset the player's rotations back to their original values
                     if (this.prevRotation != null) {
+                        this.smoothYawBuffer.addLast(this.target.rotation.getYaw());
+                        while (this.smoothYawBuffer.size() > Baritone.settings().smoothLookTicks.value) {
+                            this.smoothYawBuffer.removeFirst();
+                        }
+                        this.smoothPitchBuffer.addLast(this.target.rotation.getPitch());
+                        while (this.smoothPitchBuffer.size() > Baritone.settings().smoothLookTicks.value) {
+                            this.smoothPitchBuffer.removeFirst();
+                        }
                         if (this.target.mode == Target.Mode.SERVER) {
                             ctx.player().setYRot(this.prevRotation.getYaw());
                             ctx.player().setXRot(this.prevRotation.getPitch());
-                        }// else if (ctx.player().isFallFlying() && Baritone.settings().elytraSmoothLook.value) {
-                        //   ctx.player().setYRot((float) this.smoothYawBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getYaw()));
-                        //   if (ctx.player().isFallFlying()) {
-                        //       ctx.player().setXRot((float) this.smoothPitchBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getPitch()));
-                        //   }
-                        //}
-                        /** TODO: reimplement elytra and falling */
+                        } else if (ctx.player().isFallFlying() ? Baritone.settings().elytraSmoothLook.value : Baritone.settings().smoothLook.value) {
+                            ctx.player().setYRot((float) this.smoothYawBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getYaw()));
+                            if (ctx.player().isFallFlying()) {
+                                ctx.player().setXRot((float) this.smoothPitchBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getPitch()));
+                            }
+                        }
                         //ctx.player().xRotO = prevRotation.getPitch();
                         //ctx.player().yRotO = prevRotation.getYaw();
                         this.prevRotation = null;

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -117,9 +117,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
         if (this.target == null) {
             if (event.getState() == EventState.PRE) {
-                this.renderArc = null;
-                this.cachedVisualPartialTicks = Float.NaN;
-                this.cachedVisualRotation = null;
+                this.resetInterpolation();
             }
             return;
         }
@@ -187,7 +185,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         switch (event.getState()) {
             case PRE: {
                 if (this.target.mode == Target.Mode.NONE) {
-                    this.clearRenderArc();
+                    this.resetInterpolation();
                     return;
                 }
                 if (this.target.mode == Target.Mode.SERVER) {

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -66,6 +66,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private final Deque<Float> smoothYawBuffer;
     private final Deque<Float> smoothPitchBuffer;
     private RotationArc interpolationArc;
+    private Target.Mode interpolationMode;
     private Vec3 interpolationOrigin;
     private RotationArc pendingRenderArc;
     private RotationArc renderArc;
@@ -193,9 +194,9 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 }
 
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
-                final Rotation start = ctx.playerRotations();
+                final Rotation start = this.startingRotation(this.target.mode);
                 final Rotation actual = this.target.rotation(this.processor);
-                this.updateInterpolation(start, actual, ctx.playerHead(), this.target.restartInterpolation);
+                this.updateInterpolation(start, actual, ctx.playerHead(), this.target.restartInterpolation, this.target.mode);
                 break;
             }
             case POST: {
@@ -221,8 +222,26 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         }
     }
 
-    private void updateInterpolation(Rotation start, Rotation actual, Vec3 origin, boolean restartArc) {
+    private Rotation startingRotation(Target.Mode mode) {
+        if (mode == Target.Mode.CLIENT) {
+            return this.prevRotation;
+        }
+        return ctx.playerRotations();
+    }
+
+    private void updateInterpolation(
+            Rotation start,
+            Rotation actual,
+            Vec3 origin,
+            boolean restartArc,
+            Target.Mode mode) {
         final int interpolationSpeed = Baritone.settings().interpolatedLookLength.value;
+
+        if (this.interpolationArc != null && this.interpolationMode != mode) {
+            this.interpolationArc = null;
+            this.interpolationOrigin = null;
+            this.pendingRenderArc = null;
+        }
 
         if (this.interpolationArc != null && (restartArc || this.interpolationOriginMoved(origin))) {
             start = this.interpolationArc.getCurrentRotation();
@@ -231,6 +250,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
         if (this.interpolationArc == null) {
             this.interpolationArc = RotationArc.fromAngularSpeed(start, actual, interpolationSpeed);
+            this.interpolationMode = mode;
             this.interpolationOrigin = origin;
         }
 
@@ -285,6 +305,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     private void resetInterpolation() {
         this.interpolationArc = null;
+        this.interpolationMode = null;
         this.interpolationOrigin = null;
         this.pendingRenderArc = null;
         this.renderArc = null;

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -27,6 +27,7 @@ import baritone.api.event.events.PlayerUpdateEvent;
 import baritone.api.event.events.RotationMoveEvent;
 import baritone.api.event.events.TickEvent;
 import baritone.api.event.events.WorldEvent;
+import baritone.api.event.events.type.EventState;
 import baritone.api.utils.IPlayerContext;
 import baritone.api.utils.Rotation;
 import baritone.api.utils.RotationUtils;
@@ -62,8 +63,12 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private final Deque<Float> smoothYawBuffer;
     private final Deque<Float> smoothPitchBuffer;
     private RotationArc interpolationArc;
+    private RotationArc pendingRenderArc;
+    private RotationArc renderArc;
     private Rotation previousArcSample;
     private Rotation currentArcSample;
+    private float cachedVisualPartialTicks = Float.NaN;
+    private Rotation cachedVisualRotation;
 
     public LookBehavior(Baritone baritone) {
         super(baritone);
@@ -93,6 +98,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     public void onPlayerUpdate(PlayerUpdateEvent event) {
 
         if (this.target == null) {
+            if (event.getState() == EventState.PRE) {
+                this.renderArc = null;
+                this.cachedVisualPartialTicks = Float.NaN;
+                this.cachedVisualRotation = null;
+            }
             return;
         }
 
@@ -159,6 +169,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         switch (event.getState()) {
             case PRE: {
                 if (this.target.mode == Target.Mode.NONE) {
+                    this.pendingRenderArc = null;
                     return;
                 }
 
@@ -195,6 +206,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
         this.previousArcSample = this.interpolationArc.getCurrentRotation();
         this.currentArcSample = this.interpolationArc.advance();
+        this.pendingRenderArc = this.interpolationArc;
         this.applyRotation(this.currentArcSample);
         this.serverRotation = this.currentArcSample;
         if (this.interpolationArc.isComplete()) {
@@ -208,15 +220,34 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     }
 
     private void applyVisualArc() {
+        this.renderArc = this.pendingRenderArc;
+        this.pendingRenderArc = null;
+        this.cachedVisualPartialTicks = Float.NaN;
+        this.cachedVisualRotation = null;
         ctx.player().yRotO = this.previousArcSample.getYaw();
         ctx.player().xRotO = this.previousArcSample.getPitch();
         this.applyRotation(this.currentArcSample);
     }
 
+    public Rotation getVisualRotation(float partialTicks) {
+        if (this.renderArc == null) {
+            return null;
+        }
+        if (this.cachedVisualRotation == null || this.cachedVisualPartialTicks != partialTicks) {
+            this.cachedVisualPartialTicks = partialTicks;
+            this.cachedVisualRotation = this.renderArc.getCurrentRotation(partialTicks);
+        }
+        return this.cachedVisualRotation;
+    }
+
     private void resetInterpolation() {
         this.interpolationArc = null;
+        this.pendingRenderArc = null;
+        this.renderArc = null;
         this.previousArcSample = null;
         this.currentArcSample = null;
+        this.cachedVisualPartialTicks = Float.NaN;
+        this.cachedVisualRotation = null;
     }
 
     @Override

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -250,6 +250,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             boolean restartArc,
             Target.Mode mode) {
         final int interpolationSpeed = Baritone.settings().interpolatedLookLength.value;
+        Rotation arcStart = start;
 
         if (this.interpolationArc != null && this.interpolationMode != mode) {
             this.interpolationArc = null;
@@ -259,12 +260,15 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
         if (this.interpolationArc != null
                 && (restartArc || this.interpolationOriginMoved(origin))) {
-            start = this.interpolationArc.getCurrentRotation();
+            arcStart = this.interpolationArc.getCurrentRotation();
             this.interpolationArc = null;
         }
 
         if (this.interpolationArc == null) {
-            this.interpolationArc = RotationArc.fromAngularSpeed(start, actual, interpolationSpeed);
+            this.interpolationArc = RotationArc.fromAngularSpeed(
+                    arcStart,
+                    actual,
+                    interpolationSpeed);
             this.interpolationMode = mode;
             this.interpolationOrigin = origin;
         }

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -170,7 +170,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 break;
             }
             case POST: {
-                if (this.prevRotation != null && this.target.mode == Target.Mode.SERVER) {
+                if (this.prevRotation != null && this.previousArcSample != null && this.currentArcSample != null) {
+                    this.applyVisualArc();
+                    this.previousArcSample = null;
+                    this.currentArcSample = null;
+                } else if (this.prevRotation != null && this.target.mode == Target.Mode.SERVER) {
                     ctx.player().setYRot(this.prevRotation.getYaw());
                     ctx.player().setXRot(this.prevRotation.getPitch());
                 }
@@ -202,6 +206,12 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private void applyRotation(Rotation rotation) {
         ctx.player().setYRot(rotation.getYaw());
         ctx.player().setXRot(rotation.getPitch());
+    }
+
+    private void applyVisualArc() {
+        ctx.player().yRotO = this.previousArcSample.getYaw();
+        ctx.player().xRotO = this.previousArcSample.getPitch();
+        this.applyRotation(this.currentArcSample);
     }
 
     private void resetInterpolation() {

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -30,13 +30,12 @@ import baritone.api.event.events.WorldEvent;
 import baritone.api.utils.IPlayerContext;
 import baritone.api.utils.Rotation;
 import baritone.api.utils.RotationUtils;
+import baritone.api.utils.RotationUtils.RotationArc;
 import baritone.behavior.look.ForkableRandom;
-import baritone.utils.BaritoneMath;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
-import net.minecraft.world.phys.Vec3;
 
 public final class LookBehavior extends Behavior implements ILookBehavior {
 
@@ -454,50 +453,4 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         }
     }
 
-    private static final class RotationArc {
-
-        private final Rotation startRotation;
-        private final Rotation targetRotation;
-        private final int length;
-        private int stage;
-
-        private RotationArc(Rotation startRotation, Rotation targetRotation, int length) {
-            this.startRotation = startRotation;
-            this.targetRotation = targetRotation;
-            this.length = Math.max(1, length);
-        }
-
-        private Rotation getCurrentRotation() {
-            return this.arcAt(BaritoneMath.normalize(this.stage, this.length));
-        }
-
-        private Rotation advance() {
-            if (this.stage < this.length) {
-                this.stage++;
-            }
-            return this.getCurrentRotation();
-        }
-
-        private boolean isComplete() {
-            return this.stage >= this.length;
-        }
-
-        private Rotation arcAt(double t) {
-            if (t <= 0) {
-                return this.startRotation;
-            }
-            if (t >= 1) {
-                return this.targetRotation;
-            }
-            final Vec3 source = RotationUtils.calcLookDirectionFromRotation(this.startRotation);
-            final Vec3 target = RotationUtils.calcLookDirectionFromRotation(this.targetRotation);
-            if (source.distanceToSqr(target) < 1.0E-8) {
-                return this.targetRotation;
-            }
-            return RotationUtils.calcRotationFromVec3d(
-                    Vec3.ZERO,
-                    RotationUtils.alerp(source, target, Vec3.ZERO, t),
-                    new Rotation(0, 0));
-        }
-    }
 }

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -187,8 +187,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         switch (event.getState()) {
             case PRE: {
                 if (this.target.mode == Target.Mode.NONE) {
-                    this.pendingRenderArc = null;
+                    this.clearRenderArc();
                     return;
+                }
+                if (this.target.mode == Target.Mode.SERVER) {
+                    this.clearRenderArc();
                 }
 
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
@@ -199,7 +202,12 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             }
             case POST: {
                 if (this.prevRotation != null && this.previousArcSample != null && this.currentArcSample != null) {
-                    this.applyVisualArc();
+                    if (this.target.mode == Target.Mode.SERVER) {
+                        this.clearRenderArc();
+                        this.applyRotation(this.prevRotation);
+                    } else {
+                        this.applyVisualArc();
+                    }
                     this.previousArcSample = null;
                     this.currentArcSample = null;
                 } else if (this.prevRotation != null && this.target.mode == Target.Mode.SERVER) {
@@ -257,6 +265,13 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         ctx.player().yRotO = this.previousArcSample.getYaw();
         ctx.player().xRotO = this.previousArcSample.getPitch();
         this.applyRotation(this.currentArcSample);
+    }
+
+    private void clearRenderArc() {
+        this.renderArc = null;
+        this.pendingRenderArc = null;
+        this.cachedVisualPartialTicks = Float.NaN;
+        this.cachedVisualRotation = null;
     }
 
     public Rotation getVisualRotation(float partialTicks) {

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -88,7 +88,10 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     }
 
     @Override
-    public void updateTarget(Rotation rotation, boolean blockInteract, boolean restartInterpolation) {
+    public void updateTarget(
+            Rotation rotation,
+            boolean blockInteract,
+            boolean restartInterpolation) {
         this.updateTarget(rotation, blockInteract, restartInterpolation, false);
     }
 
@@ -98,7 +101,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             boolean blockInteract,
             boolean restartInterpolation,
             boolean exactRotation) {
-        this.target = new Target(rotation, Target.Mode.resolve(ctx, blockInteract), restartInterpolation, exactRotation);
+        this.target = new Target(
+                rotation,
+                Target.Mode.resolve(ctx, blockInteract),
+                restartInterpolation,
+                exactRotation);
     }
 
     @Override
@@ -196,11 +203,18 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
                 final Rotation start = this.startingRotation(this.target.mode);
                 final Rotation actual = this.target.rotation(this.processor);
-                this.updateInterpolation(start, actual, ctx.playerHead(), this.target.restartInterpolation, this.target.mode);
+                this.updateInterpolation(
+                        start,
+                        actual,
+                        ctx.playerHead(),
+                        this.target.restartInterpolation,
+                        this.target.mode);
                 break;
             }
             case POST: {
-                if (this.prevRotation != null && this.previousArcSample != null && this.currentArcSample != null) {
+                if (this.prevRotation != null
+                        && this.previousArcSample != null
+                        && this.currentArcSample != null) {
                     if (this.target.mode == Target.Mode.SERVER) {
                         this.clearRenderArc();
                         this.applyRotation(this.prevRotation);
@@ -243,7 +257,8 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             this.pendingRenderArc = null;
         }
 
-        if (this.interpolationArc != null && (restartArc || this.interpolationOriginMoved(origin))) {
+        if (this.interpolationArc != null
+                && (restartArc || this.interpolationOriginMoved(origin))) {
             start = this.interpolationArc.getCurrentRotation();
             this.interpolationArc = null;
         }
@@ -504,7 +519,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         public final boolean restartInterpolation;
         public final boolean exactRotation;
 
-        public Target(Rotation rotation, Mode mode, boolean restartInterpolation, boolean exactRotation) {
+        public Target(
+                Rotation rotation,
+                Mode mode,
+                boolean restartInterpolation,
+                boolean exactRotation) {
             this.rotation = rotation;
             this.mode = mode;
             this.restartInterpolation = restartInterpolation;

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -32,6 +32,7 @@ import baritone.api.utils.IPlayerContext;
 import baritone.api.utils.Rotation;
 import baritone.api.utils.RotationUtils;
 import baritone.api.utils.RotationUtils.RotationArc;
+import baritone.api.utils.input.Input;
 import baritone.behavior.look.ForkableRandom;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -72,6 +73,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private RotationArc renderArc;
     private Rotation previousArcSample;
     private Rotation currentArcSample;
+    private Rotation movementRotation;
     private float cachedVisualPartialTicks = Float.NaN;
     private Rotation cachedVisualRotation;
 
@@ -106,6 +108,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 Target.Mode.resolve(ctx, blockInteract),
                 restartInterpolation,
                 exactRotation);
+        this.movementRotation = this.target.rotation(this.processor);
     }
 
     @Override
@@ -351,6 +354,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     public void onWorldEvent(WorldEvent event) {
         this.serverRotation = null;
         this.target = null;
+        this.movementRotation = null;
         this.resetInterpolation();
     }
 
@@ -371,11 +375,27 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     @Override
     public void onPlayerRotationMove(RotationMoveEvent event) {
+        Rotation rotation = null;
         if (this.target != null) {
-            final Rotation actual = this.target.rotation(this.processor);
-            event.setYaw(actual.getYaw());
-            event.setPitch(actual.getPitch());
+            rotation = this.target.rotation(this.processor);
+            this.movementRotation = rotation;
+        } else if (this.movementRotation != null && this.hasForcedMovementInput()) {
+            rotation = this.movementRotation;
+        } else {
+            this.movementRotation = null;
         }
+
+        if (rotation != null) {
+            event.setYaw(rotation.getYaw());
+            event.setPitch(rotation.getPitch());
+        }
+    }
+
+    private boolean hasForcedMovementInput() {
+        return baritone.getInputOverrideHandler().isInputForcedDown(Input.MOVE_FORWARD)
+                || baritone.getInputOverrideHandler().isInputForcedDown(Input.MOVE_BACK)
+                || baritone.getInputOverrideHandler().isInputForcedDown(Input.MOVE_LEFT)
+                || baritone.getInputOverrideHandler().isInputForcedDown(Input.MOVE_RIGHT);
     }
 
     private static final class AimProcessor extends AbstractAimProcessor {

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -83,7 +83,12 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     @Override
     public void updateTarget(Rotation rotation, boolean blockInteract) {
-        this.target = new Target(rotation, Target.Mode.resolve(ctx, blockInteract));
+        this.updateTarget(rotation, blockInteract, false);
+    }
+
+    @Override
+    public void updateTarget(Rotation rotation, boolean blockInteract, boolean restartInterpolation) {
+        this.target = new Target(rotation, Target.Mode.resolve(ctx, blockInteract), restartInterpolation);
     }
 
     @Override
@@ -180,7 +185,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
                 final Rotation start = ctx.playerRotations();
                 final Rotation actual = this.processor.peekRotation(this.target.rotation);
-                this.updateInterpolation(start, actual, ctx.playerHead());
+                this.updateInterpolation(start, actual, ctx.playerHead(), this.target.restartInterpolation);
                 break;
             }
             case POST: {
@@ -201,10 +206,10 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         }
     }
 
-    private void updateInterpolation(Rotation start, Rotation actual, Vec3 origin) {
+    private void updateInterpolation(Rotation start, Rotation actual, Vec3 origin, boolean restartArc) {
         final int interpolationSpeed = Baritone.settings().interpolatedLookLength.value;
 
-        if (this.interpolationArc != null && this.interpolationOriginMoved(origin)) {
+        if (this.interpolationArc != null && (restartArc || this.interpolationOriginMoved(origin))) {
             start = this.interpolationArc.getCurrentRotation();
             this.interpolationArc = null;
         }
@@ -453,10 +458,12 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
         public final Rotation rotation;
         public final Mode mode;
+        public final boolean restartInterpolation;
 
-        public Target(Rotation rotation, Mode mode) {
+        public Target(Rotation rotation, Mode mode, boolean restartInterpolation) {
             this.rotation = rotation;
             this.mode = mode;
+            this.restartInterpolation = restartInterpolation;
         }
 
         enum Mode {

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -88,7 +88,16 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     @Override
     public void updateTarget(Rotation rotation, boolean blockInteract, boolean restartInterpolation) {
-        this.target = new Target(rotation, Target.Mode.resolve(ctx, blockInteract), restartInterpolation);
+        this.updateTarget(rotation, blockInteract, restartInterpolation, false);
+    }
+
+    @Override
+    public void updateTarget(
+            Rotation rotation,
+            boolean blockInteract,
+            boolean restartInterpolation,
+            boolean exactRotation) {
+        this.target = new Target(rotation, Target.Mode.resolve(ctx, blockInteract), restartInterpolation, exactRotation);
     }
 
     @Override
@@ -128,7 +137,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 }
 
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
-                final Rotation actual = this.processor.peekRotation(this.target.rotation);
+                final Rotation actual = this.target.rotation(this.processor);
                 ctx.player().setYRot(actual.getYaw());
                 ctx.player().setXRot(actual.getPitch());
                 break;
@@ -184,7 +193,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
                 final Rotation start = ctx.playerRotations();
-                final Rotation actual = this.processor.peekRotation(this.target.rotation);
+                final Rotation actual = this.target.rotation(this.processor);
                 this.updateInterpolation(start, actual, ctx.playerHead(), this.target.restartInterpolation);
                 break;
             }
@@ -294,7 +303,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     public void pig() {
         if (this.target != null) {
-            final Rotation actual = this.processor.peekRotation(this.target.rotation);
+            final Rotation actual = this.target.rotation(this.processor);
             ctx.player().setYRot(actual.getYaw());
         }
     }
@@ -310,7 +319,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     @Override
     public void onPlayerRotationMove(RotationMoveEvent event) {
         if (this.target != null) {
-            final Rotation actual = this.processor.peekRotation(this.target.rotation);
+            final Rotation actual = this.target.rotation(this.processor);
             event.setYaw(actual.getYaw());
             event.setPitch(actual.getPitch());
         }
@@ -459,11 +468,17 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         public final Rotation rotation;
         public final Mode mode;
         public final boolean restartInterpolation;
+        public final boolean exactRotation;
 
-        public Target(Rotation rotation, Mode mode, boolean restartInterpolation) {
+        public Target(Rotation rotation, Mode mode, boolean restartInterpolation, boolean exactRotation) {
             this.rotation = rotation;
             this.mode = mode;
             this.restartInterpolation = restartInterpolation;
+            this.exactRotation = exactRotation;
+        }
+
+        public Rotation rotation(AimProcessor processor) {
+            return this.exactRotation ? this.rotation : processor.peekRotation(this.rotation);
         }
 
         enum Mode {

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -22,19 +22,21 @@ import baritone.api.Settings;
 import baritone.api.behavior.ILookBehavior;
 import baritone.api.behavior.look.IAimProcessor;
 import baritone.api.behavior.look.ITickableAimProcessor;
-import baritone.api.event.events.*;
+import baritone.api.event.events.PacketEvent;
+import baritone.api.event.events.PlayerUpdateEvent;
+import baritone.api.event.events.RotationMoveEvent;
+import baritone.api.event.events.TickEvent;
+import baritone.api.event.events.WorldEvent;
 import baritone.api.utils.IPlayerContext;
 import baritone.api.utils.Rotation;
 import baritone.api.utils.RotationUtils;
-import baritone.api.utils.VecUtils;
 import baritone.behavior.look.ForkableRandom;
 import baritone.utils.BaritoneMath;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
-
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.world.phys.Vec3;
 
 public final class LookBehavior extends Behavior implements ILookBehavior {
 
@@ -44,7 +46,8 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private Target target;
 
     /**
-     * The rotation known to the server. Returned by {@link #getEffectiveRotation()} for use in {@link IPlayerContext}.
+     * The rotation known to the server. Returned by {@link #getEffectiveRotation()} for use
+     * in {@link IPlayerContext}.
      */
     private Rotation serverRotation;
 
@@ -57,16 +60,12 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     private final AimProcessor processor;
 
-    /**
-     * the interpolation's current stage, to be used by {@link #onPlayerUpdate(PlayerUpdateEvent)} whenever {@link Settings#interpolatedLook} is true.
-     */
-    private static int stage = 0;
-    private static Vec3 Source;
-    private static Vec3 Destiny;
-    private static Vec3 Center;
-
     private final Deque<Float> smoothYawBuffer;
     private final Deque<Float> smoothPitchBuffer;
+    private int interpolationStage;
+    private Vec3 interpolationSource;
+    private Vec3 interpolationTarget;
+    private Vec3 interpolationCenter;
 
     public LookBehavior(Baritone baritone) {
         super(baritone);
@@ -99,154 +98,136 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             return;
         }
 
-        if (!Baritone.settings().interpolatedLook.value) {
-            switch (event.getState()) {
-                //PRE: onPlayerUpdate was called before rotation data was sent to the server
-                case PRE: {
-                    if (this.target.mode == Target.Mode.NONE) {
-                        // Just return for PRE, we still want to set target to null on POST
-                        return;
-                    }
-
-                    this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
-                    final Rotation actual = this.processor.peekRotation(this.target.rotation);
-                    ctx.player().setYRot(actual.getYaw());
-                    ctx.player().setXRot(actual.getPitch());
-                    break;
-                }
-                //POST: onPlayerUpdate was called after rotation data was sent to the server
-                case POST: {
-                    // Reset the player's rotations back to their original values
-                    if (this.prevRotation != null) {
-                        this.smoothYawBuffer.addLast(this.target.rotation.getYaw());
-                        while (this.smoothYawBuffer.size() > Baritone.settings().smoothLookTicks.value) {
-                            this.smoothYawBuffer.removeFirst();
-                        }
-                        this.smoothPitchBuffer.addLast(this.target.rotation.getPitch());
-                        while (this.smoothPitchBuffer.size() > Baritone.settings().smoothLookTicks.value) {
-                            this.smoothPitchBuffer.removeFirst();
-                        }
-                        if (this.target.mode == Target.Mode.SERVER) {
-                            ctx.player().setYRot(this.prevRotation.getYaw());
-                            ctx.player().setXRot(this.prevRotation.getPitch());
-                        } else if (ctx.player().isFallFlying() ? Baritone.settings().elytraSmoothLook.value : Baritone.settings().smoothLook.value) {
-                            ctx.player().setYRot((float) this.smoothYawBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getYaw()));
-                            if (ctx.player().isFallFlying()) {
-                                ctx.player().setXRot((float) this.smoothPitchBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getPitch()));
-                            }
-                        }
-                        //ctx.player().xRotO = prevRotation.getPitch();
-                        //ctx.player().yRotO = prevRotation.getYaw();
-                        this.prevRotation = null;
-                    }
-                    // The target is done being used for this game tick, so it can be invalidated
-                    this.target = null;
-                    break;
-                }
-                default:
-                    break;
-            }
-        }else {
-            // interpolatedLook == true
-            switch (event.getState()) {
-                case PRE: {
-                    if(this.target.mode == Target.Mode.NONE) {
-                        // same security case as above
-                        return;
-                    }
-
-                    this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
-                    final Rotation actual = this.processor.peekRotation(this.target.rotation);
-
-                    if (LookBehavior.stage == 0) {
-                        LookBehavior.Center = ctx.playerHead();
-                        LookBehavior.Source = (RotationUtils.calcLookDirectionFromRotation(this.prevRotation)).add(LookBehavior.Center);
-                        LookBehavior.Destiny = (RotationUtils.calcLookDirectionFromRotation(actual)).add(LookBehavior.Center);
-
-                        RotationUtils.alerp(LookBehavior.Source, LookBehavior.Destiny, LookBehavior.Center, BaritoneMath.normalize(LookBehavior.stage, Baritone.settings().interpolatedLookLength.value)); //debug, CO&PA
-                        LookBehavior.stage ++;
-                        /*
-                        At this point, the camera rotation should still be the same as before, be it that Baritone was traveling or just exited from another mining phase.
-                         */
-                        break;
-
-                    } else if (0 < LookBehavior.stage && LookBehavior.stage < Baritone.settings().interpolatedLookLength.value) {
-                        final Rotation InterpD = RotationUtils.calcRotationFromVec3d(LookBehavior.Center, RotationUtils.alerp(LookBehavior.Source, LookBehavior.Destiny, LookBehavior.Center, BaritoneMath.normalize(LookBehavior.stage, Baritone.settings().interpolatedLookLength.value)), new Rotation(0, 0)); // love:slash:hate relationship with relative vectors
-                        ctx.player().setYRot(InterpD.getYaw());
-                        ctx.player().setXRot(InterpD.getPitch());
-                        LookBehavior.stage ++;
-                        /*
-                        here we enter the main "loop", based on the look stage the player should be looking at any point between the path projected by alerp; at the moment of writing this I'm just assuming that Baritone does a check
-                        to see if the player is looking at the block before starting to do the mining action, and is not some timer-hard-coded value.
-                         */
-                        break;
-
-                    } else if (LookBehavior.stage == Baritone.settings().interpolatedLookLength.value) {
-                        final Rotation InterpD = RotationUtils.calcRotationFromVec3d(LookBehavior.Center, RotationUtils.alerp(LookBehavior.Source, LookBehavior.Destiny, LookBehavior.Center, BaritoneMath.normalize(LookBehavior.stage, Baritone.settings().interpolatedLookLength.value)), new Rotation(0, 0)); // love:slash:hate relationship with relative vectors
-                        ctx.player().setYRot(InterpD.getYaw());
-                        ctx.player().setXRot(InterpD.getPitch());
-                        LookBehavior.stage = 0;
-                        LookBehavior.Source = null;
-                        LookBehavior.Destiny = null;
-                        /*
-                        we've reached the final part of the "loop", after setting rotations we do some cleanup to be able to enter the next mining phase.
-                        Center in theory shouldn't need to be nullified, but let's see...
-                         */
-                        break;
-
-                    } else {
-                        // wtf
-                        LookBehavior.stage = 0;
-                        LookBehavior.Source = null;
-                        LookBehavior.Destiny = null;
-                        // I hate code once debug everywhere
-                        break;
-                        // I really don't know how to debug this edge case
-                    }
-                }
-                case POST: {
-                    // Same as before, I really do wish that both PRE and POST are both done before frame generation, but that would be just not to trigger epilepsy
-                    if (this.prevRotation != null) {
-                        if (this.target.mode == Target.Mode.SERVER) {
-                            ctx.player().setYRot(this.prevRotation.getYaw());
-                            ctx.player().setXRot(this.prevRotation.getPitch());
-                        }// else if (ctx.player().isFallFlying() && Baritone.settings().elytraSmoothLook.value) {
-                        //   ctx.player().setYRot((float) this.smoothYawBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getYaw()));
-                        //   if (ctx.player().isFallFlying()) {
-                        //       ctx.player().setXRot((float) this.smoothPitchBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getPitch()));
-                        //   }
-                        //}
-                        /** TODO: reimplement elytra and falling, again, for interpolatedLook */
-                        //ctx.player().xRotO = prevRotation.getPitch();
-                        //ctx.player().yRotO = prevRotation.getYaw();
-                        if (LookBehavior.stage == Baritone.settings().interpolatedLookLength.value) {
-                            this.prevRotation = null;
-                        }
-                    }
-                    // The target is done being used for this game tick, so it can be invalidated
-                    this.target = null;
-                    break;
-                }
-                default:
-                    break;
-            }
-            /*
-             in paper(not the server software) this should work, but imma add a failed attempts counter...
-             */
-
-            //ATT1: at 10:40PM, 9/18/24 = Compile successful, executing... Stuck looking at 135.1, 0,1
-
-            /*
-            I think I had this problem before when testing alerp in a grapher, sometimes the compilers(ig?) decide that a couple of formulas are wrong because f me, in some others it does work perfectly.
-            I will re-explore all the solutions per grapher.
-             */
-            /*
-            After an embarrassingly long amount of time, I just realized I converted the angle to a vector before doing an alerp, and I need to add that vector to the player head position, otherwise the two points are near (0,0,0).
-            Realized this while debugging, and at the same time I saw that the Static modifier is too powerful(not), it is kept on memory after exiting one server and entering another (including embedded, local or internal server).
-             */
-
-            //ATT2: at 3:05PM, 9/19/24 = Compile successful, executing... works.
+        if (Baritone.settings().interpolatedLook.value) {
+            this.updateInterpolatedTarget(event);
+            return;
         }
+
+        switch (event.getState()) {
+            case PRE: {
+                if (this.target.mode == Target.Mode.NONE) {
+                    // Just return for PRE, we still want to set target to null on POST
+                    return;
+                }
+
+                this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
+                final Rotation actual = this.processor.peekRotation(this.target.rotation);
+                ctx.player().setYRot(actual.getYaw());
+                ctx.player().setXRot(actual.getPitch());
+                break;
+            }
+            case POST: {
+                if (this.prevRotation != null) {
+                    final int smoothLookTicks = Baritone.settings().smoothLookTicks.value;
+                    this.smoothYawBuffer.addLast(this.target.rotation.getYaw());
+                    while (this.smoothYawBuffer.size() > smoothLookTicks) {
+                        this.smoothYawBuffer.removeFirst();
+                    }
+                    this.smoothPitchBuffer.addLast(this.target.rotation.getPitch());
+                    while (this.smoothPitchBuffer.size() > smoothLookTicks) {
+                        this.smoothPitchBuffer.removeFirst();
+                    }
+                    if (this.target.mode == Target.Mode.SERVER) {
+                        ctx.player().setYRot(this.prevRotation.getYaw());
+                        ctx.player().setXRot(this.prevRotation.getPitch());
+                    } else if (ctx.player().isFallFlying()
+                            ? Baritone.settings().elytraSmoothLook.value
+                            : Baritone.settings().smoothLook.value) {
+                        ctx.player().setYRot((float) this.smoothYawBuffer.stream()
+                                .mapToDouble(d -> d)
+                                .average()
+                                .orElse(this.prevRotation.getYaw()));
+                        if (ctx.player().isFallFlying()) {
+                            ctx.player().setXRot((float) this.smoothPitchBuffer.stream()
+                                    .mapToDouble(d -> d)
+                                    .average()
+                                    .orElse(this.prevRotation.getPitch()));
+                        }
+                    }
+                    //ctx.player().xRotO = prevRotation.getPitch();
+                    //ctx.player().yRotO = prevRotation.getYaw();
+                    this.prevRotation = null;
+                }
+                // The target is done being used for this game tick, so it can be invalidated
+                this.target = null;
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    private void updateInterpolatedTarget(PlayerUpdateEvent event) {
+        switch (event.getState()) {
+            case PRE: {
+                if (this.target.mode == Target.Mode.NONE) {
+                    return;
+                }
+
+                this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
+                final Rotation actual = this.processor.peekRotation(this.target.rotation);
+                this.updateInterpolation(actual);
+                break;
+            }
+            case POST: {
+                if (this.prevRotation != null && this.target.mode == Target.Mode.SERVER) {
+                    ctx.player().setYRot(this.prevRotation.getYaw());
+                    ctx.player().setXRot(this.prevRotation.getPitch());
+                }
+                this.prevRotation = null;
+                this.target = null;
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    private void updateInterpolation(Rotation actual) {
+        final int interpolationLength = Baritone.settings().interpolatedLookLength.value;
+
+        if (this.interpolationStage == 0) {
+            this.interpolationCenter = ctx.playerHead();
+            this.interpolationSource = RotationUtils.calcLookDirectionFromRotation(this.prevRotation)
+                    .add(this.interpolationCenter);
+            this.interpolationTarget = RotationUtils.calcLookDirectionFromRotation(actual)
+                    .add(this.interpolationCenter);
+            this.interpolationStage++;
+            return;
+        }
+
+        if (this.interpolationStage < interpolationLength) {
+            this.applyInterpolatedRotation(interpolationLength);
+            this.interpolationStage++;
+            return;
+        }
+
+        if (this.interpolationStage == interpolationLength) {
+            this.applyInterpolatedRotation(interpolationLength);
+        }
+        this.resetInterpolation();
+    }
+
+    private void applyInterpolatedRotation(int interpolationLength) {
+        final Vec3 interpolatedLook = RotationUtils.alerp(
+                this.interpolationSource,
+                this.interpolationTarget,
+                this.interpolationCenter,
+                BaritoneMath.normalize(this.interpolationStage, interpolationLength));
+        final Rotation interpolatedRotation = RotationUtils.calcRotationFromVec3d(
+                this.interpolationCenter,
+                interpolatedLook,
+                new Rotation(0, 0));
+
+        ctx.player().setYRot(interpolatedRotation.getYaw());
+        ctx.player().setXRot(interpolatedRotation.getPitch());
+    }
+
+    private void resetInterpolation() {
+        this.interpolationStage = 0;
+        this.interpolationSource = null;
+        this.interpolationTarget = null;
+        this.interpolationCenter = null;
     }
 
     @Override
@@ -256,7 +237,8 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         }
 
         final ServerboundMovePlayerPacket packet = (ServerboundMovePlayerPacket) event.getPacket();
-        if (packet instanceof ServerboundMovePlayerPacket.Rot || packet instanceof ServerboundMovePlayerPacket.PosRot) {
+        if (packet instanceof ServerboundMovePlayerPacket.Rot
+                || packet instanceof ServerboundMovePlayerPacket.PosRot) {
             this.serverRotation = new Rotation(packet.getYRot(0.0f), packet.getXRot(0.0f));
         }
     }
@@ -265,7 +247,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     public void onWorldEvent(WorldEvent event) {
         this.serverRotation = null;
         this.target = null;
-        LookBehavior.stage = 0;
+        this.resetInterpolation();
     }
 
     public void pig() {
@@ -331,8 +313,8 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             float desiredYaw = rotation.getYaw();
             float desiredPitch = rotation.getPitch();
 
-            // In other words, the target doesn't care about the pitch, so it used playerRotations().getPitch()
-            // and it's safe to adjust it to a normal level
+            // In other words, the target doesn't care about the pitch, so it used
+            // playerRotations().getPitch() and it's safe to adjust it to a normal level
             if (desiredPitch == prev.getPitch()) {
                 desiredPitch = nudgeToLevel(desiredPitch);
             }
@@ -349,8 +331,10 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         @Override
         public final void tick() {
             // randomLooking
-            this.randomYawOffset = (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
-            this.randomPitchOffset = (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
+            this.randomYawOffset =
+                    (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
+            this.randomPitchOffset =
+                    (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
 
             // randomLooking113
             double random = this.rand.nextDouble() - 0.5;
@@ -395,7 +379,9 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         protected abstract Rotation getPrevRotation();
 
         /**
-         * Nudges the player's pitch to a regular level. (Between {@code -20} and {@code 10}, increments are by {@code 1})
+         * Nudges the player's pitch to a regular level.
+         *
+         * <p>Between {@code -20} and {@code 10}, increments are by {@code 1}.
          */
         private float nudgeToLevel(float pitch) {
             if (pitch < -20) {
@@ -419,8 +405,10 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
         private float mouseToAngle(double mouseDelta) {
             // casting float literals to double gets us the precise values used by mc
-            final double f = ctx.minecraft().options.sensitivity().get() * (double) 0.6f + (double) 0.2f;
-            return (float) (mouseDelta * f * f * f * 8.0d) * 0.15f; // yes, one double and one float scaling factor
+            final double f = ctx.minecraft().options.sensitivity().get()
+                    * (double) 0.6f
+                    + (double) 0.2f;
+            return (float) (mouseDelta * f * f * f * 8.0d) * 0.15f;
         }
     }
 
@@ -459,9 +447,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                     // always need to set angles while flying
                     return settings.elytraFreeLook.value ? SERVER : CLIENT;
                 } else if (settings.freeLook.value) {
-                    // Regardless of if antiCheatCompatibility is enabled, if a blockInteract is requested then the player
-                    // rotation needs to be set somehow, otherwise Baritone will halt since objectMouseOver() will just be
-                    // whatever the player is mousing over visually. Let's just settle for setting it silently.
+                    // Regardless of if antiCheatCompatibility is enabled, if a
+                    // blockInteract is requested then the player rotation needs to be
+                    // set somehow, otherwise Baritone will halt since objectMouseOver()
+                    // will just be whatever the player is mousing over visually. Let's
+                    // just settle for setting it silently.
                     if (blockInteract) {
                         return blockFreeLook ? SERVER : CLIENT;
                     }

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -62,10 +62,9 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     private final Deque<Float> smoothYawBuffer;
     private final Deque<Float> smoothPitchBuffer;
-    private int interpolationStage;
-    private Vec3 interpolationSource;
-    private Vec3 interpolationTarget;
-    private Vec3 interpolationCenter;
+    private RotationArc interpolationArc;
+    private Rotation previousArcSample;
+    private Rotation currentArcSample;
 
     public LookBehavior(Baritone baritone) {
         super(baritone);
@@ -165,8 +164,9 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 }
 
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
+                final Rotation start = ctx.playerRotations();
                 final Rotation actual = this.processor.peekRotation(this.target.rotation);
-                this.updateInterpolation(actual);
+                this.updateInterpolation(start, actual);
                 break;
             }
             case POST: {
@@ -183,51 +183,31 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         }
     }
 
-    private void updateInterpolation(Rotation actual) {
+    private void updateInterpolation(Rotation start, Rotation actual) {
         final int interpolationLength = Baritone.settings().interpolatedLookLength.value;
 
-        if (this.interpolationStage == 0) {
-            this.interpolationCenter = ctx.playerHead();
-            this.interpolationSource = RotationUtils.calcLookDirectionFromRotation(this.prevRotation)
-                    .add(this.interpolationCenter);
-            this.interpolationTarget = RotationUtils.calcLookDirectionFromRotation(actual)
-                    .add(this.interpolationCenter);
-            this.interpolationStage++;
-            return;
+        if (this.interpolationArc == null) {
+            this.interpolationArc = new RotationArc(start, actual, interpolationLength);
         }
 
-        if (this.interpolationStage < interpolationLength) {
-            this.applyInterpolatedRotation(interpolationLength);
-            this.interpolationStage++;
-            return;
+        this.previousArcSample = this.interpolationArc.getCurrentRotation();
+        this.currentArcSample = this.interpolationArc.advance();
+        this.applyRotation(this.currentArcSample);
+        this.serverRotation = this.currentArcSample;
+        if (this.interpolationArc.isComplete()) {
+            this.interpolationArc = null;
         }
-
-        if (this.interpolationStage == interpolationLength) {
-            this.applyInterpolatedRotation(interpolationLength);
-        }
-        this.resetInterpolation();
     }
 
-    private void applyInterpolatedRotation(int interpolationLength) {
-        final Vec3 interpolatedLook = RotationUtils.alerp(
-                this.interpolationSource,
-                this.interpolationTarget,
-                this.interpolationCenter,
-                BaritoneMath.normalize(this.interpolationStage, interpolationLength));
-        final Rotation interpolatedRotation = RotationUtils.calcRotationFromVec3d(
-                this.interpolationCenter,
-                interpolatedLook,
-                new Rotation(0, 0));
-
-        ctx.player().setYRot(interpolatedRotation.getYaw());
-        ctx.player().setXRot(interpolatedRotation.getPitch());
+    private void applyRotation(Rotation rotation) {
+        ctx.player().setYRot(rotation.getYaw());
+        ctx.player().setXRot(rotation.getPitch());
     }
 
     private void resetInterpolation() {
-        this.interpolationStage = 0;
-        this.interpolationSource = null;
-        this.interpolationTarget = null;
-        this.interpolationCenter = null;
+        this.interpolationArc = null;
+        this.previousArcSample = null;
+        this.currentArcSample = null;
     }
 
     @Override
@@ -461,6 +441,53 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 // all freeLook settings are disabled so set the angles
                 return CLIENT;
             }
+        }
+    }
+
+    private static final class RotationArc {
+
+        private final Rotation startRotation;
+        private final Rotation targetRotation;
+        private final int length;
+        private int stage;
+
+        private RotationArc(Rotation startRotation, Rotation targetRotation, int length) {
+            this.startRotation = startRotation;
+            this.targetRotation = targetRotation;
+            this.length = Math.max(1, length);
+        }
+
+        private Rotation getCurrentRotation() {
+            return this.arcAt(BaritoneMath.normalize(this.stage, this.length));
+        }
+
+        private Rotation advance() {
+            if (this.stage < this.length) {
+                this.stage++;
+            }
+            return this.getCurrentRotation();
+        }
+
+        private boolean isComplete() {
+            return this.stage >= this.length;
+        }
+
+        private Rotation arcAt(double t) {
+            if (t <= 0) {
+                return this.startRotation;
+            }
+            if (t >= 1) {
+                return this.targetRotation;
+            }
+            final Vec3 source = RotationUtils.calcLookDirectionFromRotation(this.startRotation);
+            final Vec3 target = RotationUtils.calcLookDirectionFromRotation(this.targetRotation);
+            if (source.distanceToSqr(target) < 1.0E-8) {
+                return this.targetRotation;
+            }
+            return RotationUtils.calcRotationFromVec3d(
+                    Vec3.ZERO,
+                    RotationUtils.alerp(source, target, Vec3.ZERO, t),
+                    new Rotation(0, 0));
         }
     }
 }

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -37,8 +37,11 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.world.phys.Vec3;
 
 public final class LookBehavior extends Behavior implements ILookBehavior {
+
+    private static final double ORIGIN_EPSILON = 1.0E-8;
 
     /**
      * The current look target, may be {@code null}.
@@ -63,6 +66,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private final Deque<Float> smoothYawBuffer;
     private final Deque<Float> smoothPitchBuffer;
     private RotationArc interpolationArc;
+    private Vec3 interpolationOrigin;
     private RotationArc pendingRenderArc;
     private RotationArc renderArc;
     private Rotation previousArcSample;
@@ -176,7 +180,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
                 final Rotation start = ctx.playerRotations();
                 final Rotation actual = this.processor.peekRotation(this.target.rotation);
-                this.updateInterpolation(start, actual);
+                this.updateInterpolation(start, actual, ctx.playerHead());
                 break;
             }
             case POST: {
@@ -197,11 +201,17 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         }
     }
 
-    private void updateInterpolation(Rotation start, Rotation actual) {
+    private void updateInterpolation(Rotation start, Rotation actual, Vec3 origin) {
         final int interpolationSpeed = Baritone.settings().interpolatedLookLength.value;
+
+        if (this.interpolationArc != null && this.interpolationOriginMoved(origin)) {
+            start = this.interpolationArc.getCurrentRotation();
+            this.interpolationArc = null;
+        }
 
         if (this.interpolationArc == null) {
             this.interpolationArc = RotationArc.fromAngularSpeed(start, actual, interpolationSpeed);
+            this.interpolationOrigin = origin;
         }
 
         this.previousArcSample = this.interpolationArc.getCurrentRotation();
@@ -211,7 +221,13 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         this.serverRotation = this.currentArcSample;
         if (this.interpolationArc.isComplete()) {
             this.interpolationArc = null;
+            this.interpolationOrigin = null;
         }
+    }
+
+    private boolean interpolationOriginMoved(Vec3 origin) {
+        return this.interpolationOrigin != null
+                && this.interpolationOrigin.distanceToSqr(origin) > ORIGIN_EPSILON;
     }
 
     private void applyRotation(Rotation rotation) {
@@ -242,6 +258,7 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
     private void resetInterpolation() {
         this.interpolationArc = null;
+        this.interpolationOrigin = null;
         this.pendingRenderArc = null;
         this.renderArc = null;
         this.previousArcSample = null;

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -198,10 +198,10 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     }
 
     private void updateInterpolation(Rotation start, Rotation actual) {
-        final int interpolationLength = Baritone.settings().interpolatedLookLength.value;
+        final int interpolationSpeed = Baritone.settings().interpolatedLookLength.value;
 
         if (this.interpolationArc == null) {
-            this.interpolationArc = new RotationArc(start, actual, interpolationLength);
+            this.interpolationArc = RotationArc.fromAngularSpeed(start, actual, interpolationSpeed);
         }
 
         this.previousArcSample = this.interpolationArc.getCurrentRotation();

--- a/src/main/java/baritone/behavior/PathingBehavior.java
+++ b/src/main/java/baritone/behavior/PathingBehavior.java
@@ -36,6 +36,7 @@ import baritone.pathing.path.PathExecutor;
 import baritone.process.ElytraProcess;
 import baritone.utils.PathRenderer;
 import baritone.utils.PathingCommandContext;
+import baritone.utils.PlayerControlGuard;
 import baritone.utils.pathing.Favoring;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -100,6 +101,14 @@ public final class PathingBehavior extends Behavior implements IPathingBehavior,
             return;
         }
 
+        if (!PlayerControlGuard.canControl(ctx)) {
+            pausedThisTick = true;
+            unpausedLastTick = false;
+            baritone.getInputOverrideHandler().clearAllKeys();
+            baritone.getInputOverrideHandler().getBlockBreakHelper().stopBreakingBlock();
+            baritone.getPathingControlManager().preTick();
+            return;
+        }
         expectedSegmentStart = pathStart();
         baritone.getPathingControlManager().preTick();
         tickPath();

--- a/src/main/java/baritone/pathing/movement/Movement.java
+++ b/src/main/java/baritone/pathing/movement/Movement.java
@@ -137,7 +137,8 @@ public abstract class Movement implements IMovement, MovementHelper {
                 baritone.getLookBehavior().updateTarget(
                         rotation,
                         target.hasToForceRotations(),
-                        target.shouldRestartInterpolation()));
+                        target.shouldRestartInterpolation(),
+                        target.isExactRotation()));
         baritone.getInputOverrideHandler().clearAllKeys();
         currentState.getInputStates().forEach((input, forced) -> {
             baritone.getInputOverrideHandler().setInputForceState(input, forced);
@@ -165,7 +166,7 @@ public abstract class Movement implements IMovement, MovementHelper {
                 somethingInTheWay = true;
                 MovementHelper.switchToBestToolFor(ctx, BlockStateInterface.get(ctx, blockPos));
                 if (baritone.getInputOverrideHandler().isBreakingBlock(blockPos)) {
-                    state.setTarget(new MovementState.MovementTarget(ctx.playerRotations(), true, true));
+                    state.setTarget(new MovementState.MovementTarget(ctx.playerRotations(), true, true, true));
                     state.setInput(Input.CLICK_LEFT, true);
                     return false;
                 }

--- a/src/main/java/baritone/pathing/movement/Movement.java
+++ b/src/main/java/baritone/pathing/movement/Movement.java
@@ -30,6 +30,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
 
 public abstract class Movement implements IMovement, MovementHelper {
 
@@ -113,6 +114,37 @@ public abstract class Movement implements IMovement, MovementHelper {
         return getValidPositions().contains(ctx.playerFeet()) || getValidPositions().contains(((PathingBehavior) baritone.getPathingBehavior()).pathStart());
     }
 
+    protected boolean leftClickBlock(MovementState state, BlockPos pos) {
+        if (!ctx.isLookingAt(pos)) {
+            return false;
+        }
+        state.setBlockBreakTarget(pos)
+                .setInput(Input.CLICK_LEFT, true);
+        return true;
+    }
+
+    protected boolean leftClickSelectedBlock(MovementState state) {
+        Optional<BlockPos> selected = ctx.getSelectedBlock();
+        if (!selected.isPresent()) {
+            return false;
+        }
+        state.setBlockBreakTarget(selected.get())
+                .setInput(Input.CLICK_LEFT, true);
+        return true;
+    }
+
+    protected boolean rightClickBlock(MovementState state, BlockPos pos) {
+        Optional<BlockHitResult> selected = ctx.getSelectedBlockHitResult()
+                .filter(hit -> hit.getBlockPos().equals(pos));
+        if (!selected.isPresent()) {
+            return false;
+        }
+        BlockHitResult hit = selected.get();
+        state.setBlockPlaceTarget(hit.getBlockPos(), hit.getDirection())
+                .setInput(Input.CLICK_RIGHT, true);
+        return true;
+    }
+
     /**
      * Handles the execution of the latest Movement
      * State, and offers a Status to the calling class.
@@ -127,7 +159,10 @@ public abstract class Movement implements IMovement, MovementHelper {
             currentState.setInput(Input.JUMP, true);
         }
         if (ctx.player().isInWall()) {
-            ctx.getSelectedBlock().ifPresent(pos -> MovementHelper.switchToBestToolFor(ctx, BlockStateInterface.get(ctx, pos)));
+            ctx.getSelectedBlock().ifPresent(pos -> {
+                MovementHelper.switchToBestToolFor(ctx, BlockStateInterface.get(ctx, pos));
+                currentState.setBlockBreakTarget(pos);
+            });
             currentState.setInput(Input.CLICK_LEFT, true);
         }
 
@@ -188,10 +223,7 @@ public abstract class Movement implements IMovement, MovementHelper {
                 if (reachable.isPresent()) {
                     Rotation rotTowardsBlock = reachable.get();
                     state.setTarget(new MovementState.MovementTarget(rotTowardsBlock, true));
-                    if (ctx.isLookingAt(blockPos)) {
-                        state.setBlockBreakTarget(blockPos)
-                                .setInput(Input.CLICK_LEFT, true);
-                    }
+                    leftClickBlock(state, blockPos);
                     return false;
                 }
                 //get rekt minecraft

--- a/src/main/java/baritone/pathing/movement/Movement.java
+++ b/src/main/java/baritone/pathing/movement/Movement.java
@@ -140,7 +140,8 @@ public abstract class Movement implements IMovement, MovementHelper {
                         target.shouldRestartInterpolation(),
                         target.isExactRotation()));
         baritone.getInputOverrideHandler().clearAllKeys();
-        currentState.getBlockBreakTarget().ifPresent(baritone.getInputOverrideHandler()::setBlockBreakTarget);
+        currentState.getBlockBreakTarget().ifPresent(
+                baritone.getInputOverrideHandler()::setBlockBreakTarget);
         currentState.getBlockPlaceTarget().ifPresent(pos ->
                 currentState.getBlockPlaceSide().ifPresent(side ->
                         baritone.getInputOverrideHandler().setBlockPlaceTarget(pos, side)));
@@ -171,12 +172,19 @@ public abstract class Movement implements IMovement, MovementHelper {
                 somethingInTheWay = true;
                 MovementHelper.switchToBestToolFor(ctx, BlockStateInterface.get(ctx, blockPos));
                 if (baritone.getInputOverrideHandler().isBreakingBlock(blockPos)) {
-                    state.setTarget(new MovementState.MovementTarget(ctx.playerRotations(), true, true, true))
+                    state.setTarget(new MovementState.MovementTarget(
+                                    ctx.playerRotations(),
+                                    true,
+                                    true,
+                                    true))
                             .setBlockBreakTarget(blockPos)
                             .setInput(Input.CLICK_LEFT, true);
                     return false;
                 }
-                Optional<Rotation> reachable = RotationUtils.reachable(ctx, blockPos, ctx.playerController().getBlockReachDistance());
+                Optional<Rotation> reachable = RotationUtils.reachable(
+                        ctx,
+                        blockPos,
+                        ctx.playerController().getBlockReachDistance());
                 if (reachable.isPresent()) {
                     Rotation rotTowardsBlock = reachable.get();
                     state.setTarget(new MovementState.MovementTarget(rotTowardsBlock, true));

--- a/src/main/java/baritone/pathing/movement/Movement.java
+++ b/src/main/java/baritone/pathing/movement/Movement.java
@@ -132,10 +132,12 @@ public abstract class Movement implements IMovement, MovementHelper {
         }
 
         // If the movement target has to force the new rotations, or we aren't using silent move, then force the rotations
-        currentState.getTarget().getRotation().ifPresent(rotation ->
+        MovementState.MovementTarget target = currentState.getTarget();
+        target.getRotation().ifPresent(rotation ->
                 baritone.getLookBehavior().updateTarget(
                         rotation,
-                        currentState.getTarget().hasToForceRotations()));
+                        target.hasToForceRotations(),
+                        target.shouldRestartInterpolation()));
         baritone.getInputOverrideHandler().clearAllKeys();
         currentState.getInputStates().forEach((input, forced) -> {
             baritone.getInputOverrideHandler().setInputForceState(input, forced);
@@ -162,11 +164,16 @@ public abstract class Movement implements IMovement, MovementHelper {
             if (!MovementHelper.canWalkThrough(ctx, blockPos)) { // can't break air, so don't try
                 somethingInTheWay = true;
                 MovementHelper.switchToBestToolFor(ctx, BlockStateInterface.get(ctx, blockPos));
+                if (baritone.getInputOverrideHandler().isBreakingBlock(blockPos)) {
+                    state.setTarget(new MovementState.MovementTarget(ctx.playerRotations(), true, true));
+                    state.setInput(Input.CLICK_LEFT, true);
+                    return false;
+                }
                 Optional<Rotation> reachable = RotationUtils.reachable(ctx, blockPos, ctx.playerController().getBlockReachDistance());
                 if (reachable.isPresent()) {
                     Rotation rotTowardsBlock = reachable.get();
                     state.setTarget(new MovementState.MovementTarget(rotTowardsBlock, true));
-                    if (ctx.isLookingAt(blockPos) || ctx.playerRotations().isReallyCloseTo(rotTowardsBlock)) {
+                    if (ctx.isLookingAt(blockPos)) {
                         state.setInput(Input.CLICK_LEFT, true);
                     }
                     return false;

--- a/src/main/java/baritone/pathing/movement/Movement.java
+++ b/src/main/java/baritone/pathing/movement/Movement.java
@@ -140,10 +140,15 @@ public abstract class Movement implements IMovement, MovementHelper {
                         target.shouldRestartInterpolation(),
                         target.isExactRotation()));
         baritone.getInputOverrideHandler().clearAllKeys();
+        currentState.getBlockBreakTarget().ifPresent(baritone.getInputOverrideHandler()::setBlockBreakTarget);
+        currentState.getBlockPlaceTarget().ifPresent(pos ->
+                currentState.getBlockPlaceSide().ifPresent(side ->
+                        baritone.getInputOverrideHandler().setBlockPlaceTarget(pos, side)));
         currentState.getInputStates().forEach((input, forced) -> {
             baritone.getInputOverrideHandler().setInputForceState(input, forced);
         });
         currentState.getInputStates().clear();
+        currentState.clearBlockInteractionTargets();
 
         // If the current status indicates a completed movement
         if (currentState.getStatus().isComplete()) {
@@ -166,8 +171,9 @@ public abstract class Movement implements IMovement, MovementHelper {
                 somethingInTheWay = true;
                 MovementHelper.switchToBestToolFor(ctx, BlockStateInterface.get(ctx, blockPos));
                 if (baritone.getInputOverrideHandler().isBreakingBlock(blockPos)) {
-                    state.setTarget(new MovementState.MovementTarget(ctx.playerRotations(), true, true, true));
-                    state.setInput(Input.CLICK_LEFT, true);
+                    state.setTarget(new MovementState.MovementTarget(ctx.playerRotations(), true, true, true))
+                            .setBlockBreakTarget(blockPos)
+                            .setInput(Input.CLICK_LEFT, true);
                     return false;
                 }
                 Optional<Rotation> reachable = RotationUtils.reachable(ctx, blockPos, ctx.playerController().getBlockReachDistance());
@@ -175,7 +181,8 @@ public abstract class Movement implements IMovement, MovementHelper {
                     Rotation rotTowardsBlock = reachable.get();
                     state.setTarget(new MovementState.MovementTarget(rotTowardsBlock, true));
                     if (ctx.isLookingAt(blockPos)) {
-                        state.setInput(Input.CLICK_LEFT, true);
+                        state.setBlockBreakTarget(blockPos)
+                                .setInput(Input.CLICK_LEFT, true);
                     }
                     return false;
                 }

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -821,14 +821,16 @@ public interface MovementHelper extends ActionCosts, Helper {
                 }
             }
         }
-        if (ctx.getSelectedBlock().isPresent()) {
-            BlockPos selectedBlock = ctx.getSelectedBlock().get();
-            Direction side = ((BlockHitResult) ctx.objectMouseOver()).getDirection();
+        Optional<BlockHitResult> selected = ctx.getSelectedBlockHitResult();
+        if (selected.isPresent()) {
+            BlockPos selectedBlock = selected.get().getBlockPos();
+            Direction side = selected.get().getDirection();
             // only way for selectedBlock.equals(placeAt) to be true is if it's replaceable
             if (selectedBlock.equals(placeAt) || (MovementHelper.canPlaceAgainst(ctx, selectedBlock) && selectedBlock.relative(side).equals(placeAt))) {
                 if (wouldSneak) {
                     state.setInput(Input.SNEAK, true);
                 }
+                state.setBlockPlaceTarget(selectedBlock, side);
                 ((Baritone) baritone).getInventoryBehavior().selectThrowawayForLocation(true, placeAt.getX(), placeAt.getY(), placeAt.getZ());
                 return PlaceResult.READY_TO_PLACE;
             }

--- a/src/main/java/baritone/pathing/movement/MovementState.java
+++ b/src/main/java/baritone/pathing/movement/MovementState.java
@@ -73,6 +73,7 @@ public class MovementState {
         private boolean forceRotations;
 
         private boolean restartInterpolation;
+        private boolean exactRotation;
 
         public MovementTarget() {
             this(null, false);
@@ -83,9 +84,18 @@ public class MovementState {
         }
 
         public MovementTarget(Rotation rotation, boolean forceRotations, boolean restartInterpolation) {
+            this(rotation, forceRotations, restartInterpolation, false);
+        }
+
+        public MovementTarget(
+                Rotation rotation,
+                boolean forceRotations,
+                boolean restartInterpolation,
+                boolean exactRotation) {
             this.rotation = rotation;
             this.forceRotations = forceRotations;
             this.restartInterpolation = restartInterpolation;
+            this.exactRotation = exactRotation;
         }
 
         public final Optional<Rotation> getRotation() {
@@ -98,6 +108,10 @@ public class MovementState {
 
         public boolean shouldRestartInterpolation() {
             return this.restartInterpolation;
+        }
+
+        public boolean isExactRotation() {
+            return this.exactRotation;
         }
     }
 }

--- a/src/main/java/baritone/pathing/movement/MovementState.java
+++ b/src/main/java/baritone/pathing/movement/MovementState.java
@@ -72,13 +72,20 @@ public class MovementState {
          */
         private boolean forceRotations;
 
+        private boolean restartInterpolation;
+
         public MovementTarget() {
             this(null, false);
         }
 
         public MovementTarget(Rotation rotation, boolean forceRotations) {
+            this(rotation, forceRotations, false);
+        }
+
+        public MovementTarget(Rotation rotation, boolean forceRotations, boolean restartInterpolation) {
             this.rotation = rotation;
             this.forceRotations = forceRotations;
+            this.restartInterpolation = restartInterpolation;
         }
 
         public final Optional<Rotation> getRotation() {
@@ -87,6 +94,10 @@ public class MovementState {
 
         public boolean hasToForceRotations() {
             return this.forceRotations;
+        }
+
+        public boolean shouldRestartInterpolation() {
+            return this.restartInterpolation;
         }
     }
 }

--- a/src/main/java/baritone/pathing/movement/MovementState.java
+++ b/src/main/java/baritone/pathing/movement/MovementState.java
@@ -20,6 +20,8 @@ package baritone.pathing.movement;
 import baritone.api.pathing.movement.MovementStatus;
 import baritone.api.utils.Rotation;
 import baritone.api.utils.input.Input;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +32,9 @@ public class MovementState {
     private MovementStatus status;
     private MovementTarget target = new MovementTarget();
     private final Map<Input, Boolean> inputState = new HashMap<>();
+    private BlockPos blockBreakTarget;
+    private BlockPos blockPlaceTarget;
+    private Direction blockPlaceSide;
 
     public MovementState setStatus(MovementStatus status) {
         this.status = status;
@@ -56,6 +61,35 @@ public class MovementState {
 
     public Map<Input, Boolean> getInputStates() {
         return this.inputState;
+    }
+
+    public MovementState setBlockBreakTarget(BlockPos pos) {
+        this.blockBreakTarget = pos;
+        return this;
+    }
+
+    public Optional<BlockPos> getBlockBreakTarget() {
+        return Optional.ofNullable(this.blockBreakTarget);
+    }
+
+    public MovementState setBlockPlaceTarget(BlockPos pos, Direction side) {
+        this.blockPlaceTarget = pos;
+        this.blockPlaceSide = side;
+        return this;
+    }
+
+    public Optional<BlockPos> getBlockPlaceTarget() {
+        return Optional.ofNullable(this.blockPlaceTarget);
+    }
+
+    public Optional<Direction> getBlockPlaceSide() {
+        return Optional.ofNullable(this.blockPlaceSide);
+    }
+
+    public void clearBlockInteractionTargets() {
+        this.blockBreakTarget = null;
+        this.blockPlaceTarget = null;
+        this.blockPlaceSide = null;
     }
 
     public static class MovementTarget {

--- a/src/main/java/baritone/pathing/movement/MovementState.java
+++ b/src/main/java/baritone/pathing/movement/MovementState.java
@@ -102,7 +102,8 @@ public class MovementState {
         /**
          * Whether or not this target must force rotations.
          * <p>
-         * {@code true} if we're trying to place or break blocks, {@code false} if we're trying to look at the movement location
+         * {@code true} if we're trying to place or break blocks, {@code false}
+         * if we're trying to look at the movement location
          */
         private boolean forceRotations;
 
@@ -117,7 +118,10 @@ public class MovementState {
             this(rotation, forceRotations, false);
         }
 
-        public MovementTarget(Rotation rotation, boolean forceRotations, boolean restartInterpolation) {
+        public MovementTarget(
+                Rotation rotation,
+                boolean forceRotations,
+                boolean restartInterpolation) {
             this(rotation, forceRotations, restartInterpolation, false);
         }
 

--- a/src/main/java/baritone/pathing/movement/movements/MovementFall.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementFall.java
@@ -110,8 +110,8 @@ public class MovementFall extends Movement {
 
                 targetRotation = new Rotation(toDest.getYaw(), 90.0F);
 
-                if (ctx.isLookingAt(dest) || ctx.isLookingAt(dest.below())) {
-                    state.setInput(Input.CLICK_RIGHT, true);
+                if (!rightClickBlock(state, dest)) {
+                    rightClickBlock(state, dest.below());
                 }
             }
         }

--- a/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
@@ -221,10 +221,11 @@ public class MovementPillar extends Movement {
                             .map(rot -> new MovementState.MovementTarget(rot, true))
                             .ifPresent(state::setTarget);
                     state.setInput(Input.JUMP, false); // breaking is like 5x slower when you're jumping
-                    state.setInput(Input.CLICK_LEFT, true);
+                    leftClickBlock(state, src);
                     blockIsThere = false;
-                } else if (ctx.player().isCrouching() && (ctx.isLookingAt(src.below()) || ctx.isLookingAt(src)) && ctx.player().position().y > dest.getY() + 0.1) {
-                    state.setInput(Input.CLICK_RIGHT, true);
+                } else if (ctx.player().isCrouching() && ctx.player().position().y > dest.getY() + 0.1) {
+                    rightClickBlock(state, src.below());
+                    rightClickBlock(state, src);
                 }
             }
         }

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -228,8 +228,15 @@ public class MovementTraverse extends Movement {
             boolean canOpen = !(Blocks.IRON_DOOR.equals(pb0.getBlock()) || Blocks.IRON_DOOR.equals(pb1.getBlock()));
 
             if (notPassable && canOpen) {
-                return state.setTarget(new MovementState.MovementTarget(RotationUtils.calcRotationFromVec3d(ctx.playerHead(), VecUtils.calculateBlockCenter(ctx.world(), positionsToBreak[0]), ctx.playerRotations()), true))
-                        .setInput(Input.CLICK_RIGHT, true);
+                BlockPos blocked = pb0.getBlock() instanceof DoorBlock ? positionsToBreak[0] : positionsToBreak[1];
+                state.setTarget(new MovementState.MovementTarget(
+                        RotationUtils.calcRotationFromVec3d(
+                                ctx.playerHead(),
+                                VecUtils.calculateBlockCenter(ctx.world(), blocked),
+                                ctx.playerRotations()),
+                        true));
+                rightClickBlock(state, blocked);
+                return state;
             }
         }
 
@@ -240,7 +247,9 @@ public class MovementTraverse extends Movement {
             if (blocked != null) {
                 Optional<Rotation> rotation = RotationUtils.reachable(ctx, blocked);
                 if (rotation.isPresent()) {
-                    return state.setTarget(new MovementState.MovementTarget(rotation.get(), true)).setInput(Input.CLICK_RIGHT, true);
+                    state.setTarget(new MovementState.MovementTarget(rotation.get(), true));
+                    rightClickBlock(state, blocked);
+                    return state;
                 }
             }
         }
@@ -316,7 +325,7 @@ public class MovementTraverse extends Movement {
                         }
                     } else if (ctx.playerRotations().isReallyCloseTo(state.getTarget().rotation)) {
                         // well i guess theres something in the way
-                        return state.setInput(Input.CLICK_LEFT, true);
+                        leftClickSelectedBlock(state);
                     }
                     return state;
                 }
@@ -342,12 +351,12 @@ public class MovementTraverse extends Movement {
                 } else {
                     state.setTarget(new MovementState.MovementTarget(backToFace, true));
                 }
-                if (ctx.isLookingAt(goalLook)) {
-                    return state.setInput(Input.CLICK_RIGHT, true); // wait to right click until we are able to place
+                if (rightClickBlock(state, goalLook)) {
+                    return state; // wait to right click until we are able to place
                 }
                 // Out.log("Trying to look at " + goalLook + ", actually looking at" + Baritone.whatAreYouLookingAt());
                 if (ctx.playerRotations().isReallyCloseTo(state.getTarget().rotation)) {
-                    state.setInput(Input.CLICK_LEFT, true);
+                    leftClickSelectedBlock(state);
                 }
                 return state;
             }

--- a/src/main/java/baritone/process/BackfillProcess.java
+++ b/src/main/java/baritone/process/BackfillProcess.java
@@ -79,7 +79,8 @@ public final class BackfillProcess extends BaritoneProcessHelper {
                 case READY_TO_PLACE:
                     fake.getBlockPlaceTarget().ifPresent(pos ->
                             fake.getBlockPlaceSide().ifPresent(side ->
-                                    baritone.getInputOverrideHandler().setBlockPlaceTarget(pos, side)));
+                                    baritone.getInputOverrideHandler()
+                                            .setBlockPlaceTarget(pos, side)));
                     baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
                 case ATTEMPTING:

--- a/src/main/java/baritone/process/BackfillProcess.java
+++ b/src/main/java/baritone/process/BackfillProcess.java
@@ -77,6 +77,9 @@ public final class BackfillProcess extends BaritoneProcessHelper {
                 case NO_OPTION:
                     continue;
                 case READY_TO_PLACE:
+                    fake.getBlockPlaceTarget().ifPresent(pos ->
+                            fake.getBlockPlaceSide().ifPresent(side ->
+                                    baritone.getInputOverrideHandler().setBlockPlaceTarget(pos, side)));
                     baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
                 case ATTEMPTING:

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -577,7 +577,9 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             baritone.getLookBehavior().updateTarget(rot, true);
             ctx.player().getInventory().selected = toPlace.get().hotbarSelection;
             baritone.getInputOverrideHandler().setInputForceState(Input.SNEAK, true);
-            baritone.getInputOverrideHandler().setBlockPlaceTarget(toPlace.get().placeAgainst, toPlace.get().side);
+            baritone.getInputOverrideHandler().setBlockPlaceTarget(
+                    toPlace.get().placeAgainst,
+                    toPlace.get().side);
             if (ctx.isLookingAt(toPlace.get().placeAgainst, toPlace.get().side)) {
                 baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
             }

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -103,6 +103,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
     private int layer;
     private int numRepeats;
     private List<BlockState> approxPlaceable;
+    private Placement heldPlacement;
     public int stopAtHeight = 0;
 
     public BuilderProcess(Baritone baritone) {
@@ -169,6 +170,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         this.numRepeats = 0;
         this.observedCompleted = new LongOpenHashSet();
         this.incorrectPositions = null;
+        this.heldPlacement = null;
     }
 
     public void resume() {
@@ -177,6 +179,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
 
     public void pause() {
         paused = true;
+        this.heldPlacement = null;
     }
 
     @Override
@@ -312,12 +315,19 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
     public static class Placement {
 
         private final int hotbarSelection;
+        private final BlockPos target;
         private final BlockPos placeAgainst;
         private final Direction side;
         private final Rotation rot;
 
-        public Placement(int hotbarSelection, BlockPos placeAgainst, Direction side, Rotation rot) {
+        public Placement(
+                int hotbarSelection,
+                BlockPos target,
+                BlockPos placeAgainst,
+                Direction side,
+                Rotation rot) {
             this.hotbarSelection = hotbarSelection;
+            this.target = target;
             this.placeAgainst = placeAgainst;
             this.side = side;
             this.rot = rot;
@@ -353,6 +363,34 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         return Optional.empty();
     }
 
+    private Optional<Placement> revalidateHeldPlacement(BuilderCalculationContext bcc) {
+        if (this.heldPlacement == null) {
+            return Optional.empty();
+        }
+        BlockPos target = this.heldPlacement.target;
+        BlockState current = bcc.bsi.get0(target);
+        BlockState desired = bcc.getSchematic(target.getX(), target.getY(), target.getZ(), current);
+        if (desired == null
+                || !MovementHelper.isReplaceable(
+                        target.getX(),
+                        target.getY(),
+                        target.getZ(),
+                        current,
+                        bcc.bsi)
+                || valid(current, desired, false)) {
+            this.heldPlacement = null;
+            return Optional.empty();
+        }
+        Optional<Placement> placement = possibleToPlace(
+                desired,
+                target.getX(),
+                target.getY(),
+                target.getZ(),
+                bcc.bsi);
+        this.heldPlacement = placement.orElse(null);
+        return placement;
+    }
+
     public boolean placementPlausible(BlockPos pos, BlockState state) {
         VoxelShape voxelshape = state.getCollisionShape(ctx.world(), pos);
         return voxelshape.isEmpty() || ctx.world().isUnobstructed(null, voxelshape.move(pos.getX(), pos.getY(), pos.getZ()));
@@ -386,7 +424,12 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 if (result != null && result.getType() == HitResult.Type.BLOCK && ((BlockHitResult) result).getBlockPos().equals(placeAgainstPos) && ((BlockHitResult) result).getDirection() == against.getOpposite()) {
                     OptionalInt hotbar = hasAnyItemThatWouldPlace(toPlace, result, actualRot);
                     if (hotbar.isPresent()) {
-                        return Optional.of(new Placement(hotbar.getAsInt(), placeAgainstPos, against.getOpposite(), rot));
+                        return Optional.of(new Placement(
+                                hotbar.getAsInt(),
+                                new BetterBlockPos(x, y, z),
+                                placeAgainstPos,
+                                against.getOpposite(),
+                                rot));
                     }
                 }
             }
@@ -518,6 +561,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             if (Baritone.settings().buildInLayers.value && layer * Baritone.settings().layerHeight.value < stopAtHeight) {
                 logDirect("Starting layer " + layer);
                 layer++;
+                this.heldPlacement = null;
                 return onTick(calcFailed, isSafeToCancel, recursions + 1);
             }
             Vec3i repeat = Baritone.settings().buildRepeat.value;
@@ -534,6 +578,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             // build repeat time
             layer = 0;
             origin = new BlockPos(origin).offset(repeat);
+            this.heldPlacement = null;
             if (!Baritone.settings().buildRepeatSneaky.value) {
                 schematic.reset();
             }
@@ -546,6 +591,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
 
         Optional<Tuple<BetterBlockPos, Rotation>> toBreak = toBreakNearPlayer(bcc);
         if (toBreak.isPresent() && isSafeToCancel && ctx.player().isOnGround()) {
+            this.heldPlacement = null;
             // we'd like to pause to break this block
             // only change look direction if it's safe (don't want to fuck up an in progress parkour for example
             Rotation rot = toBreak.get().getB();
@@ -571,8 +617,12 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             return new PathingCommand(null, PathingCommandType.CANCEL_AND_SET_GOAL);
         }
         List<BlockState> desirableOnHotbar = new ArrayList<>();
-        Optional<Placement> toPlace = searchForPlacables(bcc, desirableOnHotbar);
+        Optional<Placement> toPlace = revalidateHeldPlacement(bcc);
+        if (!toPlace.isPresent()) {
+            toPlace = searchForPlacables(bcc, desirableOnHotbar);
+        }
         if (toPlace.isPresent() && isSafeToCancel && ctx.player().isOnGround() && ticks <= 0) {
+            this.heldPlacement = toPlace.get();
             Rotation rot = toPlace.get().rot;
             baritone.getLookBehavior().updateTarget(rot, true);
             ctx.player().getInventory().selected = toPlace.get().hotbarSelection;
@@ -585,6 +635,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             }
             return new PathingCommand(null, PathingCommandType.CANCEL_AND_SET_GOAL);
         }
+        this.heldPlacement = null;
 
         if (Baritone.settings().allowInventory.value) {
             ArrayList<Integer> usefulSlots = new ArrayList<>();
@@ -1002,6 +1053,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         numRepeats = 0;
         paused = false;
         observedCompleted = null;
+        heldPlacement = null;
     }
 
     @Override

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -550,7 +550,6 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             // only change look direction if it's safe (don't want to fuck up an in progress parkour for example
             Rotation rot = toBreak.get().getB();
             BetterBlockPos pos = toBreak.get().getA();
-            baritone.getLookBehavior().updateTarget(rot, true);
             MovementHelper.switchToBestToolFor(ctx, bcc.get(pos));
             if (ctx.player().isCrouching()) {
                 // really horrible bug where a block is visible for breaking while sneaking but not otherwise
@@ -558,7 +557,13 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 // and is unable since it's unsneaked in the intermediary tick
                 baritone.getInputOverrideHandler().setInputForceState(Input.SNEAK, true);
             }
-            if (ctx.isLookingAt(pos) || ctx.playerRotations().isReallyCloseTo(rot)) {
+            if (baritone.getInputOverrideHandler().isBreakingBlock(pos)) {
+                baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true);
+                baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
+            } else {
+                baritone.getLookBehavior().updateTarget(rot, true);
+            }
+            if (ctx.isLookingAt(pos)) {
                 baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
             }
             return new PathingCommand(null, PathingCommandType.CANCEL_AND_SET_GOAL);

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -558,7 +558,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 baritone.getInputOverrideHandler().setInputForceState(Input.SNEAK, true);
             }
             if (baritone.getInputOverrideHandler().isBreakingBlock(pos)) {
-                baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true);
+                baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true, true);
                 baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
             } else {
                 baritone.getLookBehavior().updateTarget(rot, true);

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -559,11 +559,13 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             }
             if (baritone.getInputOverrideHandler().isBreakingBlock(pos)) {
                 baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true, true);
+                baritone.getInputOverrideHandler().setBlockBreakTarget(pos);
                 baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
             } else {
                 baritone.getLookBehavior().updateTarget(rot, true);
             }
             if (ctx.isLookingAt(pos)) {
+                baritone.getInputOverrideHandler().setBlockBreakTarget(pos);
                 baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
             }
             return new PathingCommand(null, PathingCommandType.CANCEL_AND_SET_GOAL);
@@ -575,7 +577,8 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
             baritone.getLookBehavior().updateTarget(rot, true);
             ctx.player().getInventory().selected = toPlace.get().hotbarSelection;
             baritone.getInputOverrideHandler().setInputForceState(Input.SNEAK, true);
-            if ((ctx.isLookingAt(toPlace.get().placeAgainst) && ((BlockHitResult) ctx.objectMouseOver()).getDirection().equals(toPlace.get().side)) || ctx.playerRotations().isReallyCloseTo(rot)) {
+            baritone.getInputOverrideHandler().setBlockPlaceTarget(toPlace.get().placeAgainst, toPlace.get().side);
+            if (ctx.isLookingAt(toPlace.get().placeAgainst, toPlace.get().side)) {
                 baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
             }
             return new PathingCommand(null, PathingCommandType.CANCEL_AND_SET_GOAL);

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -104,6 +104,22 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         super(baritone);
     }
 
+    private void leftClickBlock(BlockPos pos) {
+        baritone.getInputOverrideHandler().setBlockBreakTarget(pos);
+        baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
+    }
+
+    private void rightClickBlock(BlockPos pos, Direction side) {
+        baritone.getInputOverrideHandler().setBlockPlaceTarget(pos, side);
+        baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
+    }
+
+    private void rightClickSelectedBlock(BlockPos pos) {
+        ctx.getSelectedBlockHitResult()
+                .filter(hit -> hit.getBlockPos().equals(pos))
+                .ifPresent(hit -> rightClickBlock(hit.getBlockPos(), hit.getDirection()));
+    }
+
     @Override
     public boolean isActive() {
         return active;
@@ -278,7 +294,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
                 baritone.getLookBehavior().updateTarget(rot.get(), true);
                 MovementHelper.switchToBestToolFor(ctx, ctx.world().getBlockState(pos));
                 if (ctx.isLookingAt(pos)) {
-                    baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
+                    leftClickBlock(pos);
                 }
                 return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
             }
@@ -295,8 +311,8 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
                 HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), rot.get(), blockReachDistance);
                 if (result instanceof BlockHitResult && ((BlockHitResult) result).getDirection() == Direction.UP) {
                     baritone.getLookBehavior().updateTarget(rot.get(), true);
-                    if (ctx.isLookingAt(pos)) {
-                        baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
+                    if (ctx.isLookingAt(pos, Direction.UP)) {
+                        rightClickBlock(pos, Direction.UP);
                     }
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
                 }
@@ -316,8 +332,8 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
                     HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), rot.get(), blockReachDistance);
                     if (result instanceof BlockHitResult && ((BlockHitResult) result).getDirection() == dir) {
                         baritone.getLookBehavior().updateTarget(rot.get(), true);
-                        if (ctx.isLookingAt(pos)) {
-                            baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
+                        if (ctx.isLookingAt(pos, dir)) {
+                            rightClickBlock(pos, dir);
                         }
                         return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
                     }
@@ -332,7 +348,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             if (rot.isPresent() && isSafeToCancel && baritone.getInventoryBehavior().throwaway(true, this::isBoneMeal)) {
                 baritone.getLookBehavior().updateTarget(rot.get(), true);
                 if (ctx.isLookingAt(pos)) {
-                    baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
+                    rightClickSelectedBlock(pos);
                 }
                 return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
             }

--- a/src/main/java/baritone/process/GetToBlockProcess.java
+++ b/src/main/java/baritone/process/GetToBlockProcess.java
@@ -35,6 +35,7 @@ import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
 
 import java.util.*;
 
@@ -214,7 +215,13 @@ public final class GetToBlockProcess extends BaritoneProcessHelper implements IG
             Optional<Rotation> reachable = RotationUtils.reachable(ctx, pos, ctx.playerController().getBlockReachDistance());
             if (reachable.isPresent()) {
                 baritone.getLookBehavior().updateTarget(reachable.get(), true);
-                if (knownLocations.contains(ctx.getSelectedBlock().orElse(null))) {
+                Optional<BlockHitResult> selected = ctx.getSelectedBlockHitResult()
+                        .filter(hit -> knownLocations.contains(hit.getBlockPos()));
+                if (selected.isPresent()) {
+                    BlockHitResult hit = selected.get();
+                    baritone.getInputOverrideHandler().setBlockPlaceTarget(
+                            hit.getBlockPos(),
+                            hit.getDirection());
                     baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true); // TODO find some way to right click even if we're in an ESC menu
                     System.out.println(ctx.player().containerMenu);
                     if (!(ctx.player().containerMenu instanceof InventoryMenu)) {

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -126,7 +126,11 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
             if (!MovementHelper.avoidBreaking(baritone.bsi, pos.getX(), pos.getY(), pos.getZ(), state)) {
                 MovementHelper.switchToBestToolFor(ctx, ctx.world().getBlockState(pos));
                 if (isSafeToCancel && baritone.getInputOverrideHandler().isBreakingBlock(pos)) {
-                    baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true, true);
+                    baritone.getLookBehavior().updateTarget(
+                            ctx.playerRotations(),
+                            true,
+                            true,
+                            true);
                     baritone.getInputOverrideHandler().setBlockBreakTarget(pos);
                     baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -124,11 +124,16 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
             BlockPos pos = shaft.get();
             BlockState state = baritone.bsi.get0(pos);
             if (!MovementHelper.avoidBreaking(baritone.bsi, pos.getX(), pos.getY(), pos.getZ(), state)) {
+                MovementHelper.switchToBestToolFor(ctx, ctx.world().getBlockState(pos));
+                if (isSafeToCancel && baritone.getInputOverrideHandler().isBreakingBlock(pos)) {
+                    baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true);
+                    baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
+                    return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
+                }
                 Optional<Rotation> rot = RotationUtils.reachable(ctx, pos);
                 if (rot.isPresent() && isSafeToCancel) {
                     baritone.getLookBehavior().updateTarget(rot.get(), true);
-                    MovementHelper.switchToBestToolFor(ctx, ctx.world().getBlockState(pos));
-                    if (ctx.isLookingAt(pos) || ctx.playerRotations().isReallyCloseTo(rot.get())) {
+                    if (ctx.isLookingAt(pos)) {
                         baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
                     }
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -126,7 +126,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
             if (!MovementHelper.avoidBreaking(baritone.bsi, pos.getX(), pos.getY(), pos.getZ(), state)) {
                 MovementHelper.switchToBestToolFor(ctx, ctx.world().getBlockState(pos));
                 if (isSafeToCancel && baritone.getInputOverrideHandler().isBreakingBlock(pos)) {
-                    baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true);
+                    baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true, true);
                     baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
                 }

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -127,6 +127,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
                 MovementHelper.switchToBestToolFor(ctx, ctx.world().getBlockState(pos));
                 if (isSafeToCancel && baritone.getInputOverrideHandler().isBreakingBlock(pos)) {
                     baritone.getLookBehavior().updateTarget(ctx.playerRotations(), true, true, true);
+                    baritone.getInputOverrideHandler().setBlockBreakTarget(pos);
                     baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
                 }
@@ -134,6 +135,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
                 if (rot.isPresent() && isSafeToCancel) {
                     baritone.getLookBehavior().updateTarget(rot.get(), true);
                     if (ctx.isLookingAt(pos)) {
+                        baritone.getInputOverrideHandler().setBlockBreakTarget(pos);
                         baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_LEFT, true);
                     }
                     return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);

--- a/src/main/java/baritone/utils/BaritoneMath.java
+++ b/src/main/java/baritone/utils/BaritoneMath.java
@@ -34,4 +34,9 @@ public final class BaritoneMath {
     public static int fastCeil(final double v) {
         return FLOOR_DOUBLE_I - (int) (FLOOR_DOUBLE_D - v);
     }
+
+    public static double normalize(double value, double maxValue) {
+        if (maxValue == 0) return 0;
+        return value/maxValue;
+    }
 }

--- a/src/main/java/baritone/utils/BaritoneMath.java
+++ b/src/main/java/baritone/utils/BaritoneMath.java
@@ -36,7 +36,9 @@ public final class BaritoneMath {
     }
 
     public static double normalize(double value, double maxValue) {
-        if (maxValue == 0) return 0;
-        return value/maxValue;
+        if (maxValue == 0) {
+            return 0;
+        }
+        return value / maxValue;
     }
 }

--- a/src/main/java/baritone/utils/BlockBreakHelper.java
+++ b/src/main/java/baritone/utils/BlockBreakHelper.java
@@ -52,7 +52,7 @@ public final class BlockBreakHelper {
     }
 
     public boolean isBreakingBlock(BlockPos pos) {
-        return wasHitting && pos.equals(breakingBlock);
+        return wasHitting && pos.equals(breakingBlock) && ctx.isLookingAt(pos);
     }
 
     public void tick(boolean isLeftClick) {

--- a/src/main/java/baritone/utils/BlockBreakHelper.java
+++ b/src/main/java/baritone/utils/BlockBreakHelper.java
@@ -62,7 +62,8 @@ public final class BlockBreakHelper {
         }
         HitResult trace = ctx.objectMouseOver();
         boolean isBlockTrace = trace != null && trace.getType() == HitResult.Type.BLOCK;
-        if (target != null && (!isBlockTrace || !((BlockHitResult) trace).getBlockPos().equals(target))) {
+        if (target != null
+                && (!isBlockTrace || !((BlockHitResult) trace).getBlockPos().equals(target))) {
             clearBreakingBlock();
             return;
         }
@@ -72,10 +73,14 @@ public final class BlockBreakHelper {
             ctx.playerController().setHittingBlock(wasHitting);
             if (ctx.playerController().hasBrokenBlock()) {
                 ctx.playerController().syncHeldItem();
-                ctx.playerController().clickBlock(blockTrace.getBlockPos(), blockTrace.getDirection());
+                ctx.playerController().clickBlock(
+                        blockTrace.getBlockPos(),
+                        blockTrace.getDirection());
                 ctx.player().swing(InteractionHand.MAIN_HAND);
             } else {
-                if (ctx.playerController().onPlayerDamageBlock(blockTrace.getBlockPos(), blockTrace.getDirection())) {
+                if (ctx.playerController().onPlayerDamageBlock(
+                        blockTrace.getBlockPos(),
+                        blockTrace.getDirection())) {
                     ctx.player().swing(InteractionHand.MAIN_HAND);
                 }
                 if (ctx.playerController().hasBrokenBlock()) { // block broken this tick

--- a/src/main/java/baritone/utils/BlockBreakHelper.java
+++ b/src/main/java/baritone/utils/BlockBreakHelper.java
@@ -20,6 +20,7 @@ package baritone.utils;
 import baritone.api.BaritoneAPI;
 import baritone.api.utils.IPlayerContext;
 import baritone.utils.accessor.IPlayerControllerMP;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -34,6 +35,7 @@ public final class BlockBreakHelper {
 
     private final IPlayerContext ctx;
     private boolean wasHitting;
+    private BlockPos breakingBlock;
     private int breakDelayTimer = 0;
 
     BlockBreakHelper(IPlayerContext ctx) {
@@ -45,8 +47,12 @@ public final class BlockBreakHelper {
         if (ctx.player() != null && wasHitting) {
             ctx.playerController().setHittingBlock(false);
             ctx.playerController().resetBlockRemoving();
-            wasHitting = false;
+            clearBreakingBlock();
         }
+    }
+
+    public boolean isBreakingBlock(BlockPos pos) {
+        return wasHitting && pos.equals(breakingBlock);
     }
 
     public void tick(boolean isLeftClick) {
@@ -58,13 +64,14 @@ public final class BlockBreakHelper {
         boolean isBlockTrace = trace != null && trace.getType() == HitResult.Type.BLOCK;
 
         if (isLeftClick && isBlockTrace) {
+            BlockHitResult blockTrace = (BlockHitResult) trace;
             ctx.playerController().setHittingBlock(wasHitting);
             if (ctx.playerController().hasBrokenBlock()) {
                 ctx.playerController().syncHeldItem();
-                ctx.playerController().clickBlock(((BlockHitResult) trace).getBlockPos(), ((BlockHitResult) trace).getDirection());
+                ctx.playerController().clickBlock(blockTrace.getBlockPos(), blockTrace.getDirection());
                 ctx.player().swing(InteractionHand.MAIN_HAND);
             } else {
-                if (ctx.playerController().onPlayerDamageBlock(((BlockHitResult) trace).getBlockPos(), ((BlockHitResult) trace).getDirection())) {
+                if (ctx.playerController().onPlayerDamageBlock(blockTrace.getBlockPos(), blockTrace.getDirection())) {
                     ctx.player().swing(InteractionHand.MAIN_HAND);
                 }
                 if (ctx.playerController().hasBrokenBlock()) { // block broken this tick
@@ -76,12 +83,22 @@ public final class BlockBreakHelper {
             }
             // if true, we're breaking a block. if false, we broke the block this tick
             wasHitting = !ctx.playerController().hasBrokenBlock();
+            if (wasHitting) {
+                breakingBlock = blockTrace.getBlockPos();
+            } else {
+                clearBreakingBlock();
+            }
             // this value will be reset by the MC client handling mouse keys
             // since we're not spoofing the click keybind to the client, the client will stop the break if isDestroyingBlock is true
             // we store and restore this value on the next tick to determine if we're breaking a block
             ctx.playerController().setHittingBlock(false);
         } else {
-            wasHitting = false;
+            clearBreakingBlock();
         }
+    }
+
+    private void clearBreakingBlock() {
+        wasHitting = false;
+        breakingBlock = null;
     }
 }

--- a/src/main/java/baritone/utils/BlockBreakHelper.java
+++ b/src/main/java/baritone/utils/BlockBreakHelper.java
@@ -55,13 +55,17 @@ public final class BlockBreakHelper {
         return wasHitting && pos.equals(breakingBlock) && ctx.isLookingAt(pos);
     }
 
-    public void tick(boolean isLeftClick) {
+    public void tick(boolean isLeftClick, BlockPos target) {
         if (breakDelayTimer > 0) {
             breakDelayTimer--;
             return;
         }
         HitResult trace = ctx.objectMouseOver();
         boolean isBlockTrace = trace != null && trace.getType() == HitResult.Type.BLOCK;
+        if (target != null && (!isBlockTrace || !((BlockHitResult) trace).getBlockPos().equals(target))) {
+            clearBreakingBlock();
+            return;
+        }
 
         if (isLeftClick && isBlockTrace) {
             BlockHitResult blockTrace = (BlockHitResult) trace;

--- a/src/main/java/baritone/utils/BlockPlaceHelper.java
+++ b/src/main/java/baritone/utils/BlockPlaceHelper.java
@@ -19,6 +19,8 @@ package baritone.utils;
 
 import baritone.Baritone;
 import baritone.api.utils.IPlayerContext;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.phys.BlockHitResult;
@@ -35,7 +37,7 @@ public class BlockPlaceHelper {
         this.ctx = playerContext;
     }
 
-    public void tick(boolean rightClickRequested) {
+    public void tick(boolean rightClickRequested, BlockPos target, Direction side) {
         if (rightClickTimer > 0) {
             rightClickTimer--;
             return;
@@ -44,9 +46,13 @@ public class BlockPlaceHelper {
         if (!rightClickRequested || ctx.player().isHandsBusy() || mouseOver == null || mouseOver.getType() != HitResult.Type.BLOCK) {
             return;
         }
+        BlockHitResult blockHit = (BlockHitResult) mouseOver;
+        if (target != null && (!blockHit.getBlockPos().equals(target) || blockHit.getDirection() != side)) {
+            return;
+        }
         rightClickTimer = Baritone.settings().rightClickSpeed.value - BASE_PLACE_DELAY;
         for (InteractionHand hand : InteractionHand.values()) {
-            if (ctx.playerController().processRightClickBlock(ctx.player(), ctx.world(), hand, (BlockHitResult) mouseOver) == InteractionResult.SUCCESS) {
+            if (ctx.playerController().processRightClickBlock(ctx.player(), ctx.world(), hand, blockHit) == InteractionResult.SUCCESS) {
                 ctx.player().swing(hand);
                 return;
             }

--- a/src/main/java/baritone/utils/BlockPlaceHelper.java
+++ b/src/main/java/baritone/utils/BlockPlaceHelper.java
@@ -38,23 +38,55 @@ public class BlockPlaceHelper {
     }
 
     public void tick(boolean rightClickRequested, BlockPos target, Direction side) {
+        if (this.isCoolingDown()) {
+            return;
+        }
+
+        BlockHitResult blockHit = this.targetedBlockHit(rightClickRequested, target, side);
+        if (blockHit == null) {
+            return;
+        }
+
+        rightClickTimer = Baritone.settings().rightClickSpeed.value - BASE_PLACE_DELAY;
+        this.tryRightClick(blockHit);
+    }
+
+    private boolean isCoolingDown() {
         if (rightClickTimer > 0) {
             rightClickTimer--;
-            return;
+            return true;
         }
+        return false;
+    }
+
+    private BlockHitResult targetedBlockHit(
+            boolean rightClickRequested,
+            BlockPos target,
+            Direction side) {
+        if (!rightClickRequested || ctx.player().isHandsBusy()) {
+            return null;
+        }
+
         HitResult mouseOver = ctx.objectMouseOver();
-        if (!rightClickRequested
-                || ctx.player().isHandsBusy()
-                || mouseOver == null
+        if (mouseOver == null
                 || mouseOver.getType() != HitResult.Type.BLOCK) {
-            return;
+            return null;
         }
+
         BlockHitResult blockHit = (BlockHitResult) mouseOver;
-        if (target != null
-                && (!blockHit.getBlockPos().equals(target) || blockHit.getDirection() != side)) {
-            return;
+        if (!this.matchesTarget(blockHit, target, side)) {
+            return null;
         }
-        rightClickTimer = Baritone.settings().rightClickSpeed.value - BASE_PLACE_DELAY;
+
+        return blockHit;
+    }
+
+    private boolean matchesTarget(BlockHitResult blockHit, BlockPos target, Direction side) {
+        return target == null
+                || (blockHit.getBlockPos().equals(target) && blockHit.getDirection() == side);
+    }
+
+    private void tryRightClick(BlockHitResult blockHit) {
         for (InteractionHand hand : InteractionHand.values()) {
             if (ctx.playerController().processRightClickBlock(
                     ctx.player(),

--- a/src/main/java/baritone/utils/BlockPlaceHelper.java
+++ b/src/main/java/baritone/utils/BlockPlaceHelper.java
@@ -43,20 +43,32 @@ public class BlockPlaceHelper {
             return;
         }
         HitResult mouseOver = ctx.objectMouseOver();
-        if (!rightClickRequested || ctx.player().isHandsBusy() || mouseOver == null || mouseOver.getType() != HitResult.Type.BLOCK) {
+        if (!rightClickRequested
+                || ctx.player().isHandsBusy()
+                || mouseOver == null
+                || mouseOver.getType() != HitResult.Type.BLOCK) {
             return;
         }
         BlockHitResult blockHit = (BlockHitResult) mouseOver;
-        if (target != null && (!blockHit.getBlockPos().equals(target) || blockHit.getDirection() != side)) {
+        if (target != null
+                && (!blockHit.getBlockPos().equals(target) || blockHit.getDirection() != side)) {
             return;
         }
         rightClickTimer = Baritone.settings().rightClickSpeed.value - BASE_PLACE_DELAY;
         for (InteractionHand hand : InteractionHand.values()) {
-            if (ctx.playerController().processRightClickBlock(ctx.player(), ctx.world(), hand, blockHit) == InteractionResult.SUCCESS) {
+            if (ctx.playerController().processRightClickBlock(
+                    ctx.player(),
+                    ctx.world(),
+                    hand,
+                    blockHit) == InteractionResult.SUCCESS) {
                 ctx.player().swing(hand);
                 return;
             }
-            if (!ctx.player().getItemInHand(hand).isEmpty() && ctx.playerController().processRightClick(ctx.player(), ctx.world(), hand) == InteractionResult.SUCCESS) {
+            if (!ctx.player().getItemInHand(hand).isEmpty()
+                    && ctx.playerController().processRightClick(
+                            ctx.player(),
+                            ctx.world(),
+                            hand) == InteractionResult.SUCCESS) {
                 return;
             }
         }

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -120,7 +120,10 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
             setInputForceState(Input.CLICK_RIGHT, false);
         }
         blockBreakHelper.tick(isInputForcedDown(Input.CLICK_LEFT), blockBreakTarget);
-        blockPlaceHelper.tick(isInputForcedDown(Input.CLICK_RIGHT), blockPlaceTarget, blockPlaceSide);
+        blockPlaceHelper.tick(
+                isInputForcedDown(Input.CLICK_RIGHT),
+                blockPlaceTarget,
+                blockPlaceSide);
 
         if (inControl()) {
             if (ctx.player().input.getClass() != PlayerMovementInput.class) {
@@ -148,7 +151,9 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
 
     private void restorePlayerInput() {
         LocalPlayer player = ctx.player();
-        if (player != null && player.input != null && player.input.getClass() == PlayerMovementInput.class) {
+        if (player != null
+                && player.input != null
+                && player.input.getClass() == PlayerMovementInput.class) {
             player.input = new KeyboardInput(ctx.minecraft().options);
         }
     }

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -25,6 +25,7 @@ import baritone.api.utils.input.Input;
 import baritone.behavior.Behavior;
 import net.minecraft.client.player.KeyboardInput;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +47,9 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
 
     private final BlockBreakHelper blockBreakHelper;
     private final BlockPlaceHelper blockPlaceHelper;
+    private BlockPos blockBreakTarget;
+    private BlockPos blockPlaceTarget;
+    private Direction blockPlaceSide;
 
     public InputOverrideHandler(Baritone baritone) {
         super(baritone);
@@ -81,11 +85,25 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
     @Override
     public final void clearAllKeys() {
         this.inputForceStateMap.clear();
+        this.blockBreakTarget = null;
+        this.blockPlaceTarget = null;
+        this.blockPlaceSide = null;
     }
 
     @Override
     public boolean isBreakingBlock(BlockPos pos) {
         return this.blockBreakHelper.isBreakingBlock(pos);
+    }
+
+    @Override
+    public void setBlockBreakTarget(BlockPos pos) {
+        this.blockBreakTarget = pos;
+    }
+
+    @Override
+    public void setBlockPlaceTarget(BlockPos pos, Direction side) {
+        this.blockPlaceTarget = pos;
+        this.blockPlaceSide = side;
     }
 
     @Override
@@ -96,8 +114,8 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         if (isInputForcedDown(Input.CLICK_LEFT)) {
             setInputForceState(Input.CLICK_RIGHT, false);
         }
-        blockBreakHelper.tick(isInputForcedDown(Input.CLICK_LEFT));
-        blockPlaceHelper.tick(isInputForcedDown(Input.CLICK_RIGHT));
+        blockBreakHelper.tick(isInputForcedDown(Input.CLICK_LEFT), blockBreakTarget);
+        blockPlaceHelper.tick(isInputForcedDown(Input.CLICK_RIGHT), blockPlaceTarget, blockPlaceSide);
 
         if (inControl()) {
             if (ctx.player().input.getClass() != PlayerMovementInput.class) {

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -24,6 +24,7 @@ import baritone.api.utils.IInputOverrideHandler;
 import baritone.api.utils.input.Input;
 import baritone.behavior.Behavior;
 import net.minecraft.client.player.KeyboardInput;
+import net.minecraft.core.BlockPos;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -80,6 +81,11 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
     @Override
     public final void clearAllKeys() {
         this.inputForceStateMap.clear();
+    }
+
+    @Override
+    public boolean isBreakingBlock(BlockPos pos) {
+        return this.blockBreakHelper.isBreakingBlock(pos);
     }
 
     @Override

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -24,6 +24,7 @@ import baritone.api.utils.IInputOverrideHandler;
 import baritone.api.utils.input.Input;
 import baritone.behavior.Behavior;
 import net.minecraft.client.player.KeyboardInput;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 
@@ -111,6 +112,10 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         if (event.getType() == TickEvent.Type.OUT) {
             return;
         }
+        if (!PlayerControlGuard.canControl(ctx)) {
+            stopControllingPlayer();
+            return;
+        }
         if (isInputForcedDown(Input.CLICK_LEFT)) {
             setInputForceState(Input.CLICK_RIGHT, false);
         }
@@ -128,6 +133,24 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         }
         // only set it if it was previously incorrect
         // gotta do it this way, or else it constantly thinks you're beginning a double tap W sprint lol
+    }
+
+    @Override
+    public void onPlayerDeath() {
+        stopControllingPlayer();
+    }
+
+    private void stopControllingPlayer() {
+        clearAllKeys();
+        blockBreakHelper.stopBreakingBlock();
+        restorePlayerInput();
+    }
+
+    private void restorePlayerInput() {
+        LocalPlayer player = ctx.player();
+        if (player != null && player.input != null && player.input.getClass() == PlayerMovementInput.class) {
+            player.input = new KeyboardInput(ctx.minecraft().options);
+        }
     }
 
     private boolean inControl() {

--- a/src/main/java/baritone/utils/PathingControlManager.java
+++ b/src/main/java/baritone/utils/PathingControlManager.java
@@ -86,6 +86,10 @@ public class PathingControlManager implements IPathingControlManager {
     public void preTick() {
         inControlLastTick = inControlThisTick;
         inControlThisTick = null;
+        if (!PlayerControlGuard.canControl(baritone.getPlayerContext())) {
+            command = null;
+            return;
+        }
         PathingBehavior p = baritone.getPathingBehavior();
         command = executeProcesses();
         if (command == null) {
@@ -126,6 +130,10 @@ public class PathingControlManager implements IPathingControlManager {
     }
 
     private void postTick() {
+        if (!PlayerControlGuard.canControl(baritone.getPlayerContext())) {
+            command = null;
+            return;
+        }
         // if we did this in pretick, it would suck
         // we use the time between ticks as calculation time
         // therefore, we only cancel and recalculate after the tick for the current path has executed

--- a/src/main/java/baritone/utils/PlayerControlGuard.java
+++ b/src/main/java/baritone/utils/PlayerControlGuard.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils;
+
+import baritone.api.utils.IPlayerContext;
+import net.minecraft.client.gui.screens.DeathScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.player.LocalPlayer;
+
+public final class PlayerControlGuard {
+
+    private PlayerControlGuard() {}
+
+    public static boolean canControl(IPlayerContext ctx) {
+        return canControl(ctx.player(), ctx.minecraft().screen)
+                && ctx.world() != null
+                && !ctx.minecraft().isPaused();
+    }
+
+    public static boolean canControl(LocalPlayer player, Screen screen) {
+        if (player == null || !player.isAlive()) {
+            return false;
+        }
+        return screen == null || (!screen.isPauseScreen() && !(screen instanceof DeathScreen));
+    }
+}

--- a/src/main/java/baritone/utils/PlayerControlGuard.java
+++ b/src/main/java/baritone/utils/PlayerControlGuard.java
@@ -24,7 +24,8 @@ import net.minecraft.client.player.LocalPlayer;
 
 public final class PlayerControlGuard {
 
-    private PlayerControlGuard() {}
+    private PlayerControlGuard() {
+    }
 
     public static boolean canControl(IPlayerContext ctx) {
         return canControl(ctx.player(), ctx.minecraft().screen)

--- a/src/test/java/baritone/utils/RotationUtilsTest.java
+++ b/src/test/java/baritone/utils/RotationUtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils;
+
+import baritone.api.utils.RotationUtils;
+import net.minecraft.world.phys.Vec3;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RotationUtilsTest {
+
+    private static final double EPSILON = 1.0E-10;
+
+    @Test
+    public void testAlerpIdenticalPoints() {
+        Vec3 point = new Vec3(1, 2, 3);
+
+        assertVecEquals(point, RotationUtils.alerp(point, point, Vec3.ZERO, 0.5));
+    }
+
+    @Test
+    public void testAlerpZeroVectorFallsBackToLine() {
+        assertVecEquals(
+                new Vec3(0.5, 0, 0),
+                RotationUtils.alerp(Vec3.ZERO, new Vec3(2, 0, 0), Vec3.ZERO, 0.25));
+    }
+
+    @Test
+    public void testAlerpSameRayFallsBackToLine() {
+        assertVecEquals(
+                new Vec3(1.5, 0, 0),
+                RotationUtils.alerp(new Vec3(1, 0, 0), new Vec3(2, 0, 0), Vec3.ZERO, 0.5));
+    }
+
+    @Test
+    public void testAlerpOppositeRayUsesStableHalfCircle() {
+        assertVecEquals(
+                new Vec3(0, 0, 1),
+                RotationUtils.alerp(new Vec3(1, 0, 0), new Vec3(-1, 0, 0), Vec3.ZERO, 0.5));
+    }
+
+    private static void assertVecEquals(Vec3 expected, Vec3 actual) {
+        assertEquals(expected.x, actual.x, EPSILON);
+        assertEquals(expected.y, actual.y, EPSILON);
+        assertEquals(expected.z, actual.z, EPSILON);
+    }
+}

--- a/src/test/java/baritone/utils/RotationUtilsTest.java
+++ b/src/test/java/baritone/utils/RotationUtilsTest.java
@@ -61,13 +61,22 @@ public class RotationUtilsTest {
     public void testRotationArcUsesAngularSpeed() {
         assertEquals(
                 1,
-                countTicks(RotationArc.fromAngularSpeed(new Rotation(0, 0), new Rotation(10, 0), 30)));
+                countTicks(RotationArc.fromAngularSpeed(
+                        new Rotation(0, 0),
+                        new Rotation(10, 0),
+                        30)));
         assertEquals(
                 3,
-                countTicks(RotationArc.fromAngularSpeed(new Rotation(0, 0), new Rotation(90, 0), 30)));
+                countTicks(RotationArc.fromAngularSpeed(
+                        new Rotation(0, 0),
+                        new Rotation(90, 0),
+                        30)));
         assertEquals(
                 4,
-                countTicks(RotationArc.fromAngularSpeed(new Rotation(0, 0), new Rotation(91, 0), 30)));
+                countTicks(RotationArc.fromAngularSpeed(
+                        new Rotation(0, 0),
+                        new Rotation(91, 0),
+                        30)));
     }
 
     @Test

--- a/src/test/java/baritone/utils/RotationUtilsTest.java
+++ b/src/test/java/baritone/utils/RotationUtilsTest.java
@@ -70,6 +70,14 @@ public class RotationUtilsTest {
                 countTicks(RotationArc.fromAngularSpeed(new Rotation(0, 0), new Rotation(91, 0), 30)));
     }
 
+    @Test
+    public void testRotationArcAvoidsViewPole() {
+        RotationArc arc = new RotationArc(new Rotation(0, 80), new Rotation(180, 80), 10);
+
+        assertEquals(90, arc.arcAt(0.5).getYaw(), 1.0E-4);
+        assertEquals(80, arc.arcAt(0.5).getPitch(), 1.0E-4);
+    }
+
     private static void assertVecEquals(Vec3 expected, Vec3 actual) {
         assertEquals(expected.x, actual.x, EPSILON);
         assertEquals(expected.y, actual.y, EPSILON);

--- a/src/test/java/baritone/utils/RotationUtilsTest.java
+++ b/src/test/java/baritone/utils/RotationUtilsTest.java
@@ -17,7 +17,9 @@
 
 package baritone.utils;
 
+import baritone.api.utils.Rotation;
 import baritone.api.utils.RotationUtils;
+import baritone.api.utils.RotationUtils.RotationArc;
 import net.minecraft.world.phys.Vec3;
 import org.junit.Test;
 
@@ -55,9 +57,31 @@ public class RotationUtilsTest {
                 RotationUtils.alerp(new Vec3(1, 0, 0), new Vec3(-1, 0, 0), Vec3.ZERO, 0.5));
     }
 
+    @Test
+    public void testRotationArcUsesAngularSpeed() {
+        assertEquals(
+                1,
+                countTicks(RotationArc.fromAngularSpeed(new Rotation(0, 0), new Rotation(10, 0), 30)));
+        assertEquals(
+                3,
+                countTicks(RotationArc.fromAngularSpeed(new Rotation(0, 0), new Rotation(90, 0), 30)));
+        assertEquals(
+                4,
+                countTicks(RotationArc.fromAngularSpeed(new Rotation(0, 0), new Rotation(91, 0), 30)));
+    }
+
     private static void assertVecEquals(Vec3 expected, Vec3 actual) {
         assertEquals(expected.x, actual.x, EPSILON);
         assertEquals(expected.y, actual.y, EPSILON);
         assertEquals(expected.z, actual.z, EPSILON);
+    }
+
+    private static int countTicks(RotationArc arc) {
+        int ticks = 0;
+        while (!arc.isComplete()) {
+            arc.advance();
+            ticks++;
+        }
+        return ticks;
     }
 }


### PR DESCRIPTION
Replaced old, in many cases not working "smoothlook" with "interpolatedLook", which forces global player rotation in both axis to follow a "path" from source looking position(rotation) to target, removing jittering when, for instance, mining blocks; it WILL hinder baritone's default mining speed, but the main purpose is to make actions seem slightly more humanly possible, time of the interpolation is controlled by interpolatedLookLength, in ticks.

<!-- No UwU's or OwO's allowed -->
