### PR TITLE
Fix height vs. max build height mixup

### DIFF
--- a/src/main/java/baritone/utils/BlockStateInterfaceAccessWrapper.java
+++ b/src/main/java/baritone/utils/BlockStateInterfaceAccessWrapper.java
@@ -56,7 +56,7 @@ public final class BlockStateInterfaceAccessWrapper implements BlockGetter {
 
     @Override
     public int getHeight() {
-        return bsi.world.getMaxBuildHeight();
+        return bsi.world.getHeight();
     }
 
     @Override


### PR DESCRIPTION
That one is embarrassing for me. I looked at that diff so often and somehow managed to only notice the mistake when I had to fix a merge conflict 5 lines further down the file when merging into 1.21.3
<!-- No UwU's or OwO's allowed -->
