### PR TITLE
Fix nether-pathfinder with optimized forge/neoforge builds

### DIFF
--- a/scripts/proguard.pro
+++ b/scripts/proguard.pro
@@ -54,6 +54,11 @@
 -dontwarn baritone.utils.schematic.schematica.**
 -dontwarn baritone.utils.schematic.litematica.**
 
+# nether-pathfinder uses JNI to acess its own classes
+# and some of our builds include it before running proguard
+# conservatively keep all of it, even though only PathSegment.<init> is needed
+-keep,allowoptimization class dev.babbaj.pathfinder.** { *; }
+
 # Keep - Applications. Keep all application classes, along with their 'main'
 # methods.
 -keepclasseswithmembers public class * {

--- a/src/main/java/baritone/command/defaults/ElytraCommand.java
+++ b/src/main/java/baritone/command/defaults/ElytraCommand.java
@@ -216,7 +216,7 @@ public class ElytraCommand extends Command {
         final String osArch = System.getProperty("os.arch");
         final String osName = System.getProperty("os.name");
         return String.format(
-                "Legacy architectures are not supported. Your CPU is %s and your operating system is %s. " +
+                "Failed loading native library. Your CPU is %s and your operating system is %s. " +
                         "Supported architectures are 64 bit x86, and 64 bit ARM. Supported operating systems are Windows, " +
                         "Linux, and Mac",
                 osArch, osName


### PR DESCRIPTION
We shadow the java part of netherpathfinder on forge and neoforge and we do so before running proguard.
Since `PathSegment`s are only ever constructed via JNI by libnether-pathfinder proguard determines that `PathSegment` is never instantiated at all and rips out the constructor, making the game crash for obvious reasons.

Nether-pathfinder also seems to have a slight problem with it's logging, since the messages it prints don't make it into the log file.

Funnily, proguard now prints a message that explicitly keeping library classes is not needed.

Fixes #4656
<!-- No UwU's or OwO's allowed -->
