### PR TITLE
Fix for neoforge ItemStack init recursion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx4G
 
 available_loaders=fabric,forge,neoforge,tweaker
 
-mod_version=1.11.0
+mod_version=1.11.2
 maven_group=baritone
 archives_base_name=baritone
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx4G
 
 available_loaders=fabric,forge,neoforge,tweaker
 
-mod_version=1.11.2
+mod_version=1.11.0
 maven_group=baritone
 archives_base_name=baritone
 

--- a/src/launch/java/baritone/launch/mixins/MixinItemStack.java
+++ b/src/launch/java/baritone/launch/mixins/MixinItemStack.java
@@ -18,6 +18,7 @@
 package baritone.launch.mixins;
 
 import baritone.api.utils.accessor.IItemStack;
+import baritone.launch.util.ItemStackInitGuard;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
@@ -50,7 +51,15 @@ public abstract class MixinItemStack implements IItemStack {
             at = @At("RETURN")
     )
     private void onInit(CallbackInfo ci) {
+        if (ItemStackInitGuard.isEntered()) {
+            return;
+        }
+        ItemStackInitGuard.enter();
+        try {
         recalculateHash();
+        } finally {
+            ItemStackInitGuard.exit();
+        }
     }
 
     @Inject(

--- a/src/launch/java/baritone/launch/util/ItemStackInitGuard.java
+++ b/src/launch/java/baritone/launch/util/ItemStackInitGuard.java
@@ -18,10 +18,10 @@
 package baritone.launch.util;
 
 public final class ItemStackInitGuard {
-    private ItemStackInitGuard() {}
-
     private static final ThreadLocal<Boolean> GUARD =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
+    
+    private ItemStackInitGuard() {}
 
     public static boolean isEntered() {
         return Boolean.TRUE.equals(GUARD.get());

--- a/src/launch/java/baritone/launch/util/ItemStackInitGuard.java
+++ b/src/launch/java/baritone/launch/util/ItemStackInitGuard.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.launch.util;
+
+public final class ItemStackInitGuard {
+    private ItemStackInitGuard() {}
+
+    private static final ThreadLocal<Boolean> GUARD =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    public static boolean isEntered() {
+        return Boolean.TRUE.equals(GUARD.get());
+    }
+
+    public static void enter() {
+        GUARD.set(Boolean.TRUE);
+    }
+
+    public static void exit() {
+        GUARD.set(Boolean.FALSE);
+    }
+}
+


### PR DESCRIPTION
this fixes a crash on neoforge 1.21 where baritone’s ItemStack mixin can end up calling itself over and over

this happens when other mods access ItemStack data like durability or hashes while an ItemStack is still being created, which causes baritone’s init hook to re-enter and eventually stack overflow or crash on join

the fix adds a small threadlocal guard so the ItemStack init hook does nothing if it’s already running, which breaks the recursion without changing normal behavior

seen with mods like silent gear, but this should apply generally to neoforge setups

fix & related: https://github.com/cabaletta/baritone/issues/4538
