### PR TITLE
Update build limits

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -181,9 +181,10 @@ public final class Settings {
     public final Setting<Boolean> assumeSafeWalk = new Setting<>(false);
 
     /**
-     * Does nothing since it's intended functionality is redundant
+     * If true, parkour is allowed to make jumps when standing on blocks at the maximum height, so player feet is y=256
+     * <p>
+     * Defaults to false because this fails on constantiam. Please let me know if this is ever disabled. Please.
      */
-    @Deprecated
     public final Setting<Boolean> allowJumpAt256 = new Setting<>(false);
 
     /**

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -181,6 +181,13 @@ public final class Settings {
     public final Setting<Boolean> assumeSafeWalk = new Setting<>(false);
 
     /**
+     * If true, parkour is allowed to make jumps when standing on blocks at the maximum height, so player feet is y=256
+     * <p>
+     * Defaults to false because this fails on constantiam. Please let me know if this is ever disabled. Please.
+     */
+    public final Setting<Boolean> allowJumpAt256 = new Setting<>(false);
+
+    /**
      * This should be monetized it's so good
      * <p>
      * Defaults to true, but only actually takes effect if allowParkour is also true

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -181,10 +181,9 @@ public final class Settings {
     public final Setting<Boolean> assumeSafeWalk = new Setting<>(false);
 
     /**
-     * If true, parkour is allowed to make jumps when standing on blocks at the maximum height, so player feet is y=256
-     * <p>
-     * Defaults to false because this fails on constantiam. Please let me know if this is ever disabled. Please.
+     * Does nothing since it's intended functionality is redundant
      */
+    @Deprecated
     public final Setting<Boolean> allowJumpAt256 = new Setting<>(false);
 
     /**

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -192,7 +192,7 @@ public final class Settings {
      */
     @Deprecated
     @JavaOnly
-    public final Settings<Boolean> allowJumpAt256 = new Setting<>(false);
+    public final Setting<Boolean> allowJumpAt256 = new Setting<>(false);
 
     /**
      * This should be monetized it's so good

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -185,7 +185,14 @@ public final class Settings {
      * <p>
      * Defaults to false because this fails on constantiam. Please let me know if this is ever disabled. Please.
      */
-    public final Setting<Boolean> allowJumpAt256 = new Setting<>(false);
+    public final Setting<Boolean> allowJumpAtBuildLimit = new Setting<>(false);
+
+    /**
+     * Just here so mods that use the API don't break. Does nothing.
+     */
+    @Deprecated
+    @JavaOnly
+    public final Settings<Boolean> allowJumpAt256 = new Setting<>(false);
 
     /**
      * This should be monetized it's so good

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -181,13 +181,6 @@ public final class Settings {
     public final Setting<Boolean> assumeSafeWalk = new Setting<>(false);
 
     /**
-     * If true, parkour is allowed to make jumps when standing on blocks at the maximum height, so player feet is y=256
-     * <p>
-     * Defaults to false because this fails on constantiam. Please let me know if this is ever disabled. Please.
-     */
-    public final Setting<Boolean> allowJumpAt256 = new Setting<>(false);
-
-    /**
      * This should be monetized it's so good
      * <p>
      * Defaults to true, but only actually takes effect if allowParkour is also true

--- a/src/main/java/baritone/command/defaults/RenderCommand.java
+++ b/src/main/java/baritone/command/defaults/RenderCommand.java
@@ -40,10 +40,10 @@ public class RenderCommand extends Command {
         int renderDistance = (ctx.minecraft().options.renderDistance().get() + 1) * 16;
         ctx.minecraft().levelRenderer.setBlocksDirty(
                 origin.x - renderDistance,
-                0,
+                ctx.world().dimensionType().minY(),
                 origin.z - renderDistance,
                 origin.x + renderDistance,
-                255,
+                ctx.world().dimensionType().minY() + ctx.world().dimensionType().height(),
                 origin.z + renderDistance
         );
         logDirect("Done");

--- a/src/main/java/baritone/command/defaults/RenderCommand.java
+++ b/src/main/java/baritone/command/defaults/RenderCommand.java
@@ -40,10 +40,10 @@ public class RenderCommand extends Command {
         int renderDistance = (ctx.minecraft().options.renderDistance().get() + 1) * 16;
         ctx.minecraft().levelRenderer.setBlocksDirty(
                 origin.x - renderDistance,
-                ctx.world().dimensionType().minY(),
+                ctx.world().getMinBuildHeight(),
                 origin.z - renderDistance,
                 origin.x + renderDistance,
-                ctx.world().dimensionType().minY() + ctx.world().dimensionType().height(),
+                ctx.world().getMinBuildHeight(),
                 origin.z + renderDistance
         );
         logDirect("Done");

--- a/src/main/java/baritone/command/defaults/RenderCommand.java
+++ b/src/main/java/baritone/command/defaults/RenderCommand.java
@@ -43,7 +43,7 @@ public class RenderCommand extends Command {
                 ctx.world().getMinBuildHeight(),
                 origin.z - renderDistance,
                 origin.x + renderDistance,
-                ctx.world().getMinBuildHeight(),
+                ctx.world().getMaxBuildHeight(),
                 origin.z + renderDistance
         );
         logDirect("Done");

--- a/src/main/java/baritone/command/defaults/TunnelCommand.java
+++ b/src/main/java/baritone/command/defaults/TunnelCommand.java
@@ -44,7 +44,7 @@ public class TunnelCommand extends Command {
             int width = Integer.parseInt(args.getArgs().get(1).getValue());
             int depth = Integer.parseInt(args.getArgs().get(2).getValue());
 
-            if (width < 1 || height < 2 || depth < 1 || height > 255) {
+            if (width < 1 || height < 2 || depth < 1 || height > ctx.world().getMaxBuildHeight()){
                 logDirect("Width and depth must at least be 1 block; Height must at least be 2 blocks, and cannot be greater than the build limit.");
                 cont = false;
             }

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -63,6 +63,7 @@ public class CalculationContext {
     public final List<Block> allowBreakAnyway;
     public final boolean allowParkour;
     public final boolean allowParkourPlace;
+    public final boolean allowJumpAt256;
     public final boolean allowParkourAscend;
     public final boolean assumeWalkOnWater;
     public boolean allowFallIntoLava;
@@ -103,6 +104,7 @@ public class CalculationContext {
         this.allowBreakAnyway = new ArrayList<>(Baritone.settings().allowBreakAnyway.value);
         this.allowParkour = Baritone.settings().allowParkour.value;
         this.allowParkourPlace = Baritone.settings().allowParkourPlace.value;
+        this.allowJumpAt256 = Baritone.settings().allowJumpAt256.value;
         this.allowParkourAscend = Baritone.settings().allowParkourAscend.value;
         this.assumeWalkOnWater = Baritone.settings().assumeWalkOnWater.value;
         this.allowFallIntoLava = false; // Super secret internal setting for ElytraBehavior

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -63,6 +63,9 @@ public class CalculationContext {
     public final List<Block> allowBreakAnyway;
     public final boolean allowParkour;
     public final boolean allowParkourPlace;
+    @Deprecated
+    @JavaOnly
+    public final boolean allowJumpAt256;
     public final boolean allowJumpAtBuildLimit;
     public final boolean allowParkourAscend;
     public final boolean assumeWalkOnWater;
@@ -104,7 +107,8 @@ public class CalculationContext {
         this.allowBreakAnyway = new ArrayList<>(Baritone.settings().allowBreakAnyway.value);
         this.allowParkour = Baritone.settings().allowParkour.value;
         this.allowParkourPlace = Baritone.settings().allowParkourPlace.value;
-        this.allowJumpAtBuildLimit = Baritone.settings().allowJumpAt256.value;
+        this.allowJumpAt256 = Baritone.settings().allowJumpAt256.value;
+        this.allowJumpAtBuildLimit = Baritone.settings().allowJumpAtBuildLimit.value;
         this.allowParkourAscend = Baritone.settings().allowParkourAscend.value;
         this.assumeWalkOnWater = Baritone.settings().assumeWalkOnWater.value;
         this.allowFallIntoLava = false; // Super secret internal setting for ElytraBehavior

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -63,7 +63,6 @@ public class CalculationContext {
     public final List<Block> allowBreakAnyway;
     public final boolean allowParkour;
     public final boolean allowParkourPlace;
-    public final boolean allowJumpAt256;
     public final boolean allowParkourAscend;
     public final boolean assumeWalkOnWater;
     public boolean allowFallIntoLava;
@@ -104,7 +103,6 @@ public class CalculationContext {
         this.allowBreakAnyway = new ArrayList<>(Baritone.settings().allowBreakAnyway.value);
         this.allowParkour = Baritone.settings().allowParkour.value;
         this.allowParkourPlace = Baritone.settings().allowParkourPlace.value;
-        this.allowJumpAt256 = Baritone.settings().allowJumpAt256.value;
         this.allowParkourAscend = Baritone.settings().allowParkourAscend.value;
         this.assumeWalkOnWater = Baritone.settings().assumeWalkOnWater.value;
         this.allowFallIntoLava = false; // Super secret internal setting for ElytraBehavior

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -63,8 +63,7 @@ public class CalculationContext {
     public final List<Block> allowBreakAnyway;
     public final boolean allowParkour;
     public final boolean allowParkourPlace;
-    @Deprecated
-    public final boolean allowJumpAt256;
+    public final boolean allowJumpAtBuildLimit;
     public final boolean allowParkourAscend;
     public final boolean assumeWalkOnWater;
     public boolean allowFallIntoLava;
@@ -105,7 +104,7 @@ public class CalculationContext {
         this.allowBreakAnyway = new ArrayList<>(Baritone.settings().allowBreakAnyway.value);
         this.allowParkour = Baritone.settings().allowParkour.value;
         this.allowParkourPlace = Baritone.settings().allowParkourPlace.value;
-        this.allowJumpAt256 = Baritone.settings().allowJumpAt256.value;
+        this.allowJumpAtBuildLimit = Baritone.settings().allowJumpAt256.value;
         this.allowParkourAscend = Baritone.settings().allowParkourAscend.value;
         this.assumeWalkOnWater = Baritone.settings().assumeWalkOnWater.value;
         this.allowFallIntoLava = false; // Super secret internal setting for ElytraBehavior

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -63,9 +63,6 @@ public class CalculationContext {
     public final List<Block> allowBreakAnyway;
     public final boolean allowParkour;
     public final boolean allowParkourPlace;
-    @Deprecated
-    @JavaOnly
-    public final boolean allowJumpAt256;
     public final boolean allowJumpAtBuildLimit;
     public final boolean allowParkourAscend;
     public final boolean assumeWalkOnWater;
@@ -107,7 +104,6 @@ public class CalculationContext {
         this.allowBreakAnyway = new ArrayList<>(Baritone.settings().allowBreakAnyway.value);
         this.allowParkour = Baritone.settings().allowParkour.value;
         this.allowParkourPlace = Baritone.settings().allowParkourPlace.value;
-        this.allowJumpAt256 = Baritone.settings().allowJumpAt256.value;
         this.allowJumpAtBuildLimit = Baritone.settings().allowJumpAtBuildLimit.value;
         this.allowParkourAscend = Baritone.settings().allowParkourAscend.value;
         this.assumeWalkOnWater = Baritone.settings().assumeWalkOnWater.value;

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -63,6 +63,7 @@ public class CalculationContext {
     public final List<Block> allowBreakAnyway;
     public final boolean allowParkour;
     public final boolean allowParkourPlace;
+    @Deprecated
     public final boolean allowJumpAt256;
     public final boolean allowParkourAscend;
     public final boolean assumeWalkOnWater;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -147,7 +147,7 @@ public class MovementDescend extends Movement {
         int effectiveStartHeight = y;
         for (int fallHeight = 3; true; fallHeight++) {
             int newY = y - fallHeight;
-            if (newY < context.world.dimensionType().minY()) {
+            if (newY < context.world.getMinBuildHeight()) {
                 // when pathing in the end, where you could plausibly fall into the void
                 // this check prevents it from getting the block at y=(below whatever the minimum height is) and crashing
                 return false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -147,7 +147,7 @@ public class MovementDescend extends Movement {
         int effectiveStartHeight = y;
         for (int fallHeight = 3; true; fallHeight++) {
             int newY = y - fallHeight;
-            if (newY < context.getBaritone().getPlayerContext().world().dimensionType().minY()) {
+            if (newY < context.world.dimensionType().minY()) {
                 // when pathing in the end, where you could plausibly fall into the void
                 // this check prevents it from getting the block at y=(below whatever the minimum height is) and crashing
                 return false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -147,7 +147,7 @@ public class MovementDescend extends Movement {
         int effectiveStartHeight = y;
         for (int fallHeight = 3; true; fallHeight++) {
             int newY = y - fallHeight;
-            if (newY < ctx.world().dimensionType().minY()) {
+            if (newY < context.getBaritone().getPlayerContext().world().dimensionType().minY()) {
                 // when pathing in the end, where you could plausibly fall into the void
                 // this check prevents it from getting the block at y=(below whatever the minimum height is) and crashing
                 return false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -147,9 +147,9 @@ public class MovementDescend extends Movement {
         int effectiveStartHeight = y;
         for (int fallHeight = 3; true; fallHeight++) {
             int newY = y - fallHeight;
-            if (newY < -64) {
+            if (newY < ctx.world().dimensionType().minY()) {
                 // when pathing in the end, where you could plausibly fall into the void
-                // this check prevents it from getting the block at y=-1 and crashing
+                // this check prevents it from getting the block at y=(below whatever the minimum height is) and crashing
                 return false;
             }
             boolean reachedMinimum = fallHeight >= context.minFallHeight;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -147,7 +147,7 @@ public class MovementDescend extends Movement {
         int effectiveStartHeight = y;
         for (int fallHeight = 3; true; fallHeight++) {
             int newY = y - fallHeight;
-            if (newY < 0) {
+            if (newY < -64) {
                 // when pathing in the end, where you could plausibly fall into the void
                 // this check prevents it from getting the block at y=-1 and crashing
                 return false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -64,6 +64,9 @@ public class MovementParkour extends Movement {
         if (!context.allowParkour) {
             return;
         }
+        if (y >= context.world.getMaxBuildHeight() && !context.allowJumpAtBuildLimit) {
+            return;
+        }
         int xDiff = dir.getStepX();
         int zDiff = dir.getStepZ();
         if (!MovementHelper.fullyPassable(context, x + xDiff, y, z + zDiff)) {

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -64,10 +64,6 @@ public class MovementParkour extends Movement {
         if (!context.allowParkour) {
             return;
         }
-        if (y == 256 && !context.allowJumpAt256) {
-            return;
-        }
-
         int xDiff = dir.getStepX();
         int zDiff = dir.getStepZ();
         if (!MovementHelper.fullyPassable(context, x + xDiff, y, z + zDiff)) {

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -64,7 +64,7 @@ public class MovementParkour extends Movement {
         if (!context.allowParkour) {
             return;
         }
-        if (y >= context.world.getMaxBuildHeight() && !context.allowJumpAtBuildLimit) {
+        if (!context.allowJumpAtBuildLimit && y >= context.world.getMaxBuildHeight()) {
             return;
         }
         int xDiff = dir.getStepX();

--- a/src/main/java/baritone/utils/BlockStateInterfaceAccessWrapper.java
+++ b/src/main/java/baritone/utils/BlockStateInterfaceAccessWrapper.java
@@ -56,12 +56,12 @@ public final class BlockStateInterfaceAccessWrapper implements BlockGetter {
 
     @Override
     public int getHeight() {
-        return 255;
+        return bsi.world.getMaxBuildHeight();
     }
 
     @Override
     public int getMinBuildHeight() {
-        return 0;
+        return bsi.world.getMinBuildHeight();
     }
 
 }


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->
Update minimum and maximum build limit to account for the 1.18 update.
In response to #4734.
Also remove `allowJumpAt256` since it's a redundancy (an alternative option would be to go with #3949).