### PR TITLE
Detect when blocks are clickable

### DIFF
--- a/src/main/java/baritone/pathing/movement/movements/MovementFall.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementFall.java
@@ -30,6 +30,7 @@ import baritone.pathing.movement.MovementHelper;
 import baritone.pathing.movement.MovementState;
 import baritone.pathing.movement.MovementState.MovementTarget;
 import baritone.utils.pathing.MutableMoveResult;
+import baritone.utils.reflection.InteractabilityHelper;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -105,6 +106,9 @@ public class MovementFall extends Movement {
 
                 targetRotation = new Rotation(toDest.getYaw(), 90.0F);
 
+                boolean clickable = InteractabilityHelper.hasRightClickAction(ctx.world().getBlockState(dest.below()));
+                state.setInput(Input.SNEAK, clickable);
+
                 if (ctx.isLookingAt(dest) || ctx.isLookingAt(dest.below())) {
                     state.setInput(Input.CLICK_RIGHT, true);
                 }
@@ -119,7 +123,12 @@ public class MovementFall extends Movement {
             if (isWater) { // only match water, not flowing water (which we cannot pick up with a bucket)
                 if (Inventory.isHotbarSlot(ctx.player().getInventory().findSlotMatchingItem(STACK_BUCKET_EMPTY))) {
                     ctx.player().getInventory().selected = ctx.player().getInventory().findSlotMatchingItem(STACK_BUCKET_EMPTY);
-                    if (ctx.player().getDeltaMovement().y >= 0) {
+
+                    // Note: this can not happen if there is water below, so no risk of drowning
+                    boolean clickable = InteractabilityHelper.hasRightClickAction(ctx.world().getBlockState(dest.below()));
+                    state.setInput(Input.SNEAK, clickable);
+
+                    if (ctx.player().getDeltaMovement().y >= 0 || ctx.player().isCrouching()) {
                         return state.setInput(Input.CLICK_RIGHT, true);
                     } else {
                         return state;

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -28,6 +28,7 @@ import baritone.pathing.movement.MovementHelper;
 import baritone.pathing.movement.MovementState;
 import baritone.utils.BlockStateInterface;
 import baritone.utils.pathing.MutableMoveResult;
+import baritone.utils.reflection.InteractabilityHelper;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -190,7 +191,11 @@ public class MovementParkour extends Movement {
                 if (againstX == destX - xDiff && againstZ == destZ - zDiff) { // we can't turn around that fast
                     continue;
                 }
-                if (MovementHelper.canPlaceAgainst(context.bsi, againstX, againstY, againstZ)) {
+                if (!MovementHelper.canPlaceAgainst(context.bsi, againstX, againstY, againstZ)) {
+                    continue;
+                }
+                // TODO Reflection during movement evaluation! This is BAD!
+                if (!InteractabilityHelper.hasRightClickAction(context.bsi.get0(againstX, againstY, againstZ))) {
                     res.x = destX;
                     res.y = y;
                     res.z = destZ;

--- a/src/main/java/baritone/utils/reflection/InteractabilityHelper.java
+++ b/src/main/java/baritone/utils/reflection/InteractabilityHelper.java
@@ -1,0 +1,56 @@
+package baritone.utils.reflection;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.core.BlockPos;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * @author ZacSharp
+ * @since 3/26/2025
+ */
+public class InteractabilityHelper {
+
+    // Note that this can/must not be invoked (type error)
+    private static final Method BLOCK_USE;
+
+    static {
+        Map<String, Method> blockMethods = ReflectionHelper.getMarkedMethods(DummyBlock.class);
+        BLOCK_USE = blockMethods.get("onInteract");
+    }
+
+    private InteractabilityHelper() {}
+
+    public static boolean hasRightClickAction(BlockState state) {
+        return hasRightClickAction(state.getBlock());
+    }
+
+    public static boolean hasRightClickAction(Block block) {
+        return ReflectionHelper.getBySignature(block.getClass(), BLOCK_USE).getDeclaringClass() != BlockBehaviour.class;
+    }
+
+    private static <T, E extends Throwable> T raise(E ex) throws E {
+        throw ex;
+    }
+
+    private static final class DummyBlock extends Block {
+        private DummyBlock() {
+            super(raise(new UnsupportedOperationException()));
+        }
+
+        @Override
+        @ReflectionHelper.Marker("onInteract")
+        public InteractionResult use(BlockState p_60503_, Level p_60504_, BlockPos p_60505_, Player p_60506_, InteractionHand p_60507_, BlockHitResult p_60508_) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/main/java/baritone/utils/reflection/ReflectionHelper.java
+++ b/src/main/java/baritone/utils/reflection/ReflectionHelper.java
@@ -1,0 +1,60 @@
+package baritone.utils.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author ZacSharp
+ * @since 3/26/2025
+ */
+public class ReflectionHelper {
+
+    private ReflectionHelper() {}
+
+    // Note: This approach works with public/protected/package-private methods only.
+    // If we need fields or private methods that should be possible with some mixin
+    // trickery like a custom injection point with the name we need as its target.
+    /**
+     * Get a map with all declared in {@code class} with the {@code Marker} annotation
+     * using the annotation value as the map key.
+     */
+    public static Map<String, Method> getMarkedMethods(Class<? extends Object> cls) {
+        Map<String, Method> methods = new HashMap<>();
+        for (Method method : cls.getDeclaredMethods()) {
+            Marker marker = method.getAnnotation(Marker.class);
+            if (marker == null) {
+                continue;
+            }
+            methods.put(marker.value(), method);
+        }
+        return methods;
+    }
+
+    /**
+     * Gets a public method of {@code cls} with the same name and parameter
+     * types as {@code sig}, or null if such a method does not exist.
+     *
+     * @param the class to search in
+     * @param a method with the same signature as the sought method
+     * @return the found method or null
+     */
+    public static Method getBySignature(Class<? extends Object> cls, Method sig) {
+        try {
+            return cls.getMethod(sig.getName(), sig.getParameterTypes());
+        } catch (NoSuchMethodException ex) {
+            return null;
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public static @interface Marker {
+        String value();
+    }
+}


### PR DESCRIPTION
This currently uses uncached reflection on the pathing thread, and I'd like to hear some other opinions on possible solutions.

The obvious solution would be a `Reference2BoolOpenHashMap<Class<?>>`, but due to not wanting to synchronize things that cache would have to live in `CalculationContext` despite caching static data.
Instead we could use mixin to move the cache to a final field on `Block` instances, which has the only drawback of caching per `Block` instance, not subclass (and adding a public method to an mc class).
Caching per subclass should be possible by using a custom transformer to directly write the value into the bytecode of the getter method, but that's clearly overkill. Using mixin to do this is probably not possible.


<!-- No UwU's or OwO's allowed -->
