### PR TITLE
Add regex support for mine command

### DIFF
--- a/src/main/java/baritone/command/defaults/MineCommand.java
+++ b/src/main/java/baritone/command/defaults/MineCommand.java
@@ -24,10 +24,13 @@ import baritone.api.command.argument.IArgConsumer;
 import baritone.api.command.datatypes.ForBlockOptionalMeta;
 import baritone.api.command.exception.CommandException;
 import baritone.api.utils.BlockOptionalMeta;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.block.Block;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public class MineCommand extends Command {
@@ -40,10 +43,41 @@ public class MineCommand extends Command {
     public void execute(String label, IArgConsumer args) throws CommandException {
         int quantity = args.getAsOrDefault(Integer.class, 0);
         args.requireMin(1);
-        List<BlockOptionalMeta> boms = new ArrayList<>();
-        while (args.hasAny()) {
-            boms.add(args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE));
+
+        boolean isRegex = false;
+        if (args.hasAny() && args.peekString().equals("-r")) {
+            args.getString();
+            isRegex = true;
+            args.requireMin(1);
         }
+
+        List<BlockOptionalMeta> boms = new ArrayList<>();
+
+        if (isRegex) {
+            String regex = args.getString();
+            Pattern pattern = Pattern.compile(regex);
+
+            List<Block> matchingBlocks = BuiltInRegistries.BLOCK.keySet().stream()
+                    .filter(key -> pattern.matcher(key.toString()).matches())
+                    .map(BuiltInRegistries.BLOCK::get)
+                    .toList();
+
+            if (matchingBlocks.isEmpty()) {
+                logDirect(String.format("No blocks matching the following regular expression were found: %s", regex));
+                return;
+            }
+
+            for (Block block : matchingBlocks) {
+                boms.add(new BlockOptionalMeta(block));
+            }
+
+            logDirect(String.format("Found %d blocks matching the regular expression: %s", matchingBlocks.size(), regex));
+        } else {
+            while (args.hasAny()) {
+                boms.add(args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE));
+            }
+        }
+
         BaritoneAPI.getProvider().getWorldScanner().repack(ctx);
         logDirect(String.format("Mining %s", boms.toString()));
         baritone.getMineProcess().mine(quantity, boms.toArray(new BlockOptionalMeta[0]));
@@ -52,6 +86,19 @@ public class MineCommand extends Command {
     @Override
     public Stream<String> tabComplete(String label, IArgConsumer args) throws CommandException {
         args.getAsOrDefault(Integer.class, 0);
+
+        if (args.hasExactlyOne() && !args.peekString().startsWith("-")) {
+            return Stream.concat(
+                    Stream.of("-r"),
+                    args.tabCompleteDatatype(ForBlockOptionalMeta.INSTANCE)
+            );
+        }
+
+        if (args.hasExactlyOne() && args.peekString().equals("-r")) {
+            args.getString();
+            return Stream.of(".*ore.*", ".*log.*", ".*stone.*");
+        }
+
         while (args.has(2)) {
             args.getDatatypeFor(ForBlockOptionalMeta.INSTANCE);
         }
@@ -73,7 +120,8 @@ public class MineCommand extends Command {
                 "Also see the legitMine settings (see #set l legitMine).",
                 "",
                 "Usage:",
-                "> mine diamond_ore - Mines all diamonds it can find."
+                "> mine diamond_ore - Mines all diamonds it can find.",
+                "> mine -r .*ore.* - Mines all blocks that match the regular expression '.*ore.*'."
         );
     }
 }


### PR DESCRIPTION
## Overview
This pull request adds regular expression support to the `mine` command, allowing users to mine blocks that match a specific pattern.

## Features
- Added a new `-r` flag to the `mine` command to indicate that the following argument is a regular expression
- Implemented pattern matching against block IDs in the Minecraft registry
- Added informative feedback messages about the number of blocks matched by the regex
- Updated tab completion to suggest the `-r` flag and common regex patterns
- Updated command documentation to include the new regex functionality

## Usage Examples
- `mine -r .*ore.*` - Mines all blocks that have "ore" in their ID (e.g., diamond_ore, iron_ore, gold_ore, etc.)
- `mine -r .*log.*` - Mines all types of logs
- `mine -r .*stone.*` - Mines all types of stone blocks