### PR TITLE
[1.21.10] fix nether pathfinder exception in palette scan

### DIFF
--- a/src/main/java/baritone/process/elytra/NetherPathfinderContext.java
+++ b/src/main/java/baritone/process/elytra/NetherPathfinderContext.java
@@ -196,9 +196,13 @@ public final class NetherPathfinderContext {
                     continue;
                 }
                 final PalettedContainer<BlockState> bsc = extendedblockstorage.getStates();
-                final int airId = ((IPalettedContainer<BlockState>) bsc).getPalette().idFor(AIR_BLOCK_STATE, PaletteResize.noResizeExpected());
+                IPalettedContainer<BlockState> iPalettedContainer = (IPalettedContainer<BlockState>) bsc;
+                int airId = -1;
+                if (iPalettedContainer.getPalette().maybeHas(state -> state.equals(AIR_BLOCK_STATE))) {
+                    airId = iPalettedContainer.getPalette().idFor(AIR_BLOCK_STATE, PaletteResize.noResizeExpected());
+                }
                 // pasted from FasterWorldScanner
-                final BitStorage array = ((IPalettedContainer<BlockState>) bsc).getStorage();
+                final BitStorage array = iPalettedContainer.getStorage();
                 if (array == null) continue;
                 final long[] longArray = array.getRaw();
                 final int arraySize = array.getSize();


### PR DESCRIPTION
if air is not in palette, prev code would throw an exception

```
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: java.lang.IllegalArgumentException: Unexpected palette resize, bits = 1, added value = Block{minecraft:air}
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: 	at knot//net.minecraft.class_2835.method_74154(class_2835.java:9)
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: 	at knot//net.minecraft.class_6564.method_12291(class_6564.java:33)
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: 	at knot//baritone.process.elytra.NetherPathfinderContext.writeChunkData(NetherPathfinderContext.java:199)
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: 	at knot//baritone.process.elytra.NetherPathfinderContext.lambda$queueForPacking$1(NetherPathfinderContext.java:85)
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[17:09:42] [pool-39-thread-1/INFO]: [STDERR]: 	at java.base/java.lang.Thread.run(Thread.java:1583)
[17:09:42] [pool-39-thread-2/INFO]: [STDERR]: java.lang.IllegalArgumentException: Unexpected palette resize, bits = 1, added value = Block{minecraft:air}
[17:09:42] [pool-39-thread-2/INFO]: [STDERR]: 	at knot//net.minecraft.class_2835.method_74154(class_2835.java:9)
[17:09:42] [pool-39-thread-2/INFO]: [STDERR]: 	at knot//net.minecraft.class_6564.method_12291(class_6564.java:33)
[17:09:42] [pool-39-thread-2/INFO]: [STDERR]: 	at knot//baritone.process.elytra.NetherPathfinderContext.writeChunkData(NetherPathfinderContext.java:199)
[17:09:42] [pool-39-thread-2/INFO]: [STDERR]: 	at knot//
```

in pre 1.21.10 baritone the palette is actually resized and edited. which works, but imo its better not to edit the state.
