### PR TITLE
Update Java version used by Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt update -y
 
 RUN apt install \
-          openjdk-17-jdk \
+          openjdk-21-jdk \
 	  git \
           --assume-yes
 


### PR DESCRIPTION
In 6b2fd5aceea2d09a04ce431b8a46261cb50ac428 the java version used to build baritone was bumped from 17 to 21, but the Docker build was not updated accordingly.