### PR TITLE
Allow walking on soul sand once again

### DIFF
--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -429,7 +429,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         if (block == Blocks.LADDER || (block == Blocks.VINE && Baritone.settings().allowVines.value)) { // TODO reconsider this
             return YES;
         }
-        if (block == Blocks.FARMLAND || block == Blocks.DIRT_PATH) {
+        if (block == Blocks.FARMLAND || block == Blocks.DIRT_PATH || block == Blocks.SOUL_SAND) {
             return YES;
         }
         if (block == Blocks.ENDER_CHEST || block == Blocks.CHEST || block == Blocks.TRAPPED_CHEST) {


### PR DESCRIPTION
Looks like at some point soul sand stopped being a normal cube (I think they lowered it's collision height?) so we need a special case to walk over it.

No consideration was given to where in the if-else chain the new check should be placed.

Fixes #4497
Closes #2795
Fixes #1550
Closes #1877
<!-- No UwU's or OwO's allowed -->
