### PR TITLE
Improve error messages from `#build`

### DIFF
--- a/src/api/java/baritone/api/schematic/ISchematicSystem.java
+++ b/src/api/java/baritone/api/schematic/ISchematicSystem.java
@@ -21,6 +21,7 @@ import baritone.api.command.registry.Registry;
 import baritone.api.schematic.format.ISchematicFormat;
 
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -41,4 +42,9 @@ public interface ISchematicSystem {
      * @return The corresponding format for the file, {@link Optional#empty()} if no candidates were found.
      */
     Optional<ISchematicFormat> getByFile(File file);
+
+    /**
+     * @return A list of file extensions used by supported formats
+     */
+    List<String> getFileExtensions();
 }

--- a/src/api/java/baritone/api/schematic/format/ISchematicFormat.java
+++ b/src/api/java/baritone/api/schematic/format/ISchematicFormat.java
@@ -23,6 +23,7 @@ import baritone.api.schematic.IStaticSchematic;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * The base of a {@link ISchematic} file format
@@ -42,4 +43,9 @@ public interface ISchematicFormat {
      * @return Whether or not the specified file matches this schematic format
      */
     boolean isFileType(File file);
+
+    /**
+     * @return A list of file extensions used by this format
+     */
+    List<String> getFileExtensions();
 }

--- a/src/main/java/baritone/command/defaults/BuildCommand.java
+++ b/src/main/java/baritone/command/defaults/BuildCommand.java
@@ -26,11 +26,13 @@ import baritone.api.command.datatypes.RelativeFile;
 import baritone.api.command.exception.CommandException;
 import baritone.api.command.exception.CommandInvalidStateException;
 import baritone.api.utils.BetterBlockPos;
+import baritone.utils.schematic.SchematicSystem;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.stream.Stream;
 
 public class BuildCommand extends Command {
@@ -59,6 +61,14 @@ public class BuildCommand extends Command {
             }
             throw new CommandInvalidStateException("Cannot find " + file);
         }
+        if (!SchematicSystem.INSTANCE.getByFile(file).isPresent()) {
+            StringJoiner formats = new StringJoiner(", ");
+            SchematicSystem.INSTANCE.getFileExtensions().forEach(formats::add);
+            throw new CommandInvalidStateException(String.format(
+                    "Unsupported schematic format. Reckognized file extensions are: %s",
+                    formats
+            ));
+        }
         BetterBlockPos origin = ctx.playerFeet();
         BetterBlockPos buildOrigin;
         if (args.hasAny()) {
@@ -70,7 +80,7 @@ public class BuildCommand extends Command {
         }
         boolean success = baritone.getBuilderProcess().build(file.getName(), file, buildOrigin);
         if (!success) {
-            throw new CommandInvalidStateException("Couldn't load the schematic. Unsupported file format, wrong file extension or a bug.");
+            throw new CommandInvalidStateException("Couldn't load the schematic. Either your schematic is corrupt or this is a bug.");
         }
         logDirect(String.format("Successfully loaded schematic for building\nOrigin: %s", buildOrigin));
     }

--- a/src/main/java/baritone/command/defaults/BuildCommand.java
+++ b/src/main/java/baritone/command/defaults/BuildCommand.java
@@ -44,9 +44,20 @@ public class BuildCommand extends Command {
 
     @Override
     public void execute(String label, IArgConsumer args) throws CommandException {
-        File file = args.getDatatypePost(RelativeFile.INSTANCE, schematicsDir).getAbsoluteFile();
+        final File file0 = args.getDatatypePost(RelativeFile.INSTANCE, schematicsDir).getAbsoluteFile();
+        File file = file0;
         if (FilenameUtils.getExtension(file.getAbsolutePath()).isEmpty()) {
             file = new File(file.getAbsolutePath() + "." + Baritone.settings().schematicFallbackExtension.value);
+        }
+        if (!file.exists()) {
+            if (file0.exists()) {
+                throw new CommandInvalidStateException(String.format(
+                        "Cannot load %s because I do not know which schematic format"
+                                + " that is. Please rename the file to include the correct"
+                                + " file extension.",
+                        file));
+            }
+            throw new CommandInvalidStateException("Cannot find " + file);
         }
         BetterBlockPos origin = ctx.playerFeet();
         BetterBlockPos buildOrigin;
@@ -59,7 +70,7 @@ public class BuildCommand extends Command {
         }
         boolean success = baritone.getBuilderProcess().build(file.getName(), file, buildOrigin);
         if (!success) {
-            throw new CommandInvalidStateException("Couldn't load the schematic. Make sure to use the FULL file name, including the extension (e.g. blah.schematic).");
+            throw new CommandInvalidStateException("Couldn't load the schematic. Unsupported file format, wrong file extension or a bug.");
         }
         logDirect(String.format("Successfully loaded schematic for building\nOrigin: %s", buildOrigin));
     }

--- a/src/main/java/baritone/utils/schematic/SchematicSystem.java
+++ b/src/main/java/baritone/utils/schematic/SchematicSystem.java
@@ -24,6 +24,7 @@ import baritone.utils.schematic.format.DefaultSchematicFormats;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -47,5 +48,10 @@ public enum SchematicSystem implements ISchematicSystem {
     @Override
     public Optional<ISchematicFormat> getByFile(File file) {
         return this.registry.stream().filter(format -> format.isFileType(file)).findFirst();
+    }
+
+    @Override
+    public List<String> getFileExtensions() {
+        return this.registry.stream().map(ISchematicFormat::getFileExtensions).flatMap(List::stream).toList();
     }
 }

--- a/src/main/java/baritone/utils/schematic/format/DefaultSchematicFormats.java
+++ b/src/main/java/baritone/utils/schematic/format/DefaultSchematicFormats.java
@@ -22,13 +22,15 @@ import baritone.api.schematic.format.ISchematicFormat;
 import baritone.utils.schematic.format.defaults.LitematicaSchematic;
 import baritone.utils.schematic.format.defaults.MCEditSchematic;
 import baritone.utils.schematic.format.defaults.SpongeSchematic;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtIo;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtIo;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Default implementations of {@link ISchematicFormat}
@@ -97,5 +99,10 @@ public enum DefaultSchematicFormats implements ISchematicFormat {
     @Override
     public boolean isFileType(File file) {
         return this.extension.equalsIgnoreCase(FilenameUtils.getExtension(file.getAbsolutePath()));
+    }
+
+    @Override
+    public List<String> getFileExtensions() {
+        return Collections.singletonList(this.extension);
     }
 }


### PR DESCRIPTION
Don't unconditionally yell at users to include the file extension.
* If the file exists but has not extension, tell the user to rename it.
* If the file doesn't exist, tell the user where we searched
* If the file does exist but we don't have an `ISchematicFormat` to load it, tell the user that the format is not supported and list extensions of supported formats.

The last point is a bit awkward since extensions do not map to file formats one to one and there are cases where files with an extension on the list of "supported" extensions are rejected. Specifically, we can only load a specific version of the litematic format.
And now that I think about it, the litematic loading code will only reject the file when it is too late and thus trigger the "Either your schematic is corrupt or this is a bug." message.

There is generally a lot of room for improvement concerning error messages. We have plenty of situations where some code knows precisely what went wrong, but all it can do is cause a generic "OOPS" message being displayed to the user.

<!-- No UwU's or OwO's allowed -->
