### PR TITLE
Pause if Inventory open.

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -103,6 +103,13 @@ public final class Settings {
     public final Setting<Boolean> stopWhenInventoryOpen = new Setting<>(false);
 
     /**
+     * Just here so mods that use the API don't break. Does nothing.
+     */
+    @Deprecated
+    @JavaOnly
+    public final Setting<Boolean> inventoryMoveOnlyIfStationary = new Setting<>(false);
+
+    /**
      * Disable baritone's auto-tool at runtime, but still assume that another mod will provide auto tool functionality
      * <p>
      * Specifically, path calculation will still assume that an auto tool will run at execution time, even though

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -98,9 +98,9 @@ public final class Settings {
     public final Setting<Integer> ticksBetweenInventoryMoves = new Setting<>(1);
 
     /**
-     * Come to a halt before doing any inventory moves. Intended for anticheat such as 2b2t
+     * Come to a halt if inventory opens. Intended for anticheat such as 2b2t
      */
-    public final Setting<Boolean> inventoryMoveOnlyIfStationary = new Setting<>(false);
+    public final Setting<Boolean> stopWhenInventoryOpen = new Setting<>(false);
 
     /**
      * Disable baritone's auto-tool at runtime, but still assume that another mod will provide auto tool functionality

--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -87,6 +87,10 @@ public class SettingsUtil {
                 if ("allowjumpat256".equals(settingName)) {
                     settingName = "allowjumpatbuildlimit";
                 }
+                // TODO also remove soonish
+                if ("inventoryMoveOnlyIfStationary".equals(settingName)) {
+                    settingName = "stopWhenInventoryOpen";
+                }
                 try {
                     parseAndApply(settings, settingName, settingValue);
                 } catch (Exception ex) {

--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -46,8 +46,8 @@ import java.util.function.Predicate;
 
 public final class InventoryBehavior extends Behavior implements Helper {
 
-    int ticksSinceLastInventoryMove;
-    int[] lastTickRequestedMove; // not everything asks every tick, so remember the request while coming to a halt
+    private int ticksSinceLastInventoryMove;
+    private int[] lastTickRequestedMove; // not everything asks every tick, so remember the request while coming to a halt
 
     public InventoryBehavior(Baritone baritone) {
         super(baritone);
@@ -65,7 +65,9 @@ public final class InventoryBehavior extends Behavior implements Helper {
             // we have a crafting table or a chest or something open
             return;
         }
-        ticksSinceLastInventoryMove++;
+        if (ticksSinceLastInventoryMove < Baritone.settings().ticksBetweenInventoryMoves.value) {
+            ticksSinceLastInventoryMove++;
+        }
         PathExecutor currentPath = baritone.getPathingBehavior().getCurrent();
         if (currentPath != null) {
             int throwaway = firstValidThrowaway();

--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -20,6 +20,7 @@ package baritone.behavior;
 import baritone.Baritone;
 import baritone.api.event.events.TickEvent;
 import baritone.api.utils.Helper;
+import baritone.pathing.path.PathExecutor;
 import baritone.utils.ToolSet;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.Direction;
@@ -65,16 +66,20 @@ public final class InventoryBehavior extends Behavior implements Helper {
             return;
         }
         ticksSinceLastInventoryMove++;
-        if (firstValidThrowaway() >= 9) { // aka there are none on the hotbar, but there are some in main inventory
-            requestSwapWithHotBar(firstValidThrowaway(), 8);
-        }
-        int pick = bestToolAgainst(Blocks.STONE, PickaxeItem.class);
-        if (pick >= 9) {
-            requestSwapWithHotBar(pick, 0);
-        }
-        if (lastTickRequestedMove != null) {
-            logDebug("Remembering to move " + lastTickRequestedMove[0] + " " + lastTickRequestedMove[1] + " from a previous tick");
-            requestSwapWithHotBar(lastTickRequestedMove[0], lastTickRequestedMove[1]);
+        PathExecutor currentPath = baritone.getPathingBehavior().getCurrent();
+        if (currentPath != null) {
+            int throwaway = firstValidThrowaway();
+            if (throwaway >= 9 && !currentPath.toPlace().isEmpty()) { // aka there are none on the hotbar, but there are some in main inventory
+                requestSwapWithHotBar(throwaway, 8);
+            }
+            int pick = bestToolAgainst(Blocks.STONE, PickaxeItem.class);
+            if (pick >= 9 && !currentPath.toBreak().isEmpty()) {
+                requestSwapWithHotBar(pick, 0);
+            }
+            if (lastTickRequestedMove != null) {
+                logDebug("Remembering to move " + lastTickRequestedMove[0] + " " + lastTickRequestedMove[1] + " from a previous tick");
+                requestSwapWithHotBar(lastTickRequestedMove[0], lastTickRequestedMove[1]);
+            }
         }
     }
 

--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -115,7 +115,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
             logDebug("Inventory move requested but delaying " + ticksSinceLastInventoryMove + " " + Baritone.settings().ticksBetweenInventoryMoves.value);
             return false;
         }
-        if (Baritone.settings().inventoryMoveOnlyIfStationary.value && !baritone.getInventoryPauserProcess().stationaryForInventoryMove()) {
+        if (Baritone.settings().stopWhenInventoryOpen.value && !baritone.getInventoryPauserProcess().stationaryForInventoryMove()) {
             logDebug("Inventory move requested but delaying until stationary");
             return false;
         }

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -87,7 +87,7 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         if (event.getType() == TickEvent.Type.OUT) {
             return;
         }
-        if (ctx.minecraft().screen != null) {
+        if (Baritone.settings().inventoryMoveOnlyIfStationary.value && ctx.minecraft().screen != null) {
             ctx.player().input = new KeyboardInput(ctx.minecraft().options);
             return;
         }

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -87,6 +87,10 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         if (event.getType() == TickEvent.Type.OUT) {
             return;
         }
+        if (ctx.minecraft().screen != null) {
+            ctx.player().input = new KeyboardInput(ctx.minecraft().options);
+            return;
+        }
         if (isInputForcedDown(Input.CLICK_LEFT)) {
             setInputForceState(Input.CLICK_RIGHT, false);
         }

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -87,7 +87,7 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         if (event.getType() == TickEvent.Type.OUT) {
             return;
         }
-        if (Baritone.settings().inventoryMoveOnlyIfStationary.value && ctx.minecraft().screen != null) {
+        if (Baritone.settings().stopWhenInventoryOpen.value && ctx.minecraft().screen != null) {
             ctx.player().input = new KeyboardInput(ctx.minecraft().options);
             return;
         }

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -23,6 +23,7 @@ import baritone.api.event.events.TickEvent;
 import baritone.api.utils.IInputOverrideHandler;
 import baritone.api.utils.input.Input;
 import baritone.behavior.Behavior;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.player.KeyboardInput;
 
 import java.util.HashMap;
@@ -87,7 +88,7 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         if (event.getType() == TickEvent.Type.OUT) {
             return;
         }
-        if (Baritone.settings().stopWhenInventoryOpen.value && ctx.minecraft().screen != null) {
+        if (Baritone.settings().stopWhenInventoryOpen.value && ctx.minecraft().screen instanceof InventoryScreen) {
             ctx.player().input = new KeyboardInput(ctx.minecraft().options);
             return;
         }


### PR DESCRIPTION
<!-- No UwU's or OwO's allowed -->
Closes #4825
Closes #4715
Stops executing any movements when it's in the inventory. Also should send inventory open events to server when it's changing item positions.
Servers are able to detect if a player has interacted with their inventory while they are still moving. This would stop Baritone to prevent that.