### PR TITLE
fix chuckpacker y bug

### DIFF
--- a/src/main/java/baritone/cache/ChunkPacker.java
+++ b/src/main/java/baritone/cache/ChunkPacker.java
@@ -78,7 +78,7 @@ public final class ChunkPacker {
                         for (int x = 0; x < 16; x++) {
                             int index = CachedChunk.getPositionIndex(x, y, z);
                             BlockState state = bsc.get(x, y1, z);
-                            boolean[] bits = getPathingBlockType(state, chunk, x, y, z).getBits();
+                            boolean[] bits = getPathingBlockType(state, chunk, x, y + chunk.getMinBuildHeight(), z).getBits();
                             bitSet.set(index, bits[0]);
                             bitSet.set(index + 1, bits[1]);
                             Block block = state.getBlock();


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->
`y` in `pack` is already normalized to 0 - 384 and `getPathingBlockType` was trying to normalize it again, causing `adjY` to be offset 64 blocks, which caused an oobe in the call to `BlockStateInterface.getFromChunk`.
The exception got caught but the result seems to be that special blocks close to the build limit didn't get cached.
This probably also broke the caching of water.