### PR TITLE
Disable background blur in click gui

### DIFF
--- a/src/main/java/baritone/utils/GuiClick.java
+++ b/src/main/java/baritone/utils/GuiClick.java
@@ -84,6 +84,11 @@ public class GuiClick extends Screen implements Helper {
     }
 
     @Override
+    public void renderBackground(GuiGraphics stack, int mouseX, int mouseY, float partialTicks) {
+        // Prevent default background rendering
+    }
+
+    @Override
     public boolean mouseReleased(double mouseX, double mouseY, int mouseButton) {
         if (currentMouseOver != null) { //Catch this, or else a click into void will result in a crash
             if (mouseButton == 0) {


### PR DESCRIPTION
The first version where this is needed is 1.21.6 (which is covered by the 1.21.8 branch), but the change should work on lower versions as well, so I can probably target this at the 1.19.4 branch as well.

For 1.21.10 and later we could alternatively override `isInGameUi` to return true, though this way it works on all versions and perhaps won't break silently as easily.

Fixes #4911

<!-- No UwU's or OwO's allowed -->
