### PR TITLE
Some `#farm` improvements

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -982,25 +982,43 @@ public final class Settings {
     public final Setting<Integer> farmMaxScanSize = new Setting<>(256);
 
     /**
-     * Prioritize gathering farm related drops
+     * Prioritize pickup crop drops before another farm task
      */
-    public final Setting<Boolean> farmPrioritizeGather = new Setting<>(false);
+    public final Setting<Boolean> farmPrioritizePickup = new Setting<>(false);
 
     /**
      * true = farm farm farm, i don't want to stop!
-            * false = allow farm to stop or fail
+     * false = allow farm to stop or fail
      */
     public final Setting<Boolean> farmContinuously = new Setting<>(false);
 
     /**
-     * How much farming task is enough for the Continuous Farm to resume?
+     * How much farm task queue is enough for Baritone to resume the continuous farm?
+     * {@link #farmContinuously}
      */
     public final Setting<Integer> farmContinuouslyThreshold = new Setting<>(16);
 
     /**
-     * Time interval (in seconds) for the Continuous Farm to check if threshold is fulfilled?
+     * How long Baritone should wait (in seconds) to check if continuous farm threshold is fulfilled?
+     * {@link #farmContinuously}
      */
     public final Setting<Long> farmContinuouslyIntervalSecs = new Setting<>(TimeUnit.MINUTES.toSeconds(2));
+
+    /**
+     * Farm whitelist, only interact with crop that is on the {@link #farmWhitelist} list
+     */
+    public final Setting<Boolean> farmEnableWhitelist = new Setting<>(false);
+
+    /**
+     * Crop block that Baritone is allowed to farm and collect
+     * {@link #farmEnableWhitelist}
+     */
+
+    public final Setting<List<Block>> farmWhitelist = new Setting<>(new ArrayList<>(Arrays.asList(
+            Blocks.WHEAT,
+            Blocks.POTATOES,
+            Blocks.CARROTS
+    )));
 
     /**
      * When the cache scan gives less blocks than the maximum threshold (but still above zero), scan the main world too.

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -982,6 +982,22 @@ public final class Settings {
     public final Setting<Integer> farmMaxScanSize = new Setting<>(256);
 
     /**
+     * true = farm farm farm, i don't want to stop!
+            * false = allow farm to stop or fail
+     */
+    public final Setting<Boolean> farmContinuously = new Setting<>(false);
+
+    /**
+     * How much farming task is enough for the Continuous Farm to resume?
+     */
+    public final Setting<Integer> farmContinuouslyThreshold = new Setting<>(16);
+
+    /**
+     * Time interval (in seconds) for the Continuous Farm to check if threshold is fulfilled?
+     */
+    public final Setting<Long> farmContinuouslyIntervalSecs = new Setting<>(TimeUnit.MINUTES.toSeconds(2));
+
+    /**
      * When the cache scan gives less blocks than the maximum threshold (but still above zero), scan the main world too.
      * <p>
      * Only if you have a beefy CPU and automatically mine blocks that are in cache
@@ -1397,7 +1413,7 @@ public final class Settings {
     /**
      * Desktop notification on farm fail
      */
-    public final Setting<Boolean> notificationOnFarmFail = new Setting<>(true);
+    public final Setting<Boolean> notificationOnFarmProcess = new Setting<>(true);
 
     /**
      * Desktop notification on build finished

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -982,6 +982,11 @@ public final class Settings {
     public final Setting<Integer> farmMaxScanSize = new Setting<>(256);
 
     /**
+     * Prioritize gathering farm related drops
+     */
+    public final Setting<Boolean> farmPrioritizeGather = new Setting<>(false);
+
+    /**
      * true = farm farm farm, i don't want to stop!
             * false = allow farm to stop or fail
      */

--- a/src/api/java/baritone/api/process/IFarmProcess.java
+++ b/src/api/java/baritone/api/process/IFarmProcess.java
@@ -22,6 +22,12 @@ import net.minecraft.core.BlockPos;
 public interface IFarmProcess extends IBaritoneProcess {
 
     /**
+     * Resume or pause the Farm Continuously
+     */
+    void pause();
+    void resume();
+
+    /**
      * Begin to search for crops to farm with in specified aria
      * from specified location.
      *

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -296,6 +296,18 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
 
         // Farm Continuously: Block input while paused
         if (!isPaused()) {
+            // Check if item gather is prioritized
+            if (Baritone.settings().farmPrioritizeGather.value) {
+                for (Entity entity : ctx.entities()) {
+                    if (entity instanceof ItemEntity && entity.onGround()) {
+                        ItemEntity ei = (ItemEntity) entity;
+                        if (PICKUP_DROPPED.contains(ei.getItem().getItem())) {
+                            // +0.1 because of farmland's 0.9375 and soulsand's 0.875 dummy height lol
+                            return new PathingCommand(new GoalBlock(new BetterBlockPos(entity.position().x, entity.position().y + 0.125, entity.position().z)), PathingCommandType.SET_GOAL_AND_PATH);
+                        }
+                    }
+                }
+            }
             baritone.getInputOverrideHandler().clearAllKeys();
             BetterBlockPos playerPos = ctx.playerFeet();
             double blockReachDistance = ctx.playerController().getBlockReachDistance();

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -298,14 +298,18 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
         if (!isPaused()) {
             // Check if item gather is prioritized
             if (Baritone.settings().farmPrioritizeGather.value) {
+                List<Goal> pickupGoals = new ArrayList<>();
                 for (Entity entity : ctx.entities()) {
                     if (entity instanceof ItemEntity && entity.onGround()) {
                         ItemEntity ei = (ItemEntity) entity;
                         if (PICKUP_DROPPED.contains(ei.getItem().getItem())) {
                             // +0.1 because of farmland's 0.9375 and soulsand's 0.875 dummy height lol
-                            return new PathingCommand(new GoalBlock(new BetterBlockPos(entity.position().x, entity.position().y + 0.125, entity.position().z)), PathingCommandType.SET_GOAL_AND_PATH);
+                            pickupGoals.add(new GoalBlock(new BetterBlockPos(entity.position().x, entity.position().y + 0.125, entity.position().z)));
                         }
                     }
+                }
+                if (!(pickupGoals.isEmpty())) {
+                    return new PathingCommand(new GoalComposite(pickupGoals.toArray(new Goal[0])), PathingCommandType.SET_GOAL_AND_PATH);
                 }
             }
             baritone.getInputOverrideHandler().clearAllKeys();

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -445,7 +445,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             if (Baritone.settings().notificationOnFarmProcess.value) {
                 logNotification("Farm standby", false);
             }
-            return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
+            return new PathingCommand(null, PathingCommandType.SET_GOAL_AND_PATH);
         }
         if (isPaused()) {
             // Farm Continuously: Reset the interval if the amount of goals can't fulfill the threshold
@@ -466,6 +466,8 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
     @Override
     public void onLostControl() {
         active = false;
+        this.paused = false;
+        this.time = null;
     }
 
     @Override

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -379,8 +379,8 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             if (entity instanceof ItemEntity && entity.onGround()) {
                 ItemEntity ei = (ItemEntity) entity;
                 if (PICKUP_DROPPED.contains(ei.getItem().getItem())) {
-                    // +0.1 because of farmland's 0.9375 dummy height lol
-                    goalz.add(new GoalBlock(new BetterBlockPos(entity.position().x, entity.position().y + 0.1, entity.position().z)));
+                    // +0.1 because of farmland's 0.9375 and soulsand's 0.875 dummy height lol
+                    goalz.add(new GoalBlock(new BetterBlockPos(entity.position().x, entity.position().y + 0.125, entity.position().z)));
                 }
             }
         }

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -300,6 +300,10 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             if (Baritone.settings().farmPrioritizeGather.value) {
                 List<Goal> pickupGoals = new ArrayList<>();
                 for (Entity entity : ctx.entities()) {
+                    //check if the pickupGoals is out of range.
+                    if (range != 0 && entity.blockPosition().distSqr(center) > range * range) {
+                        continue;
+                    }
                     if (entity instanceof ItemEntity && entity.onGround()) {
                         ItemEntity ei = (ItemEntity) entity;
                         if (PICKUP_DROPPED.contains(ei.getItem().getItem())) {
@@ -425,6 +429,10 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             }
         }
         for (Entity entity : ctx.entities()) {
+            //check if the pickupGoals is out of range.
+            if (range != 0 && entity.blockPosition().distSqr(center) > range * range) {
+                continue;
+            }
             if (entity instanceof ItemEntity && entity.onGround()) {
                 ItemEntity ei = (ItemEntity) entity;
                 if (PICKUP_DROPPED.contains(ei.getItem().getItem())) {


### PR DESCRIPTION
added options:
- farm continuously, configurable task threshold and check interval
- farm whitelist for crop and pickup
- farm prioritize pickup

changed:
- farm compensate pickup pos on soulsand
- farm pickup now respect `#farm <range>` 

partially resolves #396 #893 #3537
closes #775 #2315 