### PR TITLE
Migrate `allowJumpAt256` to `allowJumpAtBuildLimit` in settings files

### DIFF
--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -83,6 +83,10 @@ public class SettingsUtil {
 
                 String settingName = matcher.group("setting").toLowerCase();
                 String settingValue = matcher.group("value");
+                // TODO remove soonish
+                if ("allowjumpat256".equals(settingName)) {
+                    settingName = "allowjumpatbuildlimit";
+                }
                 try {
                     parseAndApply(settings, settingName, settingValue);
                 } catch (Exception ex) {


### PR DESCRIPTION
As requested by @babbaj in https://github.com/cabaletta/baritone/pull/4736#issuecomment-2868978202.
I assumed we are neither going to rename / remove more settings in the near future nor going to keep the migration code for long, so I did not try doing this properly.
<!-- No UwU's or OwO's allowed -->
