### PR TITLE
Pennykizler057 sys patch 1

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,34 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/src/main/java/baritone/pathing/calc/AStarPathFinder.java
+++ b/src/main/java/baritone/pathing/calc/AStarPathFinder.java
@@ -59,7 +59,7 @@ public final class AStarPathFinder extends AbstractNodeCostSearch {
             bestHeuristicSoFar[i] = startNode.estimatedCostToGoal;
             bestSoFar[i] = startNode;
         }
-        MutableMoveResult res = new MutableMoveResult();
+        MutableMoveResult mutableMoveResult = new MutableMoveResult();
         BetterWorldBorder worldBorder = new BetterWorldBorder(calcContext.world.getWorldBorder());
         long startTime = System.currentTimeMillis();
         boolean slowPath = Baritone.settings().slowPath.value;
@@ -112,8 +112,9 @@ public final class AStarPathFinder extends AbstractNodeCostSearch {
                 if (currentNode.y + moves.yOffset > 256 || currentNode.y + moves.yOffset < 0) {
                     continue;
                 }
-                res.reset();
-                moves.apply(calcContext, currentNode.x, currentNode.y, currentNode.z, res);
+                mutableMoveResult.reset();
+                moves.apply(calcContext, currentNode.x, currentNode.y, currentNode.z, mutableMoveResult);
+                MutableMoveResult res = mutableMoveResult;
                 while (res != null) {
                     numMovementsConsidered++;
                     double actionCost = res.cost;

--- a/src/main/java/baritone/pathing/calc/AStarPathFinder.java
+++ b/src/main/java/baritone/pathing/calc/AStarPathFinder.java
@@ -114,50 +114,53 @@ public final class AStarPathFinder extends AbstractNodeCostSearch {
                 }
                 res.reset();
                 moves.apply(calcContext, currentNode.x, currentNode.y, currentNode.z, res);
-                numMovementsConsidered++;
-                double actionCost = res.cost;
-                if (actionCost >= ActionCosts.COST_INF) {
-                    continue;
-                }
-                if (actionCost <= 0 || Double.isNaN(actionCost)) {
-                    throw new IllegalStateException(moves + " calculated implausible cost " + actionCost);
-                }
-                // check destination after verifying it's not COST_INF -- some movements return a static IMPOSSIBLE object with COST_INF and destination being 0,0,0 to avoid allocating a new result for every failed calculation
-                if (moves.dynamicXZ && !worldBorder.entirelyContains(res.x, res.z)) { // see issue #218
-                    continue;
-                }
-                if (!moves.dynamicXZ && (res.x != newX || res.z != newZ)) {
-                    throw new IllegalStateException(moves + " " + res.x + " " + newX + " " + res.z + " " + newZ);
-                }
-                if (!moves.dynamicY && res.y != currentNode.y + moves.yOffset) {
-                    throw new IllegalStateException(moves + " " + res.y + " " + (currentNode.y + moves.yOffset));
-                }
-                long hashCode = BetterBlockPos.longHash(res.x, res.y, res.z);
-                if (isFavoring) {
-                    // see issue #18
-                    actionCost *= favoring.calculate(hashCode);
-                }
-                PathNode neighbor = getNodeAtPosition(res.x, res.y, res.z, hashCode);
-                double tentativeCost = currentNode.cost + actionCost;
-                if (neighbor.cost - tentativeCost > minimumImprovement) {
-                    neighbor.previous = currentNode;
-                    neighbor.cost = tentativeCost;
-                    neighbor.combinedCost = tentativeCost + neighbor.estimatedCostToGoal;
-                    if (neighbor.isOpen()) {
-                        openSet.update(neighbor);
-                    } else {
-                        openSet.insert(neighbor);//dont double count, dont insert into open set if it's already there
+                while (res != null) {
+                    numMovementsConsidered++;
+                    double actionCost = res.cost;
+                    if (actionCost >= ActionCosts.COST_INF) {
+                        continue;
                     }
-                    for (int i = 0; i < COEFFICIENTS.length; i++) {
-                        double heuristic = neighbor.estimatedCostToGoal + neighbor.cost / COEFFICIENTS[i];
-                        if (bestHeuristicSoFar[i] - heuristic > minimumImprovement) {
-                            bestHeuristicSoFar[i] = heuristic;
-                            bestSoFar[i] = neighbor;
-                            if (failing && getDistFromStartSq(neighbor) > MIN_DIST_PATH * MIN_DIST_PATH) {
-                                failing = false;
+                    if (actionCost <= 0 || Double.isNaN(actionCost)) {
+                        throw new IllegalStateException(moves + " calculated implausible cost " + actionCost);
+                    }
+                    // check destination after verifying it's not COST_INF -- some movements return a static IMPOSSIBLE object with COST_INF and destination being 0,0,0 to avoid allocating a new result for every failed calculation
+                    if (moves.dynamicXZ && !worldBorder.entirelyContains(res.x, res.z)) { // see issue #218
+                        continue;
+                    }
+                    if (!moves.dynamicXZ && (res.x != newX || res.z != newZ)) {
+                        throw new IllegalStateException(moves + " " + res.x + " " + newX + " " + res.z + " " + newZ);
+                    }
+                    if (!moves.dynamicY && res.y != currentNode.y + moves.yOffset) {
+                        throw new IllegalStateException(moves + " " + res.y + " " + (currentNode.y + moves.yOffset));
+                    }
+                    long hashCode = BetterBlockPos.longHash(res.x, res.y, res.z);
+                    if (isFavoring) {
+                        // see issue #18
+                        actionCost *= favoring.calculate(hashCode);
+                    }
+                    PathNode neighbor = getNodeAtPosition(res.x, res.y, res.z, hashCode);
+                    double tentativeCost = currentNode.cost + actionCost;
+                    if (neighbor.cost - tentativeCost > minimumImprovement) {
+                        neighbor.previous = currentNode;
+                        neighbor.cost = tentativeCost;
+                        neighbor.combinedCost = tentativeCost + neighbor.estimatedCostToGoal;
+                        if (neighbor.isOpen()) {
+                            openSet.update(neighbor);
+                        } else {
+                            openSet.insert(neighbor);//dont double count, dont insert into open set if it's already there
+                        }
+                        for (int i = 0; i < COEFFICIENTS.length; i++) {
+                            double heuristic = neighbor.estimatedCostToGoal + neighbor.cost / COEFFICIENTS[i];
+                            if (bestHeuristicSoFar[i] - heuristic > minimumImprovement) {
+                                bestHeuristicSoFar[i] = heuristic;
+                                bestSoFar[i] = neighbor;
+                                if (failing && getDistFromStartSq(neighbor) > MIN_DIST_PATH * MIN_DIST_PATH) {
+                                    failing = false;
+                                }
                             }
                         }
                     }
+                    res = res.getNext();
                 }
             }
         }

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -131,8 +131,14 @@ public class MovementParkour extends Movement {
                     res.y = y;
                     res.z = destZ;
                     res.cost = costFromJumpDistance(i) + context.jumpPenalty;
+                    // for example, right here, we might just do:
+                    res = res.nextPotentialDestination();
+                    // that like, marks this `res` as "done" and we've put in this movement option's data
                 }
+                // and instead of this return
                 return;
+                // we would just continue onto the rest of the loop, and if we find an alternate landing, we would just update `res` as normal, and everything would Just Work
+                // we could return ANY number of potential movement destinations like this, and as soon as we get each new one, we just pop it into the stack by writing to `res` then doing `res = res.nextPotentialDestination();`
             }
             if (!MovementHelper.fullyPassable(context, destX, y + 3, destZ)) {
                 return;

--- a/src/main/java/baritone/utils/pathing/MutableMoveResult.java
+++ b/src/main/java/baritone/utils/pathing/MutableMoveResult.java
@@ -30,6 +30,8 @@ public final class MutableMoveResult {
     public int y;
     public int z;
     public double cost;
+    private MutableMoveResult next;
+    private boolean hasNext;
 
     public MutableMoveResult() {
         reset();
@@ -40,5 +42,24 @@ public final class MutableMoveResult {
         y = 0;
         z = 0;
         cost = ActionCosts.COST_INF;
+        hasNext = false;
+        if (next != null) {
+            next.reset();
+        }
+    }
+
+    public MutableMoveResult nextPotentialDestination() {
+        if (next == null) {
+            next = new MutableMoveResult(); // this is okay because it's one-time at the beginning (or near the beginning) of the calculation, instead of per-movement
+        }
+        hasNext = true;
+        return next;
+    }
+
+    public MutableMoveResult getNext() {
+        if (!hasNext) {
+            return null;
+        }
+        return next;
     }
 }


### PR DESCRIPTION
            - name: Setup Java JDK
  uses: actions/setup-java@v5.2.0
  with:
    # The Java version to set up. Takes a whole or semver Java version. See examples of supported syntax in README file
    java-version: # optional
    # The path to the `.java-version` file. See examples of supported syntax in README file
    java-version-file: # optional
    # Java distribution. See the list of supported distributions in README file
    distribution: 
    # The package type (jdk, jre, jdk+fx, jre+fx)
    java-package: # optional, default is jdk
    # The architecture of the package (defaults to the action runner's architecture)
    architecture: # optional
    # Path to where the compressed JDK is located
    jdkFile: # optional
    # Set this option if you want the action to check for the latest available version that satisfies the version spec
    check-latest: # optional
    # ID of the distributionManagement repository in the pom.xml file. Default is `github`
    server-id: # optional, default is github
    # Environment variable name for the username for authentication to the Apache Maven repository. Default is $GITHUB_ACTOR
    server-username: # optional, default is GITHUB_ACTOR
    # Environment variable name for password or token for authentication to the Apache Maven repository. Default is $GITHUB_TOKEN
    server-password: # optional, default is GITHUB_TOKEN
    # Path to where the settings.xml file will be written. Default is ~/.m2.
    settings-path: # optional
    # Overwrite the settings.xml file if it exists. Default is "true".
    overwrite-settings: # optional, default is true
    # GPG private key to import. Default is empty string.
    gpg-private-key: # optional
    # Environment variable name for the GPG private key passphrase. Default is $GPG_PASSPHRASE.
    gpg-passphrase: # optional
    # Name of the build platform to cache dependencies. It can be "maven", "gradle" or "sbt".
    cache: # optional
    # The path to a dependency file: pom.xml, build.gradle, build.sbt, etc. This option can be used with the `cache` option. If this option is omitted, the action searches for the dependency file in the entire repository. This option supports wildcards and a list of file names for caching multiple dependencies.
    cache-dependency-path: # optional
    # Workaround to pass job status to post job step. This variable is not intended for manual setting
    job-status: # optional, default is ${{ job.status }}
    # The token used to authenticate when fetching version manifests hosted on github.com, such as for the Microsoft Build of OpenJDK. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
    token: # optional, default is ${{ github.server_url == 'https://github.com' && github.token || '' }}
    # Name of Maven Toolchain ID if the default name of "${distribution}_${java-version}" is not wanted. See examples of supported syntax in Advanced Usage file
    mvn-toolchain-id: # optional
    # Name of Maven Toolchain Vendor if the default name of "${distribution}" is not wanted. See examples of supported syntax in Advanced Usage file
    mvn-toolchain-vendor: # optional
          pennykizler057@gmail.com