### PR TITLE
add(Settings): added settings to control block placement in fluid sources and flowing fluids

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -78,6 +78,16 @@ public final class Settings {
     public final Setting<Boolean> allowPlace = new Setting<>(true);
 
     /**
+     * Allow Baritone to place blocks in fluid source blocks
+     */
+    public final Setting<Boolean> allowPlaceInFluidsSource = new Setting<>(true);
+
+    /**
+     * Allow Baritone to place blocks in flowing fluid
+     */
+    public final Setting<Boolean> allowPlaceInFluidsFlow = new Setting<>(true);
+
+    /**
      * Allow Baritone to move items in your inventory to your hotbar
      */
     public final Setting<Boolean> allowInventory = new Setting<>(false);

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -189,6 +189,12 @@ public class CalculationContext {
         if (!worldBorder.canPlaceAt(x, z)) {
             return COST_INF;
         }
+        if (current.getFluidState().isSource() && !Baritone.settings().allowPlaceInFluidsSource.value) {
+            return COST_INF;
+        }
+        if (!current.getFluidState().isEmpty() && !current.getFluidState().isSource() && !Baritone.settings().allowPlaceInFluidsFlow.value) {
+            return COST_INF;
+        }
         return placeBlockCost;
     }
 


### PR DESCRIPTION
### Summary
This PR introduces new settings to control block placement in fluid sources and flowing fluids within the Baritone pathfinding system.

### Changes
- **Settings.java**
  - Added `allowPlaceInFluidsSource` setting to control block placement in fluid source blocks.
  - Added `allowPlaceInFluidsFlow` setting to control block placement in flowing fluids.

- **CalculationContext.java**
  - Updated `costOfPlacingAt` method to respect the new settings `allowPlaceInFluidsSource` and `allowPlaceInFluidsFlow`.

### Motivation
These changes provide more granular control over block placement behavior in different fluid states, enhancing the flexibility and customization of the Baritone pathfinding system. Previously, the pathfinder could place blocks in flowing fluids, which could cause unintended rerouting of the fluids and potentially lead to dangerous situations, such as walking into lava. By introducing these settings, users can prevent block placement in fluid sources and flowing fluids, thereby improving the safety and reliability of the pathfinding process.

### Testing
- Verified that blocks are not placed in fluid sources when `allowPlaceInFluidsSource` is set to `false`.
- Verified that blocks are not placed in flowing fluids when `allowPlaceInFluidsFlow` is set to `false`.

### Related Issues
#2840 
There are probably more, but I'm too lazy to look for them.