### PR TITLE
add(Settings): added settings to control block placement in fluid sources and flowing fluids

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -78,6 +78,16 @@ public final class Settings {
     public final Setting<Boolean> allowPlace = new Setting<>(true);
 
     /**
+     * Allow Baritone to place blocks in fluid source blocks
+     */
+    public final Setting<Boolean> allowPlaceInFluidsSource = new Setting<>(true);
+
+    /**
+     * Allow Baritone to place blocks in flowing fluid
+     */
+    public final Setting<Boolean> allowPlaceInFluidsFlow = new Setting<>(true);
+
+    /**
      * Allow Baritone to move items in your inventory to your hotbar
      */
     public final Setting<Boolean> allowInventory = new Setting<>(false);

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -161,10 +161,10 @@ public class CalculationContext {
         if (!worldBorder.canPlaceAt(x, z)) {
             return COST_INF;
         }
-        if (current.getFluidState().isSource() && !Baritone.settings().allowPlaceInFluidsSource.value) {
+        if (!Baritone.settings().allowPlaceInFluidsSource.value && current.getFluidState().isSource()) {
             return COST_INF;
         }
-        if (!current.getFluidState().isEmpty() && !current.getFluidState().isSource() && !Baritone.settings().allowPlaceInFluidsFlow.value) {
+        if (!Baritone.settings().allowPlaceInFluidsFlow.value && !current.getFluidState().isEmpty() && !current.getFluidState().isSource()) {
             return COST_INF;
         }
         return placeBlockCost;

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -161,6 +161,12 @@ public class CalculationContext {
         if (!worldBorder.canPlaceAt(x, z)) {
             return COST_INF;
         }
+        if (current.getFluidState().isSource() && !Baritone.settings().allowPlaceInFluidsSource.value) {
+            return COST_INF;
+        }
+        if (!current.getFluidState().isEmpty() && !current.getFluidState().isSource() && !Baritone.settings().allowPlaceInFluidsFlow.value) {
+            return COST_INF;
+        }
         return placeBlockCost;
     }
 


### PR DESCRIPTION
> [!IMPORTANT] 
> This PR previously existed for version 1.21.4.  
>  
> First of all, thanks for your response in #4633!  
>  
> To address your questions (@ZacSharp):  
> Here is an example demonstrating the feature in action:  
> **Video:** https://www.youtube.com/watch?v=gQQUcJAelg0
>  
> The video also illustrates how this impacts both the pathfinding and builder processes. As shown, the builder process remains unaffected because the `costOfPlacingAt` method is overridden ([Source Code](https://github.com/cabaletta/baritone/blob/a5668532b16f2c2be0b9221b2e3038a0a807822c/src/main/java/baritone/process/BuilderProcess.java#L1114-L1146)).  
>  
> If anything remains unclear, I’d be happy to clarify further and make any necessary adjustments to this PR.  

### Summary
This PR introduces new settings to control block placement in fluid sources and flowing fluids within the Baritone pathfinding system.

### Changes
- **Settings.java**
  - Added `allowPlaceInFluidsSource` setting to control block placement in fluid source blocks.
  - Added `allowPlaceInFluidsFlow` setting to control block placement in flowing fluids.

- **CalculationContext.java**
  - Updated `costOfPlacingAt` method to respect the new settings `allowPlaceInFluidsSource` and `allowPlaceInFluidsFlow`.

### Motivation
These changes provide more granular control over block placement behavior in different fluid states, enhancing the flexibility and customization of the Baritone pathfinding system. Previously, the pathfinder could place blocks in flowing fluids, which could cause unintended rerouting of the fluids and potentially lead to dangerous situations, such as walking into lava. By introducing these settings, users can prevent block placement in fluid sources and flowing fluids, thereby improving the safety and reliability of the pathfinding process.

### Testing
- Verified that blocks are not placed in fluid sources when `allowPlaceInFluidsSource` is set to `false`.
- Verified that blocks are not placed in flowing fluids when `allowPlaceInFluidsFlow` is set to `false`.

### Related Issues
#2840 
There are probably more, but I'm too lazy to look for them.