### PR TITLE
Backport #4634 and #4205 to 1.19.4

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -11,7 +11,8 @@
   ],
   "contact": {
     "homepage": "https://github.com/cabaletta/baritone",
-    "sources": "https://github.com/cabaletta/baritone"
+    "sources": "https://github.com/cabaletta/baritone",
+    "issues": "https://github.com/cabaletta/baritone/issues"
   },
 
   "license": "LGPL-3.0",
@@ -27,5 +28,12 @@
   "depends": {
     "fabricloader": ">=0.11.0",
     "minecraft": "1.19.4"
+  },
+  "custom": {
+    "modmenu": {
+      "links": {
+        "modmenu.discord": "https://discord.gg/s6fRBAUpmr"
+      }
+    }
   }
 }

--- a/src/api/java/baritone/api/process/IBuilderProcess.java
+++ b/src/api/java/baritone/api/process/IBuilderProcess.java
@@ -24,6 +24,7 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.world.level.block.state.BlockState;
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Brady
@@ -74,4 +75,17 @@ public interface IBuilderProcess extends IBaritoneProcess {
      * cause it to give up. This is updated every tick, but only while the builder process is active.
      */
     List<BlockState> getApproxPlaceable();
+    /**
+     * Returns the lower bound of the current mining layer if mineInLayers is true.
+     * If mineInLayers is false, this will return an empty optional.
+     * @return The lower bound of the current mining layer
+     */
+    Optional<Integer> getMinLayer();
+
+    /**
+     * Returns the upper bound of the current mining layer if mineInLayers is true.
+     * If mineInLayers is false, this will return an empty optional.
+     * @return The upper bound of the current mining layer
+     */
+    Optional<Integer> getMaxLayer();
 }

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -999,6 +999,22 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         return paused ? "Builder Paused" : "Building " + name;
     }
 
+    @Override
+    public Optional<Integer> getMinLayer() {
+        if (Baritone.settings().buildInLayers.value) {
+            return Optional.of(this.layer);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Integer> getMaxLayer() {
+        if (Baritone.settings().buildInLayers.value) {
+            return Optional.of(this.stopAtHeight);
+        }
+        return Optional.empty();
+    }
+
     private List<BlockState> approxPlaceable(int size) {
         List<BlockState> result = new ArrayList<>();
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
Just noticed they were merged to 1.21.1 / 1.20.2 for no apparent reason.
I didn't test this at all.
<!-- No UwU's or OwO's allowed -->
