### PR TITLE
Calculate item hash only if needed

### DIFF
--- a/src/launch/java/baritone/launch/mixins/MixinItemStack.java
+++ b/src/launch/java/baritone/launch/mixins/MixinItemStack.java
@@ -46,14 +46,6 @@ public abstract class MixinItemStack implements IItemStack {
     }
 
     @Inject(
-            method = "<init>*",
-            at = @At("RETURN")
-    )
-    private void onInit(CallbackInfo ci) {
-        recalculateHash();
-    }
-
-    @Inject(
             method = "setDamageValue",
             at = @At("TAIL")
     )
@@ -63,7 +55,8 @@ public abstract class MixinItemStack implements IItemStack {
 
     @Override
     public int getBaritoneHash() {
-        // TODO: figure out why <init> mixin not working, was 0 for some reason
+        // cannot do this in an init mixin because silentlib likes creating new
+        // items in getDamageValue, which we call in recalculateHash
         if (baritoneHash == 0) recalculateHash();
         return baritoneHash;
     }


### PR DESCRIPTION
Fixes a stackoverflow with SilentGear.
The problem is that SilentGear has a complicated parts system and to get the damage value of an `ItemStack` it first constructs the relevant `PartInstance`, which involves defensively copying the `ItemStack` before storing it in the new `PartInstance`. Copying an `ItemStack` of course triggers our hash calculation in the constructor run for the copy, we query the damage value of the new stack, and the cycle repeats.

With this change we only calculate the hash once we actually need it (and if the hash happens to be 0 we do so every time it is needed).
An alternative would be to try copying the hash from the old stack to the new one, though given the Mixin hackery this would require I'm not sure whether that would actually be better. (Need to redirect the relevant constructor call and probably also need a `ThreadLocal` to pass the hash)

Fixes #4538
Fixes #4863

<!-- No UwU's or OwO's allowed -->
