### PR TITLE
fix litematica remapping error

### DIFF
--- a/src/main/java/baritone/utils/schematic/litematica/LitematicaHelper.java
+++ b/src/main/java/baritone/utils/schematic/litematica/LitematicaHelper.java
@@ -29,6 +29,7 @@ import fi.dy.masa.litematica.world.WorldSchematic;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.util.Tuple;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
@@ -98,7 +99,7 @@ public final class LitematicaHelper {
         int minY = Integer.MAX_VALUE;
         int minZ = Integer.MAX_VALUE;
         HashMap<Vec3i, StaticSchematic> subRegions = new HashMap<>();
-        WorldSchematic schematicWorld = SchematicWorldHandler.getSchematicWorld();
+        Level schematicWorld = SchematicWorldHandler.getSchematicWorld();
         for (Map.Entry<String, SubRegionPlacement> entry : placement.getEnabledRelativeSubRegionPlacements().entrySet()) {
             SubRegionPlacement subPlacement = entry.getValue();
             Vec3i pos = transform(subPlacement.getPos(), placement.getMirror(), placement.getRotation());


### PR DESCRIPTION
fixes unimined not remapping `schematicWorld.getBlockState` to intermediary.

this PR should be merged forward, this issue is also present in 1.21.x

stacktrace:

```
[00:09:45] [Render thread/INFO]: [CHAT] [Baritone] > litematica
[00:09:45] [Render thread/INFO]: [CHAT] [Baritone] An unhandled exception occurred. The error is in your game's log, please report this at https://github.com/cabaletta/baritone/issues
...
[00:09:45] [Render thread/INFO]: [STDERR]: Caused by: java.lang.NoSuchMethodError: 'net.minecraft.class_2680 fi.dy.masa.litematica.world.WorldSchematic.getBlockState(net.minecraft.class_2338)'
[00:09:45] [Render thread/INFO]: [STDERR]: 	at baritone.utils.schematic.litematica.LitematicaHelper.getSchematic(LitematicaHelper.java:119)
[00:09:45] [Render thread/INFO]: [STDERR]: 	at baritone.process.BuilderProcess.buildOpenLitematic(BuilderProcess.java:237)
[00:09:45] [Render thread/INFO]: [STDERR]: 	at baritone.command.defaults.LitematicaCommand.execute(LitematicaCommand.java:39)
[00:09:45] [Render thread/INFO]: [STDERR]: 	at baritone.command.manager.CommandManager$ExecutionWrapper.execute(CommandManager.java:143)
```