### PR TITLE
Backport #4465 and #4396 to 1.20.4

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
 
-    implementation group: 'xyz.wagyourtail.unimined', name: 'xyz.wagyourtail.unimined.gradle.plugin', version: '1.1.0'
+    implementation group: 'xyz.wagyourtail.unimined', name: 'xyz.wagyourtail.unimined.gradle.plugin', version: '1.2.9'
 }

--- a/src/main/java/baritone/selection/Selection.java
+++ b/src/main/java/baritone/selection/Selection.java
@@ -37,7 +37,7 @@ public class Selection implements ISelection {
                 max.z - min.z + 1
         );
 
-        this.aabb = new AABB(this.min);
+        this.aabb = new AABB(min.x, min.y, min.z, max.x + 1, max.y + 1, max.z + 1);
     }
 
     @Override


### PR DESCRIPTION
These fixes are not needed on 1.20.2 and it looks like #4553 is not needed on 1.20.4 or earlier.

Confirmed that selection box aabbs are correct on 1.20.2 and loading under forge on 1.20.2 works.
Also made sure `#mine` on 1.20.4 neoforge with twilightforest installed does not crash, but that doesn't mean anything. Reading the code however it looks like we properly filter to only load the vanilla pack.
<!-- No UwU's or OwO's allowed -->
