### PR TITLE
Use `minecraft:swords` item tag to detect swords

### DIFF
--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -19,6 +19,7 @@ package baritone.utils;
 
 import baritone.Baritone;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.SwordItem;
@@ -125,7 +126,7 @@ public class ToolSet {
         BlockState blockState = b.defaultBlockState();
         for (int i = 0; i < 9; i++) {
             ItemStack itemStack = player.getInventory().getItem(i);
-            if (!Baritone.settings().useSwordToMine.value && itemStack.getItem() instanceof SwordItem) {
+            if (!Baritone.settings().useSwordToMine.value && itemStack.is(ItemTags.SWORDS)) {
                 continue;
             }
 


### PR DESCRIPTION
On later versions we check for the `WEAPON` data component instead, which matches every tool as well, making the setting pretty useless.

I was a bit surprised we can use item tags on the client, but apparently they are synced so this just works.
(Also verified this in a lan world with a datapack changing the swords tag)

fixes #4869

<!-- No UwU's or OwO's allowed -->
