### PR TITLE
add(ToolSet): implement fortune level check for crop harvesting

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -887,6 +887,11 @@ public final class Settings {
     public final Setting<Boolean> preferSilkTouch = new Setting<>(false);
 
     /**
+     * Always use the highest fortune tool when farming crops.
+     */
+    public final Setting<Boolean> useFortuneForCrops = new Setting<>(false);
+
+    /**
      * Don't stop walking forward when you need to break blocks in your way
      */
     public final Setting<Boolean> walkWhileBreaking = new Setting<>(true);
@@ -1623,7 +1628,8 @@ public final class Settings {
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
-    private @interface JavaOnly {}
+    private @interface JavaOnly {
+    }
 
     // here be dragons
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -1628,8 +1628,7 @@ public final class Settings {
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
-    private @interface JavaOnly {
-    }
+    private @interface JavaOnly {}
 
     // here be dragons
 

--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -139,29 +139,29 @@ public class ToolSet {
             if (Baritone.settings().itemSaver.value && (itemStack.getDamageValue() + Baritone.settings().itemSaverThreshold.value) >= itemStack.getMaxDamage() && itemStack.getMaxDamage() > 1) {
                 continue;
             }
-            int fortuneLevel = getFortuneLevel(itemStack);
-            if (isCrop && fortuneLevel > highestFortune && Baritone.settings().useFortuneForCrops.value) {
-                highestFortune = fortuneLevel;
+
+            double speed = calculateSpeedVsBlock(itemStack, blockState);
+            boolean silkTouch = hasSilkTouch(itemStack);
+            if (speed > highestSpeed) {
+                highestSpeed = speed;
                 best = i;
                 lowestCost = getMaterialCost(itemStack);
-                bestSilkTouch = hasSilkTouch(itemStack);
-            } else if (highestFortune == 0) {
-                double speed = calculateSpeedVsBlock(itemStack, blockState);
-                boolean silkTouch = hasSilkTouch(itemStack);
-                if (speed > highestSpeed) {
+                bestSilkTouch = silkTouch;
+            } else if (speed == highestSpeed) {
+                int cost = getMaterialCost(itemStack);
+                int fortuneLevel = getFortuneLevel(itemStack);
+                if (Baritone.settings().useFortuneForCrops.value && isCrop && ((fortuneLevel >= highestFortune && cost < lowestCost) || (fortuneLevel > highestFortune && highestFortune == 0))) {
                     highestSpeed = speed;
                     best = i;
-                    lowestCost = getMaterialCost(itemStack);
+                    lowestCost = cost;
                     bestSilkTouch = silkTouch;
-                } else if (speed == highestSpeed) {
-                    int cost = getMaterialCost(itemStack);
-                    if ((cost < lowestCost && (silkTouch || !bestSilkTouch)) ||
-                            (preferSilkTouch && !bestSilkTouch && silkTouch)) {
-                        highestSpeed = speed;
-                        best = i;
-                        lowestCost = cost;
-                        bestSilkTouch = silkTouch;
-                    }
+                    highestFortune = fortuneLevel;
+                } else if ((cost < lowestCost && highestFortune == 0 && (silkTouch || !bestSilkTouch)) ||
+                        (preferSilkTouch && !bestSilkTouch && silkTouch)) {
+                    highestSpeed = speed;
+                    best = i;
+                    lowestCost = cost;
+                    bestSilkTouch = silkTouch;
                 }
             }
         }

--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -150,7 +150,7 @@ public class ToolSet {
             } else if (speed == highestSpeed) {
                 int cost = getMaterialCost(itemStack);
                 int fortuneLevel = getFortuneLevel(itemStack);
-                if (Baritone.settings().useFortuneForCrops.value && isCrop && ((fortuneLevel >= highestFortune && cost < lowestCost) || (fortuneLevel > highestFortune && highestFortune == 0))) {
+                if (Baritone.settings().useFortuneForCrops.value && isCrop && (fortuneLevel > highestFortune || (fortuneLevel == highestFortune && cost < lowestCost))) {
                     highestSpeed = speed;
                     best = i;
                     lowestCost = cost;

--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -156,8 +156,8 @@ public class ToolSet {
                     lowestCost = cost;
                     bestSilkTouch = silkTouch;
                     highestFortune = fortuneLevel;
-                } else if ((cost < lowestCost && highestFortune == 0 && (silkTouch || !bestSilkTouch)) ||
-                        (preferSilkTouch && !bestSilkTouch && silkTouch)) {
+                } else if (highestFortune == 0 && ((cost < lowestCost && (silkTouch || !bestSilkTouch)) ||
+                        (preferSilkTouch && !bestSilkTouch && silkTouch))) {
                     highestSpeed = speed;
                     best = i;
                     lowestCost = cost;

--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -26,6 +26,7 @@ import net.minecraft.world.item.TieredItem;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.HashMap;
@@ -96,6 +97,10 @@ public class ToolSet {
         return EnchantmentHelper.getItemEnchantmentLevel(Enchantments.SILK_TOUCH, stack) > 0;
     }
 
+    public int getFortuneLevel(ItemStack stack) {
+        return EnchantmentHelper.getItemEnchantmentLevel(Enchantments.BLOCK_FORTUNE, stack);
+    }
+
     /**
      * Calculate which tool on the hotbar is best for mining, depending on an override setting,
      * related to auto tool movement cost, it will either return current selected slot, or the best slot.
@@ -123,6 +128,8 @@ public class ToolSet {
         int lowestCost = Integer.MIN_VALUE;
         boolean bestSilkTouch = false;
         BlockState blockState = b.defaultBlockState();
+        boolean isCrop = b instanceof CropBlock;
+        int highestFortune = 0;
         for (int i = 0; i < 9; i++) {
             ItemStack itemStack = player.getInventory().getItem(i);
             if (!Baritone.settings().useSwordToMine.value && itemStack.getItem() instanceof SwordItem) {
@@ -132,21 +139,29 @@ public class ToolSet {
             if (Baritone.settings().itemSaver.value && (itemStack.getDamageValue() + Baritone.settings().itemSaverThreshold.value) >= itemStack.getMaxDamage() && itemStack.getMaxDamage() > 1) {
                 continue;
             }
-            double speed = calculateSpeedVsBlock(itemStack, blockState);
-            boolean silkTouch = hasSilkTouch(itemStack);
-            if (speed > highestSpeed) {
-                highestSpeed = speed;
+            int fortuneLevel = getFortuneLevel(itemStack);
+            if (isCrop && fortuneLevel > highestFortune && Baritone.settings().useFortuneForCrops.value) {
+                highestFortune = fortuneLevel;
                 best = i;
                 lowestCost = getMaterialCost(itemStack);
-                bestSilkTouch = silkTouch;
-            } else if (speed == highestSpeed) {
-                int cost = getMaterialCost(itemStack);
-                if ((cost < lowestCost && (silkTouch || !bestSilkTouch)) ||
-                        (preferSilkTouch && !bestSilkTouch && silkTouch)) {
+                bestSilkTouch = hasSilkTouch(itemStack);
+            } else if (highestFortune == 0) {
+                double speed = calculateSpeedVsBlock(itemStack, blockState);
+                boolean silkTouch = hasSilkTouch(itemStack);
+                if (speed > highestSpeed) {
                     highestSpeed = speed;
                     best = i;
-                    lowestCost = cost;
+                    lowestCost = getMaterialCost(itemStack);
                     bestSilkTouch = silkTouch;
+                } else if (speed == highestSpeed) {
+                    int cost = getMaterialCost(itemStack);
+                    if ((cost < lowestCost && (silkTouch || !bestSilkTouch)) ||
+                            (preferSilkTouch && !bestSilkTouch && silkTouch)) {
+                        highestSpeed = speed;
+                        best = i;
+                        lowestCost = cost;
+                        bestSilkTouch = silkTouch;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Summary
This PR introduces new settings to control farming crops with silk touch.

### Changes
- **Settings.java**
  - Added `useFortuneForCrops` setting to control the behavior.

- **ToolSet.java**
  - Updated `getBestSlot(Block, boolean, boolean)` method to use the highest level fortune tool when farming a crop.

### Motivation  
Enhances the `#farm` command and other mechanics, increasing the amount, you get, from your crops.  

As far as I know, this does not consume durability, so there’s no downside to adding it - making it an obvious improvement.

For more details, check out the Minecraft Wiki: [Fortune and Seeds](https://minecraft.wiki/w/Fortune#Seeds).  

### Testing
- Verified that crops are farmed by the highest fortune level tool.
- Verified that breaking other blocks are not affected by this change.