### PR TITLE
Don't let servers trick users into running arbitrary Baritone commands

### DIFF
--- a/src/launch/java/baritone/launch/mixins/MixinScreen.java
+++ b/src/launch/java/baritone/launch/mixins/MixinScreen.java
@@ -21,16 +21,18 @@ import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.event.events.ChatEvent;
 import baritone.utils.accessor.IGuiScreen;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Style;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
-
-import java.net.URI;
-import net.minecraft.client.gui.screens.Screen;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.net.URI;
+
+import static baritone.api.command.IBaritoneChatControl.FORCE_COMMAND_PREFIX;
 
 @Mixin(Screen.class)
 public abstract class MixinScreen implements IGuiScreen {
@@ -47,9 +49,13 @@ public abstract class MixinScreen implements IGuiScreen {
         if (clickEvent == null) {
             return;
         }
+        String command = clickEvent.getValue();
+        if (command == null || !command.startsWith(FORCE_COMMAND_PREFIX)) {
+            return;
+        }
         IBaritone baritone = BaritoneAPI.getProvider().getPrimaryBaritone();
         if (baritone != null) {
-            baritone.getGameEventHandler().onSendChatMessage(new ChatEvent(clickEvent.getValue()));
+            baritone.getGameEventHandler().onSendChatMessage(new ChatEvent(command));
         }
         cir.setReturnValue(true);
         cir.cancel();


### PR DESCRIPTION
During a discussion on #4692 I ended up handcrafting books and chat messages with clickable text, which made me notice that servers can simply send `ChatComponent`s with Baritone commands and somehow get the user into clicking them to have Baritone execute the commands.
Since the server cannot know the `FORCE_COMMAND_PREFIX` this change prevents it from crafting such messages/books/signs.

I do not see how this could be used for more than deleting waypoints/settings and disconnecting the player, but this could change in future. For example I have a private branch which has a setting to specify the location of an external helper program. A single click on a sign is enough to let the server change that setting and run the command which uses it, allowing the server to run any program the user has installed.


<!-- No UwU's or OwO's allowed -->
