### PR TITLE
Port Forge build to Minecraft 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,6 @@ allprojects {
         mappings {
             intermediary()
             mojmap()
-            parchment("2023.06.26")
         }
     }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -42,3 +42,7 @@ dependencies {
 
     implementation group: 'xyz.wagyourtail.unimined', name: 'xyz.wagyourtail.unimined.gradle.plugin', version: '1.0.5'
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 17
+}

--- a/buildSrc/src/main/java/baritone/gradle/task/ProguardTask.java
+++ b/buildSrc/src/main/java/baritone/gradle/task/ProguardTask.java
@@ -19,6 +19,7 @@ package baritone.gradle.task;
 
 import baritone.gradle.util.Determinizer;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
@@ -225,12 +226,18 @@ public class ProguardTask extends BaritoneGradleTask {
             Files.delete(this.proguardOut);
         }
 
+        Configuration log4jRuntime = getProject().getConfigurations().detachedConfiguration(
+                getProject().getDependencies().create("org.apache.logging.log4j:log4j-api:2.23.1"),
+                getProject().getDependencies().create("org.apache.logging.log4j:log4j-core:2.23.1")
+        );
+
         Path workingDirectory = getTemporaryFile("");
 
         getProject().javaexec(spec -> {
             spec.workingDir(workingDirectory.toFile());
             spec.args("@" + workingDirectory.relativize(config));
-            spec.classpath(getTemporaryFile(String.format(PROGUARD_JAR, proguardVersion)));
+            spec.classpath(getProject().files(getTemporaryFile(String.format(PROGUARD_JAR, proguardVersion)), log4jRuntime));
+            spec.getMainClass().set("proguard.ProGuard");
 
             spec.executable(getJavaLauncherForProguard().getExecutablePath().getAsFile());
         }).assertNormalExitValue().rethrowFailure();

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -123,6 +123,68 @@ task createDist(type: CreateDistTask, dependsOn: proguard) {
     compType "forge"
 }
 
+tasks.register("validateMixinCompatibility") {
+    group = "verification"
+    description = "Parses dist/log.log and writes a consolidated report of mixin incompatibilities from the latest Forge run."
+
+    def logFile = rootProject.file("dist/log.log")
+    def reportFile = rootProject.file("dist/mixin-incompatibilities.txt")
+
+    inputs.file(logFile)
+    outputs.file(reportFile)
+
+    doLast {
+        if (!logFile.exists()) {
+            logger.lifecycle("No log file found at ${logFile}. Run the game once, then rerun :forge:validateMixinCompatibility.")
+            return
+        }
+
+        List<String> lines = logFile.readLines("UTF-8")
+        int latestRunStart = lines.findLastIndexOf { it.contains("Launching target 'forge_client'") }
+        List<String> runLines = latestRunStart >= 0 ? lines.subList(latestRunStart, lines.size()) : lines
+
+        LinkedHashSet<String> findings = new LinkedHashSet<>()
+        runLines.each { String line ->
+            if (line.contains("Mixin apply failed")) {
+                findings.add(line.trim())
+            }
+            if (line.contains("Invalid descriptor on mixins.baritone.json")) {
+                findings.add(line.trim())
+            }
+            if (line.contains("Critical injection failure:")) {
+                findings.add(line.trim())
+            }
+            if (line.contains("@Shadow field") && line.contains("was not located")) {
+                findings.add(line.trim())
+            }
+        }
+
+        StringBuilder report = new StringBuilder()
+        report.append("Baritone Forge Mixin Compatibility Report\n")
+        report.append("Generated at: ").append(new Date()).append("\n")
+        report.append("Source log: ").append(logFile.absolutePath).append("\n")
+        report.append("Latest run start line: ").append(latestRunStart >= 0 ? latestRunStart + 1 : 1).append("\n\n")
+
+        if (findings.isEmpty()) {
+            report.append("No mixin incompatibility signatures were detected in the latest run section.\n")
+        } else {
+            report.append("Detected issues: ").append(findings.size()).append("\n\n")
+            int i = 1
+            findings.each { String finding ->
+                report.append(i++).append(". ").append(finding).append("\n")
+            }
+        }
+
+        reportFile.parentFile.mkdirs()
+        reportFile.text = report.toString()
+
+        logger.lifecycle("Mixin compatibility report written to ${reportFile}")
+        if (!findings.isEmpty()) {
+            logger.lifecycle("Found ${findings.size()} potential incompatibility entries in latest run.")
+        }
+    }
+}
+
 build.finalizedBy(createDist)
 
 publishing {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -17,6 +17,7 @@
 
 import baritone.gradle.task.CreateDistTask
 import baritone.gradle.task.ProguardTask
+import org.gradle.api.tasks.Copy
 
 plugins {
     id "com.github.johnrengelman.shadow" version "8.0.0"
@@ -26,7 +27,7 @@ archivesBaseName = archivesBaseName + "-forge"
 
 unimined.minecraft {
     mappings {
-        devFallbackNamespace "intermediary"
+        devFallbackNamespace "mojmap"
     }
 
     forge {
@@ -78,6 +79,21 @@ remapJar {
     archiveClassifier.set null
 }
 
+tasks.named("remapJar") {
+    enabled = false
+}
+
+tasks.register("prepareReleaseJar", Copy) {
+    dependsOn shadowJar
+    from(shadowJar.archiveFile)
+    into(layout.buildDirectory.dir("libs"))
+    rename { String _ -> "${archivesBaseName}-${project.version}.jar" }
+}
+
+tasks.named("assemble") {
+    dependsOn("prepareReleaseJar")
+}
+
 jar {
     archiveClassifier.set "dev"
 
@@ -99,7 +115,7 @@ components.java {
 }
 
 task proguard(type: ProguardTask) {
-    proguardVersion "7.2.1"
+    proguardVersion "7.6.1"
     compType "forge"
 }
 

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[33,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[61,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 license="https://raw.githubusercontent.com/cabaletta/baritone/1.16.2/LICENSE"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/cabaletta/baritone/issues" #optional
@@ -35,6 +35,6 @@ A Minecraft pathfinder bot.
 modId="minecraft"
 mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange="[1.19.4]"
+versionRange="[1.21.11]"
 ordering="NONE"
 side="BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ mod_version=1.9.5
 maven_group=baritone
 archives_base_name=baritone
 
-java_version=17
+java_version=21
 
-minecraft_version=1.19.4
+minecraft_version=1.21.11
 
-forge_version=45.0.43
+forge_version=61.1.1
 
 fabric_version=0.14.11
 

--- a/scripts/proguard.pro
+++ b/scripts/proguard.pro
@@ -2,7 +2,7 @@
 -keepattributes *Annotation*
 -keepattributes InnerClasses
 
--optimizationpasses 5
+-dontoptimize
 -verbose
 -ignorewarnings
 

--- a/scripts/proguard.pro
+++ b/scripts/proguard.pro
@@ -4,6 +4,7 @@
 
 -optimizationpasses 5
 -verbose
+-ignorewarnings
 
 -allowaccessmodification # anything not kept can be changed from public to private and inlined etc
 -overloadaggressively

--- a/src/api/java/baritone/api/command/datatypes/BlockById.java
+++ b/src/api/java/baritone/api/command/datatypes/BlockById.java
@@ -20,7 +20,7 @@ package baritone.api.command.datatypes;
 import baritone.api.command.exception.CommandException;
 import baritone.api.command.helpers.TabCompleteHelper;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 
 import java.util.stream.Stream;
@@ -30,7 +30,10 @@ public enum BlockById implements IDatatypeFor<Block> {
 
     @Override
     public Block get(IDatatypeContext ctx) throws CommandException {
-        ResourceLocation id = new ResourceLocation(ctx.getConsumer().getString());
+        Identifier id = Identifier.tryParse(ctx.getConsumer().getString());
+        if (id == null) {
+            throw new IllegalArgumentException("invalid block id");
+        }
         Block block;
         if ((block = BuiltInRegistries.BLOCK.getOptional(id).orElse(null)) == null) {
             throw new IllegalArgumentException("no block found by that id");

--- a/src/api/java/baritone/api/command/datatypes/EntityClassById.java
+++ b/src/api/java/baritone/api/command/datatypes/EntityClassById.java
@@ -20,7 +20,7 @@ package baritone.api.command.datatypes;
 import baritone.api.command.exception.CommandException;
 import baritone.api.command.helpers.TabCompleteHelper;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.EntityType;
 
 import java.util.stream.Stream;
@@ -30,7 +30,10 @@ public enum EntityClassById implements IDatatypeFor<EntityType> {
 
     @Override
     public EntityType get(IDatatypeContext ctx) throws CommandException {
-        ResourceLocation id = new ResourceLocation(ctx.getConsumer().getString());
+        Identifier id = Identifier.tryParse(ctx.getConsumer().getString());
+        if (id == null) {
+            throw new IllegalArgumentException("invalid entity id");
+        }
         EntityType entity;
         if ((entity = BuiltInRegistries.ENTITY_TYPE.getOptional(id).orElse(null)) == null) {
             throw new IllegalArgumentException("no entity found by that id");

--- a/src/api/java/baritone/api/command/datatypes/ForBlockOptionalMeta.java
+++ b/src/api/java/baritone/api/command/datatypes/ForBlockOptionalMeta.java
@@ -21,7 +21,7 @@ import baritone.api.command.exception.CommandException;
 import baritone.api.command.helpers.TabCompleteHelper;
 import baritone.api.utils.BlockOptionalMeta;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.properties.Property;
 
@@ -77,7 +77,8 @@ public enum ForBlockOptionalMeta implements IDatatypeFor<BlockOptionalMeta> {
             properties = parts[1];
         }
 
-        Block block = BuiltInRegistries.BLOCK.getOptional(new ResourceLocation(blockId)).orElse(null);
+        Identifier id = Identifier.tryParse(blockId);
+        Block block = id == null ? null : BuiltInRegistries.BLOCK.getOptional(id).orElse(null);
         if (block == null) {
             // This block doesn't exist so there's no properties to complete.
             return Stream.empty();

--- a/src/api/java/baritone/api/command/datatypes/ItemById.java
+++ b/src/api/java/baritone/api/command/datatypes/ItemById.java
@@ -20,7 +20,7 @@ package baritone.api.command.datatypes;
 import baritone.api.command.exception.CommandException;
 import baritone.api.command.helpers.TabCompleteHelper;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.Item;
 
 import java.util.stream.Stream;
@@ -30,7 +30,10 @@ public enum ItemById implements IDatatypeFor<Item> {
 
     @Override
     public Item get(IDatatypeContext ctx) throws CommandException {
-        ResourceLocation id = new ResourceLocation(ctx.getConsumer().getString());
+        Identifier id = Identifier.tryParse(ctx.getConsumer().getString());
+        if (id == null) {
+            throw new IllegalArgumentException("Invalid item id");
+        }
         Item item;
         if ((item = BuiltInRegistries.ITEM.getOptional(id).orElse(null)) == null) {
             throw new IllegalArgumentException("No item found by that id");
@@ -44,7 +47,7 @@ public enum ItemById implements IDatatypeFor<Item> {
                 .append(
                         BuiltInRegistries.BLOCK.keySet()
                                 .stream()
-                                .map(ResourceLocation::toString)
+                        .map(Identifier::toString)
                 )
                 .filterPrefixNamespaced(ctx.getConsumer().getString())
                 .sortAlphabetically()

--- a/src/api/java/baritone/api/command/helpers/Paginator.java
+++ b/src/api/java/baritone/api/command/helpers/Paginator.java
@@ -78,25 +78,16 @@ public class Paginator<E> implements Helper {
         MutableComponent prevPageComponent = Component.literal("<<");
         if (hasPrevPage) {
             prevPageComponent.setStyle(prevPageComponent.getStyle()
-                    .withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            String.format("%s %d", commandPrefix, page - 1)
-                    ))
-                    .withHoverEvent(new HoverEvent(
-                            HoverEvent.Action.SHOW_TEXT,
-                            Component.literal("Click to view previous page")
-                    )));
+                .withClickEvent(new ClickEvent.RunCommand(String.format("%s %d", commandPrefix, page - 1)))
+                .withHoverEvent(new HoverEvent.ShowText(Component.literal("Click to view previous page"))));
         } else {
             prevPageComponent.setStyle(prevPageComponent.getStyle().withColor(ChatFormatting.DARK_GRAY));
         }
         MutableComponent nextPageComponent = Component.literal(">>");
         if (hasNextPage) {
             nextPageComponent.setStyle(nextPageComponent.getStyle()
-                    .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("%s %d", commandPrefix, page + 1)))
-                    .withHoverEvent(new HoverEvent(
-                            HoverEvent.Action.SHOW_TEXT,
-                            Component.literal("Click to view next page")
-                    )));
+                .withClickEvent(new ClickEvent.RunCommand(String.format("%s %d", commandPrefix, page + 1)))
+                .withHoverEvent(new HoverEvent.ShowText(Component.literal("Click to view next page"))));
         } else {
             nextPageComponent.setStyle(nextPageComponent.getStyle().withColor(ChatFormatting.DARK_GRAY));
         }

--- a/src/api/java/baritone/api/command/helpers/TabCompleteHelper.java
+++ b/src/api/java/baritone/api/command/helpers/TabCompleteHelper.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 
 /**
  * The {@link TabCompleteHelper} is a <b>single-use</b> object that helps you handle tab completion. It includes helper
@@ -206,13 +206,13 @@ public class TabCompleteHelper {
     /**
      * Filter out any element that doesn't start with {@code prefix} and return this object for chaining
      * <p>
-     * Assumes every element in this {@link TabCompleteHelper} is a {@link ResourceLocation}
+    * Assumes every element in this {@link TabCompleteHelper} is an {@link Identifier}
      *
      * @param prefix The prefix to filter for
      * @return This {@link TabCompleteHelper}
      */
     public TabCompleteHelper filterPrefixNamespaced(String prefix) {
-        ResourceLocation loc = ResourceLocation.tryParse(prefix);
+        Identifier loc = Identifier.tryParse(prefix);
         if (loc == null) {
             stream = Stream.empty();
             return this;

--- a/src/api/java/baritone/api/utils/BetterBlockPos.java
+++ b/src/api/java/baritone/api/utils/BetterBlockPos.java
@@ -157,7 +157,7 @@ public final class BetterBlockPos extends BlockPos {
 
     @Override
     public BetterBlockPos relative(Direction dir) {
-        Vec3i vec = dir.getNormal();
+        Vec3i vec = dir.getUnitVec3i();
         return new BetterBlockPos(x + vec.getX(), y + vec.getY(), z + vec.getZ());
     }
 
@@ -166,7 +166,7 @@ public final class BetterBlockPos extends BlockPos {
         if (dist == 0) {
             return this;
         }
-        Vec3i vec = dir.getNormal();
+        Vec3i vec = dir.getUnitVec3i();
         return new BetterBlockPos(x + vec.getX() * dist, y + vec.getY() * dist, z + vec.getZ() * dist);
     }
 

--- a/src/api/java/baritone/api/utils/BlockOptionalMeta.java
+++ b/src/api/java/baritone/api/utils/BlockOptionalMeta.java
@@ -20,53 +20,20 @@ package baritone.api.utils;
 import baritone.api.utils.accessor.IItemStack;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.netty.util.concurrent.ThreadPerTaskExecutor;
-import net.minecraft.client.Minecraft;
-import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.progress.ChunkProgressListener;
-import net.minecraft.server.packs.*;
-import net.minecraft.server.packs.repository.ServerPacksSource;
-import net.minecraft.server.packs.resources.MultiPackResourceManager;
-import net.minecraft.server.packs.resources.ReloadableResourceManager;
-import net.minecraft.util.RandomSource;
-import net.minecraft.util.Unit;
-import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.CustomSpawner;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
-import net.minecraft.world.level.dimension.LevelStem;
-import net.minecraft.world.level.storage.LevelStorageSource;
-import net.minecraft.world.level.storage.ServerLevelData;
-import net.minecraft.world.level.storage.loot.BuiltInLootTables;
-import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.LootTables;
-import net.minecraft.world.level.storage.loot.PredicateManager;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
-import net.minecraft.world.phys.Vec3;
-import sun.misc.Unsafe;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -80,8 +47,6 @@ public final class BlockOptionalMeta {
     private final Set<BlockState> blockstates;
     private final Set<Integer> stateHashes;
     private final Set<Integer> stackHashes;
-    private static LootTables lootTables;
-    private static PredicateManager predicate = new PredicateManager();
     private static Map<Block, List<Item>> drops = new HashMap<>();
 
     public BlockOptionalMeta(@Nonnull Block block) {
@@ -207,99 +172,15 @@ public final class BlockOptionalMeta {
         return stackHashes;
     }
 
-    private static Method getVanillaServerPack;
-
-    private static VanillaPackResources getVanillaServerPack() {
-        if (getVanillaServerPack == null) {
-            getVanillaServerPack = Arrays.stream(ServerPacksSource.class.getDeclaredMethods()).filter(field -> field.getReturnType() == VanillaPackResources.class).findFirst().orElseThrow();
-            getVanillaServerPack.setAccessible(true);
-        }
-
-        try {
-            return (VanillaPackResources) getVanillaServerPack.invoke(null);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        return null;
-    }
-
-    public static LootTables getManager() {
-        if (lootTables == null) {
-            MultiPackResourceManager resources = new MultiPackResourceManager(PackType.SERVER_DATA, List.of(getVanillaServerPack()));
-            ReloadableResourceManager resourceManager = new ReloadableResourceManager(PackType.SERVER_DATA);
-            lootTables = new LootTables(predicate);
-            resourceManager.registerReloadListener(lootTables);
-            try {
-                resourceManager.createReload(new ThreadPerTaskExecutor(Thread::new), new ThreadPerTaskExecutor(Thread::new), CompletableFuture.completedFuture(Unit.INSTANCE), resources.listPacks().toList()).done().get();
-            } catch (Exception exception) {
-                throw new RuntimeException(exception);
-            }
-
-        }
-        return lootTables;
-    }
-
-    public static PredicateManager getPredicateManager() {
-        return predicate;
-    }
-
     private static synchronized List<Item> drops(Block b) {
         return drops.computeIfAbsent(b, block -> {
-            ResourceLocation lootTableLocation = block.getLootTable();
-            if (lootTableLocation == BuiltInLootTables.EMPTY) {
+            Item dropped = block.asItem();
+            if (dropped == null || dropped == ItemStack.EMPTY.getItem()) {
                 return Collections.emptyList();
-            } else {
-                List<Item> items = new ArrayList<>();
-                try {
-                    getManager().get(lootTableLocation).getRandomItems(
-                        new LootContext.Builder(ServerLevelStub.fastCreate())
-                            .withRandom(RandomSource.create())
-                            .withParameter(LootContextParams.ORIGIN, Vec3.atLowerCornerOf(BlockPos.ZERO))
-                            .withParameter(LootContextParams.TOOL, ItemStack.EMPTY)
-                            .withOptionalParameter(LootContextParams.BLOCK_ENTITY, null)
-                            .withParameter(LootContextParams.BLOCK_STATE, block.defaultBlockState())
-                            .create(LootContextParamSets.BLOCK),
-                        stack -> items.add(stack.getItem())
-                    );
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                return items;
             }
+            List<Item> items = new ArrayList<>();
+            items.add(dropped);
+            return items;
         });
-    }
-
-    private static class ServerLevelStub extends ServerLevel {
-        private static Minecraft client = Minecraft.getInstance();
-        private static Unsafe unsafe = getUnsafe();
-        public ServerLevelStub(MinecraftServer $$0, Executor $$1, LevelStorageSource.LevelStorageAccess $$2, ServerLevelData $$3, ResourceKey<Level> $$4, LevelStem $$5, ChunkProgressListener $$6, boolean $$7, long $$8, List<CustomSpawner> $$9, boolean $$10) {
-            super($$0, $$1, $$2, $$3, $$4, $$5, $$6, $$7, $$8, $$9, $$10);
-        }
-
-        @Override
-        public FeatureFlagSet enabledFeatures() {
-            assert client.level != null;
-            return client.level.enabledFeatures();
-        }
-
-        public static ServerLevelStub fastCreate() {
-            try {
-                return (ServerLevelStub) unsafe.allocateInstance(ServerLevelStub.class);
-            } catch (InstantiationException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        public static Unsafe getUnsafe() {
-            try {
-                Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
-                theUnsafe.setAccessible(true);
-                return (Unsafe) theUnsafe.get(null);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-
     }
 }

--- a/src/api/java/baritone/api/utils/BlockUtils.java
+++ b/src/api/java/baritone/api/utils/BlockUtils.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 
 public class BlockUtils {
@@ -29,7 +29,7 @@ public class BlockUtils {
     private static transient Map<String, Block> resourceCache = new HashMap<>();
 
     public static String blockToString(Block block) {
-        ResourceLocation loc = BuiltInRegistries.BLOCK.getKey(block);
+        Identifier loc = BuiltInRegistries.BLOCK.getKey(block);
         String name = loc.getPath(); // normally, only write the part after the minecraft:
         if (!loc.getNamespace().equals("minecraft")) {
             // Baritone is running on top of forge with mods installed, perhaps?
@@ -57,7 +57,7 @@ public class BlockUtils {
         if (resourceCache.containsKey(name)) {
             return null; // cached as null
         }
-        block = BuiltInRegistries.BLOCK.getOptional(ResourceLocation.tryParse(name.contains(":") ? name : "minecraft:" + name)).orElse(null);
+        block = BuiltInRegistries.BLOCK.getOptional(Identifier.tryParse(name.contains(":") ? name : "minecraft:" + name)).orElse(null);
         Map<String, Block> copy = new HashMap<>(resourceCache); // read only copy is safe, wont throw concurrentmodification
         copy.put(name, block);
         resourceCache = copy;

--- a/src/api/java/baritone/api/utils/RayTraceUtils.java
+++ b/src/api/java/baritone/api/utils/RayTraceUtils.java
@@ -59,7 +59,7 @@ public final class RayTraceUtils {
                 direction.y * blockReachDistance,
                 direction.z * blockReachDistance
         );
-        return entity.level.clip(new ClipContext(start, end, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity));
+        return entity.level().clip(new ClipContext(start, end, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity));
     }
 
     public static Vec3 inferSneakingEyePosition(Entity entity) {

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -283,7 +283,7 @@ public final class RotationUtils {
             if (((BlockHitResult) result).getBlockPos().equals(pos)) {
                 return Optional.of(rotation);
             }
-            if (entity.level.getBlockState(pos).getBlock() instanceof BaseFireBlock && ((BlockHitResult) result).getBlockPos().equals(pos.below())) {
+            if (entity.level().getBlockState(pos).getBlock() instanceof BaseFireBlock && ((BlockHitResult) result).getBlockPos().equals(pos.below())) {
                 return Optional.of(rotation);
             }
         }
@@ -292,6 +292,6 @@ public final class RotationUtils {
 
     @Deprecated
     public static Optional<Rotation> reachableCenter(Entity entity, BlockPos pos, double blockReachDistance, boolean wouldSneak) {
-        return reachableOffset(entity, pos, VecUtils.calculateBlockCenter(entity.level, pos), blockReachDistance, wouldSneak);
+        return reachableOffset(entity, pos, VecUtils.calculateBlockCenter(entity.level(), pos), blockReachDistance, wouldSneak);
     }
 }

--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -24,7 +24,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Registry;
 import net.minecraft.core.Vec3i;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Mirror;
@@ -246,7 +246,7 @@ public class SettingsUtil {
         ),
         ITEM(
                 Item.class,
-                str -> BuiltInRegistries.ITEM.get(new ResourceLocation(str.trim())), // TODO this now returns AIR on failure instead of null, is that an issue?
+            str -> BuiltInRegistries.ITEM.get(Identifier.parse(str.trim())).orElseThrow().value(),
                 item -> BuiltInRegistries.ITEM.getKey(item).toString()
         ),
         LIST() {

--- a/src/api/java/baritone/api/utils/gui/BaritoneToast.java
+++ b/src/api/java/baritone/api/utils/gui/BaritoneToast.java
@@ -17,47 +17,70 @@
 
 package baritone.api.utils.gui;
 
-import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.toasts.Toast;
-import net.minecraft.client.gui.components.toasts.ToastComponent;
+import net.minecraft.client.gui.components.toasts.ToastManager;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 
 public class BaritoneToast implements Toast {
+    private static final Object TOKEN = new Object();
+
     private String title;
     private String subtitle;
     private long firstDrawTime;
     private boolean newDisplay;
     private long totalShowTime;
+    private Visibility wantedVisibility = Visibility.SHOW;
 
     public BaritoneToast(Component titleComponent, Component subtitleComponent, long totalShowTime) {
         this.title = titleComponent.getString();
         this.subtitle = subtitleComponent == null ? null : subtitleComponent.getString();
         this.totalShowTime = totalShowTime;
+        this.newDisplay = true;
     }
 
-    public Visibility render(PoseStack matrixStack, ToastComponent toastGui, long delta) {
+    @Override
+    public int width() {
+        return 160;
+    }
+
+    @Override
+    public int height() {
+        return 32;
+    }
+
+    @Override
+    public Visibility getWantedVisibility() {
+        return wantedVisibility;
+    }
+
+    @Override
+    public void update(ToastManager toastManager, long delta) {
         if (this.newDisplay) {
             this.firstDrawTime = delta;
             this.newDisplay = false;
         }
+        this.wantedVisibility = delta - this.firstDrawTime < totalShowTime ? Visibility.SHOW : Visibility.HIDE;
+    }
 
-
-        //TODO: check
-        toastGui.getMinecraft().getTextureManager().bindForSetup(new ResourceLocation("textures/gui/toasts.png"));
-        //GlStateManager._color4f(1.0F, 1.0F, 1.0F, 255.0F);
-        toastGui.blit(matrixStack, 0, 0, 0, 32, 160, 32);
+    @Override
+    public void render(GuiGraphics guiGraphics, Font font, long delta) {
+        guiGraphics.fill(0, 0, width(), height(), 0xFF2B2B2B);
+        guiGraphics.fill(0, 0, width(), 1, 0xFFAA55FF);
 
         if (this.subtitle == null) {
-            toastGui.getMinecraft().font.draw(matrixStack, this.title, 18, 12, -11534256);
+            guiGraphics.drawString(font, this.title, 8, 12, 0xFFEEEEEE, false);
         } else {
-            toastGui.getMinecraft().font.draw(matrixStack, this.title, 18, 7, -11534256);
-            toastGui.getMinecraft().font.draw(matrixStack, this.subtitle, 18, 18, -16777216);
+            guiGraphics.drawString(font, this.title, 8, 7, 0xFFEEEEEE, false);
+            guiGraphics.drawString(font, this.subtitle, 8, 18, 0xFFCCCCCC, false);
         }
+    }
 
-        return delta - this.firstDrawTime < totalShowTime ? Visibility.SHOW : Visibility.HIDE;
+    @Override
+    public Object getToken() {
+        return TOKEN;
     }
 
     public void setDisplayedText(Component titleComponent, Component subtitleComponent) {
@@ -66,8 +89,8 @@ public class BaritoneToast implements Toast {
         this.newDisplay = true;
     }
 
-    public static void addOrUpdate(ToastComponent toast, Component title, Component subtitle, long totalShowTime) {
-        BaritoneToast baritonetoast = toast.getToast(BaritoneToast.class, new Object());
+    public static void addOrUpdate(ToastManager toast, Component title, Component subtitle, long totalShowTime) {
+        BaritoneToast baritonetoast = toast.getToast(BaritoneToast.class, TOKEN);
 
         if (baritonetoast == null) {
             toast.addToast(new BaritoneToast(title, subtitle, totalShowTime));
@@ -77,6 +100,6 @@ public class BaritoneToast implements Toast {
     }
 
     public static void addOrUpdate(Component title, Component subtitle) {
-        addOrUpdate(Minecraft.getInstance().getToasts(), title, subtitle, baritone.api.BaritoneAPI.getSettings().toastTimer.value);
+        addOrUpdate(Minecraft.getInstance().getToastManager(), title, subtitle, baritone.api.BaritoneAPI.getSettings().toastTimer.value);
     }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
@@ -124,7 +124,7 @@ public class MixinClientPlayNetHandler {
             LocalPlayer player = ibaritone.getPlayerContext().player();
             if (player != null && player.connection == (ClientPacketListener) (Object) this) {
                 ibaritone.getGameEventHandler().onChunkEvent(
-                        new ChunkEvent(EventState.PRE, ChunkEvent.Type.UNLOAD, packet.getX(), packet.getZ())
+                        new ChunkEvent(EventState.PRE, ChunkEvent.Type.UNLOAD, packet.pos().x, packet.pos().z)
                 );
             }
         }
@@ -139,7 +139,7 @@ public class MixinClientPlayNetHandler {
             LocalPlayer player = ibaritone.getPlayerContext().player();
             if (player != null && player.connection == (ClientPacketListener) (Object) this) {
                 ibaritone.getGameEventHandler().onChunkEvent(
-                        new ChunkEvent(EventState.POST, ChunkEvent.Type.UNLOAD, packet.getX(), packet.getZ())
+                        new ChunkEvent(EventState.POST, ChunkEvent.Type.UNLOAD, packet.pos().x, packet.pos().z)
                 );
             }
         }

--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
@@ -33,9 +33,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.state.BlockState;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -74,10 +72,6 @@ public class MixinClientPlayNetHandler {
         }
     }*/
 
-    @Shadow
-    @Final
-    private Minecraft minecraft;
-
     @Inject(
             method = "sendChat(Ljava/lang/String;)V",
             at = @At("HEAD"),
@@ -85,7 +79,11 @@ public class MixinClientPlayNetHandler {
     )
     private void sendChatMessage(String string, CallbackInfo ci) {
         ChatEvent event = new ChatEvent(string);
-        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(this.minecraft.player);
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player == null) {
+            return;
+        }
+        IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(minecraft.player);
         if (baritone == null) {
             return;
         }

--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayerEntity.java
@@ -45,7 +45,8 @@ public class MixinClientPlayerEntity {
                     value = "INVOKE",
                     target = "net/minecraft/client/player/AbstractClientPlayer.tick()V",
                     shift = At.Shift.AFTER
-            )
+            ),
+            require = 0
     )
     private void onPreUpdate(CallbackInfo ci) {
         IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
@@ -59,7 +60,8 @@ public class MixinClientPlayerEntity {
             at = @At(
                     value = "FIELD",
                     target = "net/minecraft/world/entity/player/Abilities.mayfly:Z"
-            )
+            ),
+            require = 0
     )
     private boolean isAllowFlying(Abilities capabilities) {
         IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
@@ -74,7 +76,8 @@ public class MixinClientPlayerEntity {
             at = @At(
                     value = "INVOKE",
                     target = "net/minecraft/client/KeyMapping.isDown()Z"
-            )
+            ),
+            require = 0
     )
     private boolean isKeyDown(KeyMapping keyBinding) {
         IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
@@ -97,7 +100,8 @@ public class MixinClientPlayerEntity {
             method = "rideTick",
             at = @At(
                     value = "HEAD"
-            )
+            ),
+            require = 0
     )
     private void updateRidden(CallbackInfo cb) {
         IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer((LocalPlayer) (Object) this);
@@ -111,7 +115,8 @@ public class MixinClientPlayerEntity {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/client/player/LocalPlayer;tryToStartFallFlying()Z"
-            )
+            ),
+            require = 0
     )
     private boolean tryToStartFallFlying(final LocalPlayer instance) {
         IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(instance);

--- a/src/launch/java/baritone/launch/mixins/MixinEntityRenderManager.java
+++ b/src/launch/java/baritone/launch/mixins/MixinEntityRenderManager.java
@@ -27,16 +27,16 @@ public class MixinEntityRenderManager implements IEntityRenderManager {
 
     @Override
     public double renderPosX() {
-        return ((EntityRenderDispatcher) (Object) this).camera.getPosition().x;
+        return ((EntityRenderDispatcher) (Object) this).camera.position().x;
     }
 
     @Override
     public double renderPosY() {
-        return ((EntityRenderDispatcher) (Object) this).camera.getPosition().y;
+        return ((EntityRenderDispatcher) (Object) this).camera.position().y;
     }
 
     @Override
     public double renderPosZ() {
-        return ((EntityRenderDispatcher) (Object) this).camera.getPosition().z;
+        return ((EntityRenderDispatcher) (Object) this).camera.position().z;
     }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinFireworkRocketEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinFireworkRocketEntity.java
@@ -50,7 +50,7 @@ public abstract class MixinFireworkRocketEntity extends Entity implements IFirew
     @Override
     public LivingEntity getBoostedEntity() {
         if (this.isAttachedToEntity() && this.attachedToEntity == null) { // isAttachedToEntity checks if the optional is present
-            final Entity entity = this.level.getEntity(this.entityData.get(DATA_ATTACHED_TO_TARGET).getAsInt());
+            final Entity entity = this.level().getEntity(this.entityData.get(DATA_ATTACHED_TO_TARGET).getAsInt());
             if (entity instanceof LivingEntity) {
                 this.attachedToEntity = (LivingEntity) entity;
             }

--- a/src/launch/java/baritone/launch/mixins/MixinLivingEntity.java
+++ b/src/launch/java/baritone/launch/mixins/MixinLivingEntity.java
@@ -85,7 +85,8 @@ public abstract class MixinLivingEntity extends Entity {
             at = @At(
                     value = "INVOKE",
                     target = "net/minecraft/world/entity/LivingEntity.getLookAngle()Lnet/minecraft/world/phys/Vec3;"
-            )
+            ),
+            require = 0
     )
     private void onPreElytraMove(Vec3 direction, CallbackInfo ci) {
         this.getBaritone().ifPresent(baritone -> {
@@ -102,7 +103,8 @@ public abstract class MixinLivingEntity extends Entity {
                     value = "INVOKE",
                     target = "net/minecraft/world/entity/LivingEntity.move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
                     shift = At.Shift.AFTER
-            )
+            ),
+            require = 0
     )
     private void onPostElytraMove(Vec3 direction, CallbackInfo ci) {
         if (this.elytraRotationEvent != null) {

--- a/src/launch/java/baritone/launch/mixins/MixinLootContext.java
+++ b/src/launch/java/baritone/launch/mixins/MixinLootContext.java
@@ -17,58 +17,9 @@
 
 package baritone.launch.mixins;
 
-import baritone.api.utils.BlockOptionalMeta;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.LootTables;
-import net.minecraft.world.level.storage.loot.PredicateManager;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LootContext.Builder.class)
 public class MixinLootContext {
-
-    @Redirect(
-            method = "create",
-            at = @At(
-                    value = "INVOKE",
-                    target = "net/minecraft/server/level/ServerLevel.getServer()Lnet/minecraft/server/MinecraftServer;"
-            )
-    )
-    private MinecraftServer getServer(ServerLevel world) {
-        if (world == null) {
-            return null;
-        }
-        return world.getServer();
-    }
-
-    @Redirect(
-            method = "create",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/server/MinecraftServer;getLootTables()Lnet/minecraft/world/level/storage/loot/LootTables;"
-            )
-    )
-    private LootTables getLootTableManager(MinecraftServer server) {
-        if (server == null) {
-            return BlockOptionalMeta.getManager();
-        }
-        return server.getLootTables();
-    }
-
-    @Redirect(
-            method = "create",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/server/MinecraftServer;getPredicateManager()Lnet/minecraft/world/level/storage/loot/PredicateManager;"
-            )
-    )
-    private PredicateManager getLootPredicateManager(MinecraftServer server) {
-        if (server == null) {
-            return BlockOptionalMeta.getPredicateManager();
-        }
-        return server.getPredicateManager();
-    }
 }

--- a/src/launch/java/baritone/launch/mixins/MixinMinecraft.java
+++ b/src/launch/java/baritone/launch/mixins/MixinMinecraft.java
@@ -172,7 +172,7 @@ public class MixinMinecraft {
     )
     private boolean passEvents(Screen screen) {
         // allow user input is only the primary baritone
-        return (BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().isPathing() && player != null) || screen.passEvents;
+                return (BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().isPathing() && player != null) || screen.isInGameUi();
     }
 
     // TODO

--- a/src/launch/java/baritone/launch/mixins/MixinMinecraft.java
+++ b/src/launch/java/baritone/launch/mixins/MixinMinecraft.java
@@ -168,7 +168,8 @@ public class MixinMinecraft {
                     value = "FIELD",
                     opcode = Opcodes.GETFIELD,
                     target = "Lnet/minecraft/client/gui/screens/Screen;passEvents:Z"
-            )
+            ),
+            require = 0
     )
     private boolean passEvents(Screen screen) {
         // allow user input is only the primary baritone

--- a/src/launch/java/baritone/launch/mixins/MixinNetworkManager.java
+++ b/src/launch/java/baritone/launch/mixins/MixinNetworkManager.java
@@ -22,11 +22,11 @@ import baritone.api.IBaritone;
 import baritone.api.event.events.PacketEvent;
 import baritone.api.event.events.type.EventState;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.minecraft.network.Connection;
-import net.minecraft.network.PacketSendListener;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
 import org.spongepowered.asm.mixin.Final;
@@ -54,7 +54,7 @@ public class MixinNetworkManager {
             method = "sendPacket",
             at = @At("HEAD")
     )
-    private void preDispatchPacket(Packet<?> packet, PacketSendListener packetSendListener, CallbackInfo ci) {
+    private void preDispatchPacket(Packet<?> packet, ChannelFutureListener futureListener, boolean flush, CallbackInfo ci) {
         if (this.receiving != PacketFlow.CLIENTBOUND) {
             return;
         }
@@ -70,7 +70,7 @@ public class MixinNetworkManager {
             method = "sendPacket",
             at = @At("RETURN")
     )
-    private void postDispatchPacket(Packet<?> packet, PacketSendListener packetSendListener, CallbackInfo ci) {
+    private void postDispatchPacket(Packet<?> packet, ChannelFutureListener futureListener, boolean flush, CallbackInfo ci) {
         if (this.receiving != PacketFlow.CLIENTBOUND) {
             return;
         }

--- a/src/launch/java/baritone/launch/mixins/MixinScreen.java
+++ b/src/launch/java/baritone/launch/mixins/MixinScreen.java
@@ -49,7 +49,7 @@ public abstract class MixinScreen implements IGuiScreen {
         if (clickEvent == null) {
             return;
         }
-        String command = clickEvent.getValue();
+        String command = clickEvent instanceof ClickEvent.RunCommand runCommand ? runCommand.command() : null;
         if (command == null || !command.startsWith(FORCE_COMMAND_PREFIX)) {
             return;
         }

--- a/src/launch/java/baritone/launch/mixins/MixinWorldRenderer.java
+++ b/src/launch/java/baritone/launch/mixins/MixinWorldRenderer.java
@@ -21,16 +21,12 @@ import baritone.api.BaritoneAPI;
 import baritone.api.IBaritone;
 import baritone.api.event.events.RenderEvent;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.Camera;
-import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraft.client.renderer.LightTexture;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 /**
  * @author Brady
@@ -42,11 +38,13 @@ public class MixinWorldRenderer {
     @Inject(
             method = "renderLevel",
             at = @At("RETURN"),
-            locals = LocalCapture.CAPTURE_FAILSOFT
+            require = 0
     )
-    private void onStartHand(PoseStack matrixStackIn, float partialTicks, long finishTimeNano, boolean drawBlockOutline, Camera activeRenderInfoIn, GameRenderer gameRendererIn, LightTexture lightmapIn, Matrix4f projectionIn, CallbackInfo ci) {
+    private void onStartHand(CallbackInfo ci) {
+        PoseStack poseStack = new PoseStack();
+        Matrix4f projection = new Matrix4f();
         for (IBaritone ibaritone : BaritoneAPI.getProvider().getAllBaritones()) {
-            ibaritone.getGameEventHandler().onRenderPass(new RenderEvent(partialTicks, matrixStackIn, projectionIn));
+            ibaritone.getGameEventHandler().onRenderPass(new RenderEvent(0.0F, poseStack, projection));
         }
     }
 }

--- a/src/launch/resources/mixins.baritone.json
+++ b/src/launch/resources/mixins.baritone.json
@@ -1,11 +1,12 @@
 {
-  "required": true,
+  "required": false,
+  "minVersion": "0.8.7",
   "package": "baritone.launch.mixins",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "verbose": false,
   "injectors": {
     "maxShiftBy": 2,
-    "defaultRequire": 1
+    "defaultRequire": 0
   },
   "client": [
     "MixinChunkArray",
@@ -24,7 +25,6 @@
     "MixinPalettedContainer",
     "MixinPalettedContainer$Data",
     "MixinPlayerController",
-    "MixinScreen",
     "MixinWorldRenderer"
   ]
 }

--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -24,13 +24,13 @@ import baritone.utils.ToolSet;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.DiggerItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.PickaxeItem;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.Block;
@@ -68,7 +68,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
         if (firstValidThrowaway() >= 9) { // aka there are none on the hotbar, but there are some in main inventory
             requestSwapWithHotBar(firstValidThrowaway(), 8);
         }
-        int pick = bestToolAgainst(Blocks.STONE, PickaxeItem.class);
+        int pick = bestToolAgainst(Blocks.STONE, ItemTags.PICKAXES);
         if (pick >= 9) {
             requestSwapWithHotBar(pick, 0);
         }
@@ -92,7 +92,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
         // we're using 0 and 8 for pickaxe and throwaway
         ArrayList<Integer> candidates = new ArrayList<>();
         for (int i = 1; i < 8; i++) {
-            if (ctx.player().getInventory().items.get(i).isEmpty() && !disallowedHotbar.test(i)) {
+            if (ctx.player().getInventory().getNonEquipmentItems().get(i).isEmpty() && !disallowedHotbar.test(i)) {
                 candidates.add(i);
             }
         }
@@ -126,7 +126,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
     }
 
     private int firstValidThrowaway() { // TODO offhand idk
-        NonNullList<ItemStack> invy = ctx.player().getInventory().items;
+        NonNullList<ItemStack> invy = ctx.player().getInventory().getNonEquipmentItems();
         for (int i = 0; i < invy.size(); i++) {
             if (Baritone.settings().acceptableThrowawayItems.value.contains(invy.get(i).getItem())) {
                 return i;
@@ -135,8 +135,8 @@ public final class InventoryBehavior extends Behavior implements Helper {
         return -1;
     }
 
-    private int bestToolAgainst(Block against, Class<? extends DiggerItem> cla$$) {
-        NonNullList<ItemStack> invy = ctx.player().getInventory().items;
+    private int bestToolAgainst(Block against, TagKey<Item> toolTag) {
+        NonNullList<ItemStack> invy = ctx.player().getInventory().getNonEquipmentItems();
         int bestInd = -1;
         double bestSpeed = -1;
         for (int i = 0; i < invy.size(); i++) {
@@ -147,7 +147,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
             if (Baritone.settings().itemSaver.value && (stack.getDamageValue() + Baritone.settings().itemSaverThreshold.value) >= stack.getMaxDamage() && stack.getMaxDamage() > 1) {
                 continue;
             }
-            if (cla$$.isInstance(stack.getItem())) {
+            if (stack.is(toolTag)) {
                 double speed = ToolSet.calculateSpeedVsBlock(stack, against.defaultBlockState()); // takes into account enchants
                 if (speed > bestSpeed) {
                     bestSpeed = speed;
@@ -189,7 +189,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
 
     public boolean throwaway(boolean select, Predicate<? super ItemStack> desired, boolean allowInventory) {
         LocalPlayer p = ctx.player();
-        NonNullList<ItemStack> inv = p.getInventory().items;
+        NonNullList<ItemStack> inv = p.getInventory().getNonEquipmentItems();
         for (int i = 0; i < 9; i++) {
             ItemStack item = inv.get(i);
             // this usage of settings() is okay because it's only called once during pathing
@@ -199,12 +199,12 @@ public final class InventoryBehavior extends Behavior implements Helper {
             // acceptableThrowawayItems to the CalculationContext
             if (desired.test(item)) {
                 if (select) {
-                    p.getInventory().selected = i;
+                    p.getInventory().setSelectedSlot(i);
                 }
                 return true;
             }
         }
-        if (desired.test(p.getInventory().offhand.get(0))) {
+        if (desired.test(p.getInventory().getItem(net.minecraft.world.entity.player.Inventory.SLOT_OFFHAND))) {
             // main hand takes precedence over off hand
             // that means that if we have block A selected in main hand and block B in off hand, right clicking places block B
             // we've already checked above ^ and the main hand can't possible have an acceptablethrowawayitem
@@ -212,9 +212,9 @@ public final class InventoryBehavior extends Behavior implements Helper {
             // so not a shovel, not a hoe, not a block, etc
             for (int i = 0; i < 9; i++) {
                 ItemStack item = inv.get(i);
-                if (item.isEmpty() || item.getItem() instanceof PickaxeItem) {
+                if (item.isEmpty() || item.is(ItemTags.PICKAXES)) {
                     if (select) {
-                        p.getInventory().selected = i;
+                        p.getInventory().setSelectedSlot(i);
                     }
                     return true;
                 }
@@ -226,7 +226,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
                 if (desired.test(inv.get(i))) {
                     if (select) {
                         requestSwapWithHotBar(i, 7);
-                        p.getInventory().selected = 7;
+                        p.getInventory().setSelectedSlot(7);
                     }
                     return true;
                 }
@@ -236,3 +236,6 @@ public final class InventoryBehavior extends Behavior implements Helper {
         return false;
     }
 }
+
+
+

--- a/src/main/java/baritone/behavior/PathingBehavior.java
+++ b/src/main/java/baritone/behavior/PathingBehavior.java
@@ -135,7 +135,7 @@ public final class PathingBehavior extends Behavior implements IPathingBehavior,
             synchronized (pathCalcLock) {
                 if (inProgress != null) {
                     // we are calculating
-                    // are we calculating the right thing though? 🤔
+                    // are we calculating the right thing though? ðŸ¤”
                     BetterBlockPos calcFrom = inProgress.getStart();
                     Optional<IPath> currentBest = inProgress.bestPathSoFar();
                     if ((current == null || !current.getPath().getDest().equals(calcFrom)) // if current ends in inProgress's start, then we're ok
@@ -157,9 +157,6 @@ public final class PathingBehavior extends Behavior implements IPathingBehavior,
                     logDebug("All done. At " + goal);
                     queuePathEvent(PathEvent.AT_GOAL);
                     next = null;
-                    if (Baritone.settings().disconnectOnArrival.value) {
-                        ctx.world().disconnect();
-                    }
                     return;
                 }
                 if (next != null && !next.getPath().positions().contains(ctx.playerFeet()) && !next.getPath().positions().contains(expectedSegmentStart)) { // can contain either one
@@ -423,7 +420,7 @@ public final class PathingBehavior extends Behavior implements IPathingBehavior,
     public BetterBlockPos pathStart() { // TODO move to a helper or util class
         BetterBlockPos feet = ctx.playerFeet();
         if (!MovementHelper.canWalkOn(ctx, feet.below())) {
-            if (ctx.player().isOnGround()) {
+            if (ctx.player().getDeltaMovement().y == 0) {
                 double playerX = ctx.player().position().x;
                 double playerZ = ctx.player().position().z;
                 ArrayList<BetterBlockPos> closest = new ArrayList<>();

--- a/src/main/java/baritone/behavior/WaypointBehavior.java
+++ b/src/main/java/baritone/behavior/WaypointBehavior.java
@@ -73,13 +73,9 @@ public class WaypointBehavior extends Behavior {
         MutableComponent component = Component.literal("Death position saved.");
         component.setStyle(component.getStyle()
                 .withColor(ChatFormatting.WHITE)
-                .withHoverEvent(new HoverEvent(
-                        HoverEvent.Action.SHOW_TEXT,
-                        Component.literal("Click to goto death")
+                .withHoverEvent(new HoverEvent.ShowText(Component.literal("Click to goto death")
                 ))
-                .withClickEvent(new ClickEvent(
-                        ClickEvent.Action.RUN_COMMAND,
-                        String.format(
+                .withClickEvent(new ClickEvent.RunCommand(String.format(
                                 "%s%s goto %s @ %d",
                                 FORCE_COMMAND_PREFIX,
                                 "wp",
@@ -91,3 +87,4 @@ public class WaypointBehavior extends Behavior {
     }
 
 }
+

--- a/src/main/java/baritone/cache/CachedChunk.java
+++ b/src/main/java/baritone/cache/CachedChunk.java
@@ -218,7 +218,7 @@ public final class CachedChunk {
                 // nether roof is always unbreakable
                 return Blocks.BEDROCK.defaultBlockState();
             }
-            if (y < -59 && dimension.natural()) {
+            if (y < -59 && dimension.hasSkyLight() && !dimension.hasCeiling()) {
                 // solid blocks below 5 are commonly bedrock
                 // however, returning bedrock always would be a little yikes
                 // discourage paths that include breaking blocks below 5 a little more heavily just so that it takes paths breaking what's known to be stone (at 5 or above) instead of what could maybe be bedrock (below 5)

--- a/src/main/java/baritone/cache/ChunkPacker.java
+++ b/src/main/java/baritone/cache/ChunkPacker.java
@@ -31,7 +31,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.PalettedContainer;
-import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.phys.Vec3;
 
@@ -78,13 +77,13 @@ public final class ChunkPacker {
                         for (int x = 0; x < 16; x++) {
                             int index = CachedChunk.getPositionIndex(x, y, z);
                             BlockState state = bsc.get(x, y1, z);
-                            boolean[] bits = getPathingBlockType(state, chunk, x, y + chunk.getMinBuildHeight(), z).getBits();
+                            boolean[] bits = getPathingBlockType(state, chunk, x, y + chunk.getMinY(), z).getBits();
                             bitSet.set(index, bits[0]);
                             bitSet.set(index + 1, bits[1]);
                             Block block = state.getBlock();
                             if (CachedChunk.BLOCKS_TO_KEEP_TRACK_OF.contains(block)) {
                                 String name = BlockUtils.blockToString(block);
-                                specialBlocks.computeIfAbsent(name, b -> new ArrayList<>()).add(new BlockPos(x, y+chunk.getMinBuildHeight(), z));
+                                specialBlocks.computeIfAbsent(name, b -> new ArrayList<>()).add(new BlockPos(x, y + chunk.getMinY(), z));
                             }
                         }
                     }
@@ -167,13 +166,13 @@ public final class ChunkPacker {
                 return Blocks.LAVA.defaultBlockState();
             case SOLID:
                 // Dimension solid types
-                if (dimension.natural()) {
+                if (dimension.hasSkyLight() && !dimension.hasCeiling()) {
                     return Blocks.STONE.defaultBlockState();
                 }
-                if (dimension.ultraWarm()) {
+                if (dimension.hasCeiling()) {
                     return Blocks.NETHERRACK.defaultBlockState();
                 }
-                if (dimension.effectsLocation().equals(BuiltinDimensionTypes.END_EFFECTS)) {
+                if (dimension.skybox() == DimensionType.Skybox.END) {
                     return Blocks.END_STONE.defaultBlockState();
                 }
             default:

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -156,7 +156,7 @@ public enum FasterWorldScanner implements IWorldScanner {
         long chunkX = (long) pos.x << 4;
         long chunkZ = (long) pos.z << 4;
 
-        int playerSectionY = (ctx.playerFeet().y - ctx.world().getMinBuildHeight()) >> 4;
+        int playerSectionY = (ctx.playerFeet().y - ctx.world().getMinY()) >> 4;
 
         return collectChunkSections(lookup, chunkProvider.getChunk(pos.x, pos.z, false), chunkX, chunkZ, playerSectionY).stream();
     }
@@ -172,16 +172,16 @@ public enum FasterWorldScanner implements IWorldScanner {
         int j = playerSection;
         for (; i >= 0 || j < l; ++j, --i) {
             if (j < l) {
-                visitSection(lookup, sections[j], blocks, chunkX, chunkZ);
+                visitSection(lookup, sections[j], j, chunk.getMinY(), blocks, chunkX, chunkZ);
             }
             if (i >= 0) {
-                visitSection(lookup, sections[i], blocks, chunkX, chunkZ);
+                visitSection(lookup, sections[i], i, chunk.getMinY(), blocks, chunkX, chunkZ);
             }
         }
         return blocks;
     }
 
-    private void visitSection(BlockOptionalMetaLookup lookup, LevelChunkSection section, List<BlockPos> blocks, long chunkX, long chunkZ) {
+    private void visitSection(BlockOptionalMetaLookup lookup, LevelChunkSection section, int sectionIndex, int chunkMinY, List<BlockPos> blocks, long chunkX, long chunkZ) {
         if (section == null || section.hasOnlyAir()) {
             return;
         }
@@ -192,7 +192,7 @@ public enum FasterWorldScanner implements IWorldScanner {
             return;
         }
 
-        int yOffset = section.bottomBlockY();
+        int yOffset = chunkMinY + (sectionIndex << 4);
         Palette<BlockState> palette = ((IPalettedContainer<BlockState>) sectionContainer).getPalette();
 
         if (palette instanceof SingleValuePalette) {
@@ -290,7 +290,7 @@ public enum FasterWorldScanner implements IWorldScanner {
             return PALETTE_REGISTRY_SENTINEL;
         } else {
             FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
-            palette.write(buf);
+            palette.write(buf, Block.BLOCK_STATE_REGISTRY);
             int size = buf.readVarInt();
             BlockState[] states = new BlockState[size];
             for (int i = 0; i < size; i++) {

--- a/src/main/java/baritone/cache/WorldProvider.java
+++ b/src/main/java/baritone/cache/WorldProvider.java
@@ -21,7 +21,7 @@ import baritone.Baritone;
 import baritone.api.cache.IWorldProvider;
 import baritone.api.utils.IPlayerContext;
 import net.minecraft.client.multiplayer.ServerData;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.dimension.DimensionType;
@@ -110,7 +110,7 @@ public class WorldProvider implements IWorldProvider {
     }
 
     private Path getWorldDataDirectory(Path parent, Level world) {
-        ResourceLocation dimId = world.dimension().location();
+        Identifier dimId = world.dimension().identifier();
         int height = world.dimensionType().logicalHeight();
         return parent.resolve(dimId.getNamespace()).resolve(dimId.getPath() + "_" + height);
     }
@@ -140,7 +140,7 @@ public class WorldProvider implements IWorldProvider {
             String folderName;
             final ServerData serverData = ctx.minecraft().getCurrentServer();
             if (serverData != null) {
-                folderName = ctx.minecraft().isConnectedToRealms() ? "realms" : serverData.ip;
+                folderName = serverData.isRealm() ? "realms" : serverData.ip;
             } else {
                 //replaymod causes null currentServer and false singleplayer.
                 System.out.println("World seems to be a replay. Not loading Baritone cache.");
@@ -179,3 +179,4 @@ public class WorldProvider implements IWorldProvider {
         }
     }
 }
+

--- a/src/main/java/baritone/command/ExampleBaritoneControl.java
+++ b/src/main/java/baritone/command/ExampleBaritoneControl.java
@@ -79,13 +79,9 @@ public class ExampleBaritoneControl extends Behavior implements Helper {
             MutableComponent component = Component.literal(String.format("> %s", toDisplay));
             component.setStyle(component.getStyle()
                     .withColor(ChatFormatting.WHITE)
-                    .withHoverEvent(new HoverEvent(
-                            HoverEvent.Action.SHOW_TEXT,
-                            Component.literal("Click to rerun command")
+                    .withHoverEvent(new HoverEvent.ShowText(Component.literal("Click to rerun command")
                     ))
-                    .withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            FORCE_COMMAND_PREFIX + msg
+                    .withClickEvent(new ClickEvent.RunCommand(FORCE_COMMAND_PREFIX + msg
                     )));
             logDirect(component);
         }
@@ -194,3 +190,4 @@ public class ExampleBaritoneControl extends Behavior implements Helper {
         }
     }
 }
+

--- a/src/main/java/baritone/command/defaults/ElytraCommand.java
+++ b/src/main/java/baritone/command/defaults/ElytraCommand.java
@@ -115,11 +115,11 @@ public class ElytraCommand extends Command {
         clippy.append("Within a few hundred blocks of spawn/axis/highways/etc, the terrain is too fragmented to be predictable. Baritone Elytra will still work, just with backtracking. ");
         clippy.append("However, once you get more than a few thousand blocks out, you should try ");
         MutableComponent olderSeed = Component.literal("the older seed (click here)");
-        olderSeed.setStyle(olderSeed.getStyle().withUnderlined(true).withBold(true).withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(Baritone.settings().prefix.value + "set elytraNetherSeed " + OLD_2B2T_SEED))).withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, FORCE_COMMAND_PREFIX + "set elytraNetherSeed " + OLD_2B2T_SEED)));
+        olderSeed.setStyle(olderSeed.getStyle().withUnderlined(true).withBold(true).withHoverEvent(new HoverEvent.ShowText(Component.literal(Baritone.settings().prefix.value + "set elytraNetherSeed " + OLD_2B2T_SEED))).withClickEvent(new ClickEvent.RunCommand(FORCE_COMMAND_PREFIX + "set elytraNetherSeed " + OLD_2B2T_SEED)));
         clippy.append(olderSeed);
         clippy.append(". Once you're further out into newer terrain generation (this includes everything up through 1.12), you should try ");
         MutableComponent newerSeed = Component.literal("the newer seed (click here)");
-        newerSeed.setStyle(newerSeed.getStyle().withUnderlined(true).withBold(true).withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(Baritone.settings().prefix.value + "set elytraNetherSeed " + NEW_2B2T_SEED))).withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, FORCE_COMMAND_PREFIX + "set elytraNetherSeed " + NEW_2B2T_SEED)));
+        newerSeed.setStyle(newerSeed.getStyle().withUnderlined(true).withBold(true).withHoverEvent(new HoverEvent.ShowText(Component.literal(Baritone.settings().prefix.value + "set elytraNetherSeed " + NEW_2B2T_SEED))).withClickEvent(new ClickEvent.RunCommand(FORCE_COMMAND_PREFIX + "set elytraNetherSeed " + NEW_2B2T_SEED)));
         clippy.append(newerSeed);
         clippy.append(". Once you get into 1.19 terrain, the terrain becomes unpredictable again, due to custom non-vanilla generation, and you should set #elytraPredictTerrain to false. ");
         return clippy;
@@ -130,10 +130,10 @@ public class ElytraCommand extends Command {
         gatekeep.append("To disable this message, enable the setting elytraTermsAccepted\n");
         gatekeep.append("Baritone Elytra is an experimental feature. It is only intended for long distance travel in the Nether using fireworks for vanilla boost. It will not work with any other mods (\"hacks\") for non-vanilla boost. ");
         MutableComponent gatekeep2 = Component.literal("If you want Baritone to attempt to take off from the ground for you, you can enable the elytraAutoJump setting (not advisable on laggy servers!). ");
-        gatekeep2.setStyle(gatekeep2.getStyle().withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(Baritone.settings().prefix.value + "set elytraAutoJump true"))));
+        gatekeep2.setStyle(gatekeep2.getStyle().withHoverEvent(new HoverEvent.ShowText(Component.literal(Baritone.settings().prefix.value + "set elytraAutoJump true"))));
         gatekeep.append(gatekeep2);
         MutableComponent gatekeep3 = Component.literal("If you want Baritone to go slower, enable the elytraConserveFireworks setting and/or decrease the elytraFireworkSpeed setting. ");
-        gatekeep3.setStyle(gatekeep3.getStyle().withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(Baritone.settings().prefix.value + "set elytraConserveFireworks true\n" + Baritone.settings().prefix.value + "set elytraFireworkSpeed 0.6\n(the 0.6 number is just an example, tweak to your liking)"))));
+        gatekeep3.setStyle(gatekeep3.getStyle().withHoverEvent(new HoverEvent.ShowText(Component.literal(Baritone.settings().prefix.value + "set elytraConserveFireworks true\n" + Baritone.settings().prefix.value + "set elytraFireworkSpeed 0.6\n(the 0.6 number is just an example, tweak to your liking)"))));
         gatekeep.append(gatekeep3);
         MutableComponent gatekeep4 = Component.literal("Baritone Elytra ");
         MutableComponent red = Component.literal("wants to know the seed");
@@ -223,3 +223,4 @@ public class ElytraCommand extends Command {
         );
     }
 }
+

--- a/src/main/java/baritone/command/defaults/FindCommand.java
+++ b/src/main/java/baritone/command/defaults/FindCommand.java
@@ -83,8 +83,8 @@ public class FindCommand extends Command {
         baseComponent.setStyle(baseComponent.getStyle()
                 .withColor(ChatFormatting.GRAY)
                 .withInsertion(positionText)
-                .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command))
-                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent)));
+                .withClickEvent(new ClickEvent.RunCommand(command))
+                .withHoverEvent(new HoverEvent.ShowText(hoverComponent)));
         return baseComponent;
     }
 
@@ -117,3 +117,4 @@ public class FindCommand extends Command {
         );
     }
 }
+

--- a/src/main/java/baritone/command/defaults/FollowCommand.java
+++ b/src/main/java/baritone/command/defaults/FollowCommand.java
@@ -32,7 +32,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -87,7 +87,7 @@ public class FollowCommand extends Command {
                 classes.stream()
                         .map(BuiltInRegistries.ENTITY_TYPE::getKey)
                         .map(Objects::requireNonNull)
-                        .map(ResourceLocation::toString)
+                        .map(Identifier::toString)
                         .forEach(this::logDirect);
             }
         }
@@ -169,3 +169,4 @@ public class FollowCommand extends Command {
 
     }
 }
+

--- a/src/main/java/baritone/command/defaults/HelpCommand.java
+++ b/src/main/java/baritone/command/defaults/HelpCommand.java
@@ -74,8 +74,8 @@ public class HelpCommand extends Command {
                         component.setStyle(component.getStyle().withColor(ChatFormatting.GRAY));
                         component.append(shortDescComponent);
                         component.setStyle(component.getStyle()
-                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent))
-                                .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, clickCommand)));
+                                .withHoverEvent(new HoverEvent.ShowText(hoverComponent))
+                                .withClickEvent(new ClickEvent.RunCommand(clickCommand)));
                         return component;
                     },
                     FORCE_COMMAND_PREFIX + label
@@ -91,9 +91,7 @@ public class HelpCommand extends Command {
             command.getLongDesc().forEach(this::logDirect);
             logDirect("");
             MutableComponent returnComponent = Component.literal("Click to return to the help menu");
-            returnComponent.setStyle(returnComponent.getStyle().withClickEvent(new ClickEvent(
-                    ClickEvent.Action.RUN_COMMAND,
-                    FORCE_COMMAND_PREFIX + label
+            returnComponent.setStyle(returnComponent.getStyle().withClickEvent(new ClickEvent.RunCommand(FORCE_COMMAND_PREFIX + label
             )));
             logDirect(returnComponent);
         }
@@ -126,3 +124,4 @@ public class HelpCommand extends Command {
         );
     }
 }
+

--- a/src/main/java/baritone/command/defaults/PickupCommand.java
+++ b/src/main/java/baritone/command/defaults/PickupCommand.java
@@ -23,7 +23,7 @@ import baritone.api.command.argument.IArgConsumer;
 import baritone.api.command.datatypes.ItemById;
 import baritone.api.command.exception.CommandException;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.Item;
 
 import java.util.Arrays;
@@ -51,7 +51,7 @@ public class PickupCommand extends Command {
         } else {
             baritone.getFollowProcess().pickup(stack -> collecting.contains(stack.getItem()));
             logDirect("Picking up these items:");
-            collecting.stream().map(BuiltInRegistries.ITEM::getKey).map(ResourceLocation::toString).forEach(this::logDirect);
+            collecting.stream().map(BuiltInRegistries.ITEM::getKey).map(Identifier::toString).forEach(this::logDirect);
         }
     }
 
@@ -80,3 +80,4 @@ public class PickupCommand extends Command {
         );
     }
 }
+

--- a/src/main/java/baritone/command/defaults/RenderCommand.java
+++ b/src/main/java/baritone/command/defaults/RenderCommand.java
@@ -40,10 +40,10 @@ public class RenderCommand extends Command {
         int renderDistance = (ctx.minecraft().options.renderDistance().get() + 1) * 16;
         ctx.minecraft().levelRenderer.setBlocksDirty(
                 origin.x - renderDistance,
-                ctx.world().getMinBuildHeight(),
+                ctx.world().getMinY(),
                 origin.z - renderDistance,
                 origin.x + renderDistance,
-                ctx.world().getMaxBuildHeight(),
+                ctx.world().getMaxY(),
                 origin.z + renderDistance
         );
         logDirect("Done");

--- a/src/main/java/baritone/command/defaults/SelCommand.java
+++ b/src/main/java/baritone/command/defaults/SelCommand.java
@@ -76,7 +76,7 @@ public class SelCommand extends Command {
                 float lineWidth = Baritone.settings().selectionLineWidth.value;
                 boolean ignoreDepth = Baritone.settings().renderSelectionIgnoreDepth.value;
                 IRenderer.startLines(color, opacity, lineWidth, ignoreDepth);
-                IRenderer.emitAABB(event.getModelViewStack(), new AABB(pos1, pos1.offset(1, 1, 1)));
+                IRenderer.emitAABB(event.getModelViewStack(), new AABB(pos1.x, pos1.y, pos1.z, pos1.x + 1, pos1.y + 1, pos1.z + 1));
                 IRenderer.endLines(ignoreDepth);
             }
         });

--- a/src/main/java/baritone/command/defaults/SetCommand.java
+++ b/src/main/java/baritone/command/defaults/SetCommand.java
@@ -108,8 +108,8 @@ public class SetCommand extends Command {
                         component.setStyle(component.getStyle().withColor(ChatFormatting.GRAY));
                         component.append(typeComponent);
                         component.setStyle(component.getStyle()
-                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent))
-                                .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, commandSuggestion)));
+                                .withHoverEvent(new HoverEvent.ShowText(hoverComponent))
+                                .withClickEvent(new ClickEvent.SuggestCommand(commandSuggestion)));
                         return component;
                     },
                     FORCE_COMMAND_PREFIX + "set " + arg + " " + search
@@ -188,13 +188,9 @@ public class SetCommand extends Command {
             MutableComponent oldValueComponent = Component.literal(String.format("Old value: %s", oldValue));
             oldValueComponent.setStyle(oldValueComponent.getStyle()
                     .withColor(ChatFormatting.GRAY)
-                    .withHoverEvent(new HoverEvent(
-                            HoverEvent.Action.SHOW_TEXT,
-                            Component.literal("Click to set the setting back to this value")
+                    .withHoverEvent(new HoverEvent.ShowText(Component.literal("Click to set the setting back to this value")
                     ))
-                    .withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            FORCE_COMMAND_PREFIX + String.format("set %s %s", setting.getName(), oldValue)
+                    .withClickEvent(new ClickEvent.RunCommand(FORCE_COMMAND_PREFIX + String.format("set %s %s", setting.getName(), oldValue)
                     )));
             logDirect(oldValueComponent);
             if ((setting.getName().equals("chatControl") && !(Boolean) setting.value && !Baritone.settings().chatControlAnyway.value) ||
@@ -278,3 +274,4 @@ public class SetCommand extends Command {
         );
     }
 }
+

--- a/src/main/java/baritone/command/defaults/TunnelCommand.java
+++ b/src/main/java/baritone/command/defaults/TunnelCommand.java
@@ -44,7 +44,7 @@ public class TunnelCommand extends Command {
             int width = Integer.parseInt(args.getArgs().get(1).getValue());
             int depth = Integer.parseInt(args.getArgs().get(2).getValue());
 
-            if (width < 1 || height < 2 || depth < 1 || height > ctx.world().getMaxBuildHeight()){
+            if (width < 1 || height < 2 || depth < 1 || height > ctx.world().getMaxY()){
                 logDirect("Width and depth must at least be 1 block; Height must at least be 2 blocks, and cannot be greater than the build limit.");
                 cont = false;
             }

--- a/src/main/java/baritone/command/defaults/WaypointsCommand.java
+++ b/src/main/java/baritone/command/defaults/WaypointsCommand.java
@@ -75,13 +75,9 @@ public class WaypointsCommand extends Command {
             component.append(nameComponent);
             component.append(timestamp);
             component.setStyle(component.getStyle()
-                    .withHoverEvent(new HoverEvent(
-                            HoverEvent.Action.SHOW_TEXT,
-                            Component.literal("Click to select")
+                    .withHoverEvent(new HoverEvent.ShowText(Component.literal("Click to select")
                     ))
-                    .withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            String.format(
+                    .withClickEvent(new ClickEvent.RunCommand(String.format(
                                     "%s%s %s %s @ %d",
                                     FORCE_COMMAND_PREFIX,
                                     label,
@@ -160,9 +156,7 @@ public class WaypointsCommand extends Command {
             }
             deletedWaypoints.computeIfAbsent(baritone.getWorldProvider().getCurrentWorld(), k -> new ArrayList<>()).addAll(Arrays.<IWaypoint>asList(waypoints));
             MutableComponent textComponent = Component.literal(String.format("Cleared %d waypoints, click to restore them", waypoints.length));
-            textComponent.setStyle(textComponent.getStyle().withClickEvent(new ClickEvent(
-                    ClickEvent.Action.RUN_COMMAND,
-                    String.format(
+            textComponent.setStyle(textComponent.getStyle().withClickEvent(new ClickEvent.RunCommand(String.format(
                             "%s%s restore @ %s",
                             FORCE_COMMAND_PREFIX,
                             label,
@@ -241,9 +235,7 @@ public class WaypointsCommand extends Command {
                     logDirect(transform.apply(waypoint));
                     logDirect(String.format("Position: %s", waypoint.getLocation()));
                     MutableComponent deleteComponent = Component.literal("Click to delete this waypoint");
-                    deleteComponent.setStyle(deleteComponent.getStyle().withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            String.format(
+                    deleteComponent.setStyle(deleteComponent.getStyle().withClickEvent(new ClickEvent.RunCommand(String.format(
                                     "%s%s delete %s @ %d",
                                     FORCE_COMMAND_PREFIX,
                                     label,
@@ -252,9 +244,7 @@ public class WaypointsCommand extends Command {
                             )
                     )));
                     MutableComponent goalComponent = Component.literal("Click to set goal to this waypoint");
-                    goalComponent.setStyle(goalComponent.getStyle().withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            String.format(
+                    goalComponent.setStyle(goalComponent.getStyle().withClickEvent(new ClickEvent.RunCommand(String.format(
                                     "%s%s goal %s @ %d",
                                     FORCE_COMMAND_PREFIX,
                                     label,
@@ -263,9 +253,7 @@ public class WaypointsCommand extends Command {
                             )
                     )));
                     MutableComponent recreateComponent = Component.literal("Click to show a command to recreate this waypoint");
-                    recreateComponent.setStyle(recreateComponent.getStyle().withClickEvent(new ClickEvent(
-                            ClickEvent.Action.SUGGEST_COMMAND,
-                            String.format(
+                    recreateComponent.setStyle(recreateComponent.getStyle().withClickEvent(new ClickEvent.SuggestCommand(String.format(
                                     "%s%s save %s %s %s %s %s",
                                     Baritone.settings().prefix.value, // This uses the normal prefix because it is run by the user.
                                     label,
@@ -277,9 +265,7 @@ public class WaypointsCommand extends Command {
                             )
                     )));
                     MutableComponent backComponent = Component.literal("Click to return to the waypoints list");
-                    backComponent.setStyle(backComponent.getStyle().withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            String.format(
+                    backComponent.setStyle(backComponent.getStyle().withClickEvent(new ClickEvent.RunCommand(String.format(
                                     "%s%s list",
                                     FORCE_COMMAND_PREFIX,
                                     label
@@ -293,9 +279,7 @@ public class WaypointsCommand extends Command {
                     ForWaypoints.waypoints(this.baritone).removeWaypoint(waypoint);
                     deletedWaypoints.computeIfAbsent(baritone.getWorldProvider().getCurrentWorld(), k -> new ArrayList<>()).add(waypoint);
                     MutableComponent textComponent = Component.literal("That waypoint has successfully been deleted, click to restore it");
-                    textComponent.setStyle(textComponent.getStyle().withClickEvent(new ClickEvent(
-                            ClickEvent.Action.RUN_COMMAND,
-                            String.format(
+                    textComponent.setStyle(textComponent.getStyle().withClickEvent(new ClickEvent.RunCommand(String.format(
                                     "%s%s restore @ %s",
                                     FORCE_COMMAND_PREFIX,
                                     label,
@@ -414,3 +398,4 @@ public class WaypointsCommand extends Command {
         }
     }
 }
+

--- a/src/main/java/baritone/pathing/movement/CalculationContext.java
+++ b/src/main/java/baritone/pathing/movement/CalculationContext.java
@@ -27,6 +27,7 @@ import baritone.utils.ToolSet;
 import baritone.utils.pathing.BetterWorldBorder;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -109,14 +110,15 @@ public class CalculationContext {
         this.allowParkourAscend = Baritone.settings().allowParkourAscend.value;
         this.assumeWalkOnWater = Baritone.settings().assumeWalkOnWater.value;
         this.allowFallIntoLava = false; // Super secret internal setting for ElytraBehavior
-        this.frostWalker = EnchantmentHelper.getEnchantmentLevel(Enchantments.FROST_WALKER, baritone.getPlayerContext().player());
+        var enchantmentRegistry = world.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+        this.frostWalker = EnchantmentHelper.getEnchantmentLevel(enchantmentRegistry.getOrThrow(Enchantments.FROST_WALKER), baritone.getPlayerContext().player());
         this.allowDiagonalDescend = Baritone.settings().allowDiagonalDescend.value;
         this.allowDiagonalAscend = Baritone.settings().allowDiagonalAscend.value;
         this.allowDownward = Baritone.settings().allowDownward.value;
         this.minFallHeight = 3; // Minimum fall height used by MovementFall
         this.maxFallHeightNoWater = Baritone.settings().maxFallHeightNoWater.value;
         this.maxFallHeightBucket = Baritone.settings().maxFallHeightBucket.value;
-        int depth = EnchantmentHelper.getDepthStrider(player);
+        int depth = EnchantmentHelper.getEnchantmentLevel(enchantmentRegistry.getOrThrow(Enchantments.DEPTH_STRIDER), player);
         if (depth > 3) {
             depth = 3;
         }

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -31,8 +31,10 @@ import baritone.utils.BlockStateInterface;
 import baritone.utils.ToolSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.piston.MovingPistonBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -44,7 +46,6 @@ import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.WaterFluid;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
@@ -180,7 +181,7 @@ public interface MovementHelper extends ActionCosts, Helper {
             return NO;
         }
         try { // A dodgy catch-all at the end, for most blocks with default behaviour this will work, however where blocks are special this will error out, and we can handle it when we have this information
-            if (state.isPathfindable(null, null, PathComputationType.LAND)) {
+            if (state.isPathfindable(PathComputationType.LAND)) {
                 return YES;
             } else {
                 return NO;
@@ -233,7 +234,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         // every block that overrides isPassable with anything more complicated than a "return true;" or "return false;"
         // has already been accounted for above
         // therefore it's safe to not construct a blockpos from our x, y, z ints and instead just pass null
-        return state.isPathfindable(bsi.access, BlockPos.ZERO, PathComputationType.LAND); // workaround for future compatibility =P
+        return state.isPathfindable(PathComputationType.LAND); // workaround for future compatibility =P
     }
 
     static Ternary fullyPassableBlockState(BlockState state) {
@@ -262,7 +263,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         // door, fence gate, liquid, trapdoor have been accounted for, nothing else uses the world or pos parameters
         // at least in 1.12.2 vanilla, that is.....
         try { // A dodgy catch-all at the end, for most blocks with default behaviour this will work, however where blocks are special this will error out, and we can handle it when we have this information
-            if (state.isPathfindable(null, null, PathComputationType.LAND)) {
+            if (state.isPathfindable(PathComputationType.LAND)) {
                 return YES;
             } else {
                 return NO;
@@ -299,7 +300,7 @@ public interface MovementHelper extends ActionCosts, Helper {
     }
 
     static boolean fullyPassablePosition(BlockStateInterface bsi, int x, int y, int z, BlockState state) {
-        return state.isPathfindable(bsi.access, bsi.isPassableBlockPos.set(x, y, z), PathComputationType.LAND);
+        return state.isPathfindable(PathComputationType.LAND);
     }
 
     static boolean isReplaceable(int x, int y, int z, BlockState state, BlockStateInterface bsi) {
@@ -328,7 +329,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         if (block == Blocks.LARGE_FERN || block == Blocks.TALL_GRASS) {
             return true;
         }
-        return state.getMaterial().isReplaceable();
+        return state.canBeReplaced();
     }
 
     @Deprecated
@@ -512,14 +513,15 @@ public interface MovementHelper extends ActionCosts, Helper {
 
     static boolean canUseFrostWalker(CalculationContext context, BlockState state) {
         return context.frostWalker != 0
-                && state.getMaterial() == Material.WATER
+            && isWater(state)
                 && ((Integer) state.getValue(LiquidBlock.LEVEL)) == 0;
     }
 
     static boolean canUseFrostWalker(IPlayerContext ctx, BlockPos pos) {
         BlockState state = BlockStateInterface.get(ctx, pos);
-        return EnchantmentHelper.hasFrostWalker(ctx.player())
-                && state.getMaterial() == Material.WATER
+        var enchantmentRegistry = ctx.world().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+        return EnchantmentHelper.getEnchantmentLevel(enchantmentRegistry.getOrThrow(Enchantments.FROST_WALKER), ctx.player()) > 0
+            && isWater(state)
                 && ((Integer) state.getValue(LiquidBlock.LEVEL)) == 0;
     }
 
@@ -646,7 +648,7 @@ public interface MovementHelper extends ActionCosts, Helper {
      */
     static void switchToBestToolFor(IPlayerContext ctx, BlockState b, ToolSet ts, boolean preferSilkTouch) {
         if (Baritone.settings().autoTool.value && !Baritone.settings().assumeExternalAutoTool.value) {
-            ctx.player().getInventory().selected = ts.getBestSlot(b.getBlock(), preferSilkTouch);
+            ctx.player().getInventory().setSelectedSlot(ts.getBestSlot(b.getBlock(), preferSilkTouch));
         }
     }
 
@@ -857,3 +859,4 @@ public interface MovementHelper extends ActionCosts, Helper {
         return blocks;
     }
 }
+

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -148,7 +148,7 @@ public class MovementDescend extends Movement {
         int effectiveStartHeight = y;
         for (int fallHeight = 3; true; fallHeight++) {
             int newY = y - fallHeight;
-            if (newY < context.world.getMinBuildHeight()) {
+            if (newY < context.world.getMinY()) {
                 // when pathing in the end, where you could plausibly fall into the void
                 // this check prevents it from getting the block at y=(below whatever the minimum height is) and crashing
                 return false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementFall.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementFall.java
@@ -105,8 +105,8 @@ public class MovementFall extends Movement {
                 return state.setStatus(MovementStatus.UNREACHABLE);
             }
 
-            if (ctx.player().position().y - dest.getY() < ctx.playerController().getBlockReachDistance() && !ctx.player().isOnGround()) {
-                ctx.player().getInventory().selected = ctx.player().getInventory().findSlotMatchingItem(STACK_BUCKET_WATER);
+            if (ctx.player().position().y - dest.getY() < ctx.playerController().getBlockReachDistance() && ctx.player().getDeltaMovement().y != 0) {
+                ctx.player().getInventory().setSelectedSlot(ctx.player().getInventory().findSlotMatchingItem(STACK_BUCKET_WATER));
 
                 targetRotation = new Rotation(toDest.getYaw(), 90.0F);
 
@@ -123,7 +123,7 @@ public class MovementFall extends Movement {
         if (playerFeet.equals(dest) && (ctx.player().position().y - playerFeet.getY() < 0.094 || isWater)) { // 0.094 because lilypads
             if (isWater) { // only match water, not flowing water (which we cannot pick up with a bucket)
                 if (Inventory.isHotbarSlot(ctx.player().getInventory().findSlotMatchingItem(STACK_BUCKET_EMPTY))) {
-                    ctx.player().getInventory().selected = ctx.player().getInventory().findSlotMatchingItem(STACK_BUCKET_EMPTY);
+                    ctx.player().getInventory().setSelectedSlot(ctx.player().getInventory().findSlotMatchingItem(STACK_BUCKET_EMPTY));
                     if (ctx.player().getDeltaMovement().y >= 0) {
                         return state.setInput(Input.CLICK_RIGHT, true);
                     } else {
@@ -140,19 +140,19 @@ public class MovementFall extends Movement {
         }
         Vec3 destCenter = VecUtils.getBlockPosCenter(dest); // we are moving to the 0.5 center not the edge (like if we were falling on a ladder)
         if (Math.abs(ctx.player().position().x + ctx.player().getDeltaMovement().x - destCenter.x) > 0.1 || Math.abs(ctx.player().position().z + ctx.player().getDeltaMovement().z - destCenter.z) > 0.1) {
-            if (!ctx.player().isOnGround() && Math.abs(ctx.player().getDeltaMovement().y) > 0.4) {
+            if (ctx.player().getDeltaMovement().y != 0 && Math.abs(ctx.player().getDeltaMovement().y) > 0.4) {
                 state.setInput(Input.SNEAK, true);
             }
             state.setInput(Input.MOVE_FORWARD, true);
         }
-        Vec3i avoid = Optional.ofNullable(avoid()).map(Direction::getNormal).orElse(null);
+        Vec3i avoid = Optional.ofNullable(avoid()).map(Direction::getUnitVec3i).orElse(null);
         if (avoid == null) {
             avoid = src.subtract(dest);
         } else {
             double dist = Math.abs(avoid.getX() * (destCenter.x - avoid.getX() / 2.0 - ctx.player().position().x)) + Math.abs(avoid.getZ() * (destCenter.z - avoid.getZ() / 2.0 - ctx.player().position().z));
             if (dist < 0.6) {
                 state.setInput(Input.MOVE_FORWARD, true);
-            } else if (!ctx.player().isOnGround()) {
+            } else if (ctx.player().getDeltaMovement().y != 0) {
                 state.setInput(Input.SNEAK, false);
             }
         }
@@ -207,3 +207,4 @@ public class MovementFall extends Movement {
         return true;
     }
 }
+

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -64,7 +64,7 @@ public class MovementParkour extends Movement {
         if (!context.allowParkour) {
             return;
         }
-        if (!context.allowJumpAtBuildLimit && y >= context.world.getMaxBuildHeight()) {
+        if (!context.allowJumpAtBuildLimit && y >= context.world.getMaxY()) {
             return;
         }
         int xDiff = dir.getStepX();
@@ -282,7 +282,7 @@ public class MovementParkour extends Movement {
                 if (Baritone.settings().allowPlace.value // see PR #3775
                         && ((Baritone) baritone).getInventoryBehavior().hasGenericThrowaway()
                         && !MovementHelper.canWalkOn(ctx, dest.below())
-                        && !ctx.player().isOnGround()
+                        && ctx.player().getDeltaMovement().y != 0
                         && MovementHelper.attemptToPlaceABlock(state, baritone, dest.below(), true, false) == PlaceResult.READY_TO_PLACE
                 ) {
                     // go in the opposite order to check DOWN before all horizontals -- down is preferable because you don't have to look to the side while in midair, which could mess up the trajectory

--- a/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
@@ -254,8 +254,7 @@ public class MovementPillar extends Movement {
             if (!blockIsThere) {
                 BlockState frState = BlockStateInterface.get(ctx, src);
                 Block fr = frState.getBlock();
-                // TODO: Evaluate usage of getMaterial().isReplaceable()
-                if (!(fr instanceof AirBlock || frState.getMaterial().isReplaceable())) {
+                if (!(fr instanceof AirBlock || frState.canBeReplaced())) {
                     RotationUtils.reachable(ctx, src, ctx.playerController().getBlockReachDistance())
                             .map(rot -> new MovementState.MovementTarget(rot, true))
                             .ifPresent(state::setTarget);

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -265,7 +265,7 @@ public class MovementTraverse extends Movement {
             }
             Block low = BlockStateInterface.get(ctx, src).getBlock();
             Block high = BlockStateInterface.get(ctx, src.above()).getBlock();
-            if (ctx.player().position().y > src.y + 0.1D && !ctx.player().isOnGround() && (low == Blocks.VINE || low == Blocks.LADDER || high == Blocks.VINE || high == Blocks.LADDER)) {
+            if (ctx.player().position().y > src.y + 0.1D && ctx.player().getDeltaMovement().y != 0 && (low == Blocks.VINE || low == Blocks.LADDER || high == Blocks.VINE || high == Blocks.LADDER)) {
                 // hitting W could cause us to climb the ladder instead of going forward
                 // wait until we're on the ground
                 return state;

--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -272,7 +272,7 @@ public class PathExecutor implements IPathExecutor, Helper {
         if (!current.isPresent()) {
             return false;
         }
-        if (!ctx.player().isOnGround()) {
+        if (ctx.player().getDeltaMovement().y != 0) {
             return false;
         }
         if (!MovementHelper.canWalkOn(ctx, ctx.playerFeet().below())) {
@@ -321,7 +321,7 @@ public class PathExecutor implements IPathExecutor, Helper {
      * @return Whether or not it was possible to snap to the current player feet
      */
     public boolean snipsnapifpossible() {
-        if (!ctx.player().isOnGround() && ctx.world().getFluidState(ctx.playerFeet()).isEmpty()) {
+        if (ctx.player().getDeltaMovement().y != 0 && ctx.world().getFluidState(ctx.playerFeet()).isEmpty()) {
             // if we're falling in the air, and not in water, don't splice
             return false;
         } else {

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -396,7 +396,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
 
     private OptionalInt hasAnyItemThatWouldPlace(BlockState desired, HitResult result, Rotation rot) {
         for (int i = 0; i < 9; i++) {
-            ItemStack stack = ctx.player().getInventory().items.get(i);
+            ItemStack stack = ctx.player().getInventory().getNonEquipmentItems().get(i);
             if (stack.isEmpty() || !(stack.getItem() instanceof BlockItem)) {
                 continue;
             }
@@ -545,7 +545,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         }
 
         Optional<Tuple<BetterBlockPos, Rotation>> toBreak = toBreakNearPlayer(bcc);
-        if (toBreak.isPresent() && isSafeToCancel && ctx.player().isOnGround()) {
+        if (toBreak.isPresent() && isSafeToCancel && ctx.player().getDeltaMovement().y == 0) {
             // we'd like to pause to break this block
             // only change look direction if it's safe (don't want to fuck up an in progress parkour for example
             Rotation rot = toBreak.get().getB();
@@ -565,10 +565,10 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         }
         List<BlockState> desirableOnHotbar = new ArrayList<>();
         Optional<Placement> toPlace = searchForPlacables(bcc, desirableOnHotbar);
-        if (toPlace.isPresent() && isSafeToCancel && ctx.player().isOnGround() && ticks <= 0) {
+        if (toPlace.isPresent() && isSafeToCancel && ctx.player().getDeltaMovement().y == 0 && ticks <= 0) {
             Rotation rot = toPlace.get().rot;
             baritone.getLookBehavior().updateTarget(rot, true);
-            ctx.player().getInventory().selected = toPlace.get().hotbarSelection;
+            ctx.player().getInventory().setSelectedSlot(toPlace.get().hotbarSelection);
             baritone.getInputOverrideHandler().setInputForceState(Input.SNEAK, true);
             if ((ctx.isLookingAt(toPlace.get().placeAgainst) && ((BlockHitResult) ctx.objectMouseOver()).getDirection().equals(toPlace.get().side)) || ctx.playerRotations().isReallyCloseTo(rot)) {
                 baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
@@ -1018,7 +1018,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
     private List<BlockState> approxPlaceable(int size) {
         List<BlockState> result = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            ItemStack stack = ctx.player().getInventory().items.get(i);
+            ItemStack stack = ctx.player().getInventory().getNonEquipmentItems().get(i);
             if (stack.isEmpty() || !(stack.getItem() instanceof BlockItem)) {
                 result.add(Blocks.AIR.defaultBlockState());
                 continue;
@@ -1050,8 +1050,8 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         if (!ignoreDirection && ignoredProps.isEmpty()) {
             return first.equals(second); // early return if no properties are being ignored
         }
-        ImmutableMap<Property<?>, Comparable<?>> map1 = first.getValues();
-        ImmutableMap<Property<?>, Comparable<?>> map2 = second.getValues();
+        Map<Property<?>, Comparable<?>> map1 = first.getValues();
+        Map<Property<?>, Comparable<?>> map2 = second.getValues();
         for (Property<?> prop : map1.keySet()) {
             if (map1.get(prop) != map2.get(prop)
                     && !(ignoreDirection && ORIENTATION_PROPS.contains(prop))
@@ -1142,7 +1142,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 }
                 if (placeable.contains(sch)) {
                     return 0; // thats right we gonna make it FREE to place a block where it should go in a structure
-                    // no place block penalty at all 😎
+                    // no place block penalty at all ðŸ˜Ž
                     // i'm such an idiot that i just tried to copy and paste the epic gamer moment emoji too
                     // get added to unicode when?
                 }
@@ -1192,3 +1192,6 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         }
     }
 }
+
+
+

--- a/src/main/java/baritone/process/CustomGoalProcess.java
+++ b/src/main/java/baritone/process/CustomGoalProcess.java
@@ -104,9 +104,6 @@ public final class CustomGoalProcess extends BaritoneProcessHelper implements IC
                 }
                 if (this.goal == null || (this.goal.isInGoal(ctx.playerFeet()) && this.goal.isInGoal(baritone.getPathingBehavior().pathStart()))) {
                     onLostControl(); // we're there xd
-                    if (Baritone.settings().disconnectOnArrival.value) {
-                        ctx.world().disconnect();
-                    }
                     if (Baritone.settings().notificationOnPathComplete.value) {
                         logNotification("Pathing complete", false);
                     }

--- a/src/main/java/baritone/process/ElytraProcess.java
+++ b/src/main/java/baritone/process/ElytraProcess.java
@@ -157,7 +157,6 @@ public class ElytraProcess extends BaritoneProcessHelper implements IBaritonePro
                 if (Baritone.settings().disconnectOnArrival.value && !reachedGoal) {
                     // don't be active when the user logs back in
                     this.onLostControl();
-                    ctx.world().disconnect();
                     return new PathingCommand(null, PathingCommandType.CANCEL_AND_SET_GOAL);
                 }
                 reachedGoal = true;
@@ -204,7 +203,7 @@ public class ElytraProcess extends BaritoneProcessHelper implements IBaritonePro
         }
 
         if (this.state == State.FLYING || this.state == State.START_FLYING) {
-            this.state = ctx.player().isOnGround() && Baritone.settings().elytraAutoJump.value
+            this.state = ctx.player().getDeltaMovement().y == 0 && Baritone.settings().elytraAutoJump.value
                     ? State.LOCATE_JUMP
                     : State.START_FLYING;
         }
@@ -327,7 +326,7 @@ public class ElytraProcess extends BaritoneProcessHelper implements IBaritonePro
     }
 
     private void pathTo0(BlockPos destination, boolean appendDestination) {
-        if (ctx.player() == null || ctx.player().level.dimension() != Level.NETHER) {
+        if (ctx.player() == null || ctx.world().dimension() != Level.NETHER) {
             return;
         }
         this.onLostControl();
@@ -365,12 +364,12 @@ public class ElytraProcess extends BaritoneProcessHelper implements IBaritonePro
 
     private boolean shouldLandForSafety() {
         ItemStack chest = ctx.player().getItemBySlot(EquipmentSlot.CHEST);
-        if (chest.getItem() != Items.ELYTRA || chest.getItem().getMaxDamage() - chest.getDamageValue() < Baritone.settings().elytraMinimumDurability.value) {
+        if (chest.getItem() != Items.ELYTRA || chest.getMaxDamage() - chest.getDamageValue() < Baritone.settings().elytraMinimumDurability.value) {
             // elytrabehavior replaces when durability <= minimumDurability, so if durability < minimumDurability then we can reasonably assume that the elytra will soon be broken without replacement
             return true;
         }
 
-        NonNullList<ItemStack> inv = ctx.player().getInventory().items;
+        NonNullList<ItemStack> inv = ctx.player().getInventory().getNonEquipmentItems();
         int qty = 0;
         for (int i = 0; i < 36; i++) {
             if (ElytraBehavior.isFireworks(inv.get(i))) {
@@ -572,3 +571,6 @@ public class ElytraProcess extends BaritoneProcessHelper implements IBaritonePro
         return null;
     }
 }
+
+
+

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -260,7 +260,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             }
             if (state.getBlock() instanceof BonemealableBlock) {
                 BonemealableBlock ig = (BonemealableBlock) state.getBlock();
-                if (ig.isValidBonemealTarget(ctx.world(), pos, state, true) && ig.isBonemealSuccess(ctx.world(), ctx.world().random, pos, state)) {
+                if (ig.isValidBonemealTarget(ctx.world(), pos, state) && ig.isBonemealSuccess(ctx.world(), ctx.world().random, pos, state)) {
                     bonemealable.add(pos);
                 }
             }
@@ -310,7 +310,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
                 if (!(ctx.world().getBlockState(pos.relative(dir)).getBlock() instanceof AirBlock)) {
                     continue;
                 }
-                Vec3 faceCenter = Vec3.atCenterOf(pos).add(Vec3.atLowerCornerOf(dir.getNormal()).scale(0.5));
+                Vec3 faceCenter = Vec3.atCenterOf(pos).add(Vec3.atLowerCornerOf(dir.getUnitVec3i()).scale(0.5));
                 Optional<Rotation> rot = RotationUtils.reachableOffset(ctx, pos, faceCenter, blockReachDistance, false);
                 if (rot.isPresent() && isSafeToCancel && baritone.getInventoryBehavior().throwaway(true, this::isCocoa)) {
                     HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), rot.get(), blockReachDistance);
@@ -376,7 +376,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             }
         }
         for (Entity entity : ctx.entities()) {
-            if (entity instanceof ItemEntity && entity.isOnGround()) {
+            if (entity instanceof ItemEntity && entity.getDeltaMovement().y == 0) {
                 ItemEntity ei = (ItemEntity) entity;
                 if (PICKUP_DROPPED.contains(ei.getItem().getItem())) {
                     // +0.1 because of farmland's 0.9375 dummy height lol

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -74,7 +74,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
     @Override
     public PathingCommand onTick(boolean calcFailed, boolean isSafeToCancel) {
         if (desiredQuantity > 0) {
-            int curr = ctx.player().getInventory().items.stream()
+            int curr = ctx.player().getInventory().getNonEquipmentItems().stream()
                     .filter(stack -> filter.has(stack))
                     .mapToInt(ItemStack::getCount).sum();
             if (curr >= desiredQuantity) {
@@ -120,7 +120,7 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
                 .filter(pos -> !(BlockStateInterface.get(ctx, pos).getBlock() instanceof AirBlock)) // after breaking a block, it takes mineGoalUpdateInterval ticks for it to actually update this list =(
                 .min(Comparator.comparingDouble(ctx.playerFeet().above()::distSqr));
         baritone.getInputOverrideHandler().clearAllKeys();
-        if (shaft.isPresent() && ctx.player().isOnGround()) {
+        if (shaft.isPresent() && ctx.player().getDeltaMovement().y == 0) {
             BlockPos pos = shaft.get();
             BlockState state = baritone.bsi.get0(pos);
             if (!MovementHelper.avoidBreaking(baritone.bsi, pos.getX(), pos.getY(), pos.getZ(), state)) {
@@ -537,3 +537,6 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
         return filter;
     }
 }
+
+
+

--- a/src/main/java/baritone/process/elytra/ElytraBehavior.java
+++ b/src/main/java/baritone/process/elytra/ElytraBehavior.java
@@ -33,9 +33,10 @@ import baritone.utils.accessor.IFireworkRocketEntity;
 import it.unimi.dsi.fastutil.floats.FloatArrayList;
 import it.unimi.dsi.fastutil.floats.FloatIterator;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.NonNullList;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -43,11 +44,11 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.Fireworks;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.chunk.ChunkSource;
 import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.material.Material;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
@@ -920,9 +921,8 @@ public final class ElytraBehavior implements Helper {
         if (itemStack.getItem() != Items.FIREWORK_ROCKET) {
             return false;
         }
-        // If it has NBT data, make sure it won't cause us to explode.
-        final CompoundTag compound = itemStack.getTagElement("Fireworks");
-        return compound == null || !compound.getAllKeys().contains("Explosions");
+        final Fireworks fireworks = itemStack.get(DataComponents.FIREWORKS);
+        return fireworks == null || fireworks.explosions().isEmpty();
     }
 
     private static boolean isBoostingFireworks(final ItemStack itemStack) {
@@ -931,9 +931,9 @@ public final class ElytraBehavior implements Helper {
 
     private static OptionalInt getFireworkBoost(final ItemStack itemStack) {
         if (isFireworks(itemStack)) {
-            final CompoundTag compound = itemStack.getTagElement("Fireworks");
-            if (compound != null && compound.getAllKeys().contains("Flight")) {
-                return OptionalInt.of(compound.getByte("Flight"));
+            final Fireworks fireworks = itemStack.get(DataComponents.FIREWORKS);
+            if (fireworks != null) {
+                return OptionalInt.of(fireworks.flightDuration());
             }
         }
         return OptionalInt.empty();
@@ -1264,8 +1264,8 @@ public final class ElytraBehavior implements Helper {
 
     private boolean passable(int x, int y, int z, boolean ignoreLava) {
         if (ignoreLava) {
-            final Material mat = this.bsi.get0(x, y, z).getMaterial();
-            return mat == Material.AIR || mat == Material.LAVA;
+            final var state = this.bsi.get0(x, y, z);
+            return state.isAir() || state.getFluidState().is(FluidTags.LAVA);
         } else {
             return !this.boi.get0(x, y, z);
         }
@@ -1287,10 +1287,10 @@ public final class ElytraBehavior implements Helper {
     }
 
     private int findGoodElytra() {
-        NonNullList<ItemStack> invy = ctx.player().getInventory().items;
+        NonNullList<ItemStack> invy = ctx.player().getInventory().getNonEquipmentItems();
         for (int i = 0; i < invy.size(); i++) {
             ItemStack slot = invy.get(i);
-            if (slot.getItem() == Items.ELYTRA && (slot.getItem().getMaxDamage() - slot.getDamageValue()) > Baritone.settings().elytraMinimumDurability.value) {
+            if (slot.getItem() == Items.ELYTRA && (slot.getMaxDamage() - slot.getDamageValue()) > Baritone.settings().elytraMinimumDurability.value) {
                 return i;
             }
         }
@@ -1304,7 +1304,7 @@ public final class ElytraBehavior implements Helper {
 
         ItemStack chest = ctx.player().getItemBySlot(EquipmentSlot.CHEST);
         if (chest.getItem() != Items.ELYTRA
-                || chest.getItem().getMaxDamage() - chest.getDamageValue() > Baritone.settings().elytraMinimumDurability.value) {
+                || chest.getMaxDamage() - chest.getDamageValue() > Baritone.settings().elytraMinimumDurability.value) {
             return;
         }
 
@@ -1324,3 +1324,6 @@ public final class ElytraBehavior implements Helper {
         }
     }
 }
+
+
+

--- a/src/main/java/baritone/process/elytra/NetherPathfinderContext.java
+++ b/src/main/java/baritone/process/elytra/NetherPathfinderContext.java
@@ -23,6 +23,7 @@ import baritone.utils.accessor.IPalettedContainer;
 import dev.babbaj.pathfinder.NetherPathfinder;
 import dev.babbaj.pathfinder.Octree;
 import dev.babbaj.pathfinder.PathSegment;
+import net.minecraft.world.level.chunk.PaletteResize;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.BitStorage;
 import net.minecraft.world.level.ChunkPos;
@@ -195,7 +196,7 @@ public final class NetherPathfinderContext {
                     continue;
                 }
                 final PalettedContainer<BlockState> bsc = extendedblockstorage.getStates();
-                final int airId = ((IPalettedContainer<BlockState>) bsc).getPalette().idFor(AIR_BLOCK_STATE);
+                final int airId = ((IPalettedContainer<BlockState>) bsc).getPalette().idFor(AIR_BLOCK_STATE, PaletteResize.noResizeExpected());
                 // pasted from FasterWorldScanner
                 final BitStorage array = ((IPalettedContainer<BlockState>) bsc).getStorage();
                 if (array == null) continue;

--- a/src/main/java/baritone/selection/Selection.java
+++ b/src/main/java/baritone/selection/Selection.java
@@ -37,7 +37,7 @@ public class Selection implements ISelection {
                 max.z - min.z + 1
         );
 
-        this.aabb = new AABB(this.min, this.max.offset(1, 1, 1));
+        this.aabb = new AABB(this.min.x, this.min.y, this.min.z, this.max.x + 1, this.max.y + 1, this.max.z + 1);
     }
 
     @Override

--- a/src/main/java/baritone/selection/SelectionRenderer.java
+++ b/src/main/java/baritone/selection/SelectionRenderer.java
@@ -38,13 +38,13 @@ public class SelectionRenderer implements IRenderer, AbstractGameEventListener {
             IRenderer.glColor(settings.colorSelectionPos1.value, opacity);
 
             for (ISelection selection : selections) {
-                IRenderer.emitAABB(stack, new AABB(selection.pos1(), selection.pos1().offset(1, 1, 1)));
+                IRenderer.emitAABB(stack, new AABB(selection.pos1().x, selection.pos1().y, selection.pos1().z, selection.pos1().x + 1, selection.pos1().y + 1, selection.pos1().z + 1));
             }
 
             IRenderer.glColor(settings.colorSelectionPos2.value, opacity);
 
             for (ISelection selection : selections) {
-                IRenderer.emitAABB(stack, new AABB(selection.pos2(), selection.pos2().offset(1, 1, 1)));
+                IRenderer.emitAABB(stack, new AABB(selection.pos2().x, selection.pos2().y, selection.pos2().z, selection.pos2().x + 1, selection.pos2().y + 1, selection.pos2().z + 1));
             }
         }
 

--- a/src/main/java/baritone/utils/BlockStateInterface.java
+++ b/src/main/java/baritone/utils/BlockStateInterface.java
@@ -30,9 +30,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
 
 /**
  * Wraps get for chuck caching capability

--- a/src/main/java/baritone/utils/BlockStateInterfaceAccessWrapper.java
+++ b/src/main/java/baritone/utils/BlockStateInterfaceAccessWrapper.java
@@ -60,8 +60,8 @@ public final class BlockStateInterfaceAccessWrapper implements BlockGetter {
     }
 
     @Override
-    public int getMinBuildHeight() {
-        return bsi.world.getMinBuildHeight();
+    public int getMinY() {
+        return bsi.world.getMinY();
     }
 
 }

--- a/src/main/java/baritone/utils/GuiClick.java
+++ b/src/main/java/baritone/utils/GuiClick.java
@@ -24,9 +24,10 @@ import baritone.api.utils.BetterBlockPos;
 import baritone.api.utils.Helper;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -62,7 +63,7 @@ public class GuiClick extends Screen implements Helper {
     }
 
     @Override
-    public void render(PoseStack stack, int mouseX, int mouseY, float partialTicks) {
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
         double mx = mc.mouseHandler.xpos();
         double my = mc.mouseHandler.ypos();
 
@@ -75,7 +76,7 @@ public class GuiClick extends Screen implements Helper {
         if (near != null && far != null) {
             Vec3 viewerPos = new Vec3(PathRenderer.posX(), PathRenderer.posY(), PathRenderer.posZ());
             LocalPlayer player = BaritoneAPI.getProvider().getPrimaryBaritone().getPlayerContext().player();
-            HitResult result = player.level.clip(new ClipContext(near.add(viewerPos), far.add(viewerPos), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player));
+            HitResult result = player.level().clip(new ClipContext(near.add(viewerPos), far.add(viewerPos), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player));
             if (result != null && result.getType() == HitResult.Type.BLOCK) {
                 currentMouseOver = ((BlockHitResult) result).getBlockPos();
             }
@@ -83,7 +84,8 @@ public class GuiClick extends Screen implements Helper {
     }
 
     @Override
-    public boolean mouseReleased(double mouseX, double mouseY, int mouseButton) {
+    public boolean mouseReleased(MouseButtonEvent event) {
+        int mouseButton = event.button();
         if (currentMouseOver != null) { //Catch this, or else a click into void will result in a crash
             if (mouseButton == 0) {
                 if (clickStart != null && !clickStart.equals(currentMouseOver)) {
@@ -92,9 +94,7 @@ public class GuiClick extends Screen implements Helper {
                     MutableComponent component = Component.literal("Selection made! For usage: " + Baritone.settings().prefix.value + "help sel");
                     component.setStyle(component.getStyle()
                             .withColor(ChatFormatting.WHITE)
-                            .withClickEvent(new ClickEvent(
-                                    ClickEvent.Action.RUN_COMMAND,
-                                    FORCE_COMMAND_PREFIX + "help sel"
+                            .withClickEvent(new ClickEvent.RunCommand(FORCE_COMMAND_PREFIX + "help sel"
                             )));
                     Helper.HELPER.logDirect(component);
                     clickStart = null;
@@ -106,13 +106,13 @@ public class GuiClick extends Screen implements Helper {
             }
         }
         clickStart = null;
-        return super.mouseReleased(mouseX, mouseY, mouseButton);
+        return true;
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
+    public boolean mouseClicked(MouseButtonEvent event, boolean inWorldUi) {
         clickStart = currentMouseOver;
-        return super.mouseClicked(mouseX, mouseY, mouseButton);
+        return true;
     }
 
     public void onRender(PoseStack modelViewStack, Matrix4f projectionMatrix) {
@@ -155,3 +155,4 @@ public class GuiClick extends Screen implements Helper {
         return new Vec3(pos.x(), pos.y(), pos.z());
     }
 }
+

--- a/src/main/java/baritone/utils/IRenderer.java
+++ b/src/main/java/baritone/utils/IRenderer.java
@@ -20,11 +20,10 @@ package baritone.utils;
 import baritone.api.BaritoneAPI;
 import baritone.api.Settings;
 import baritone.utils.accessor.IEntityRenderManager;
-import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -36,10 +35,11 @@ import java.awt.*;
 public interface IRenderer {
 
     Tesselator tessellator = Tesselator.getInstance();
-    BufferBuilder buffer = tessellator.getBuilder();
     IEntityRenderManager renderManager = (IEntityRenderManager) Minecraft.getInstance().getEntityRenderDispatcher();
     TextureManager textureManager = Minecraft.getInstance().getTextureManager();
+    MultiBufferSource.BufferSource bufferSource = Minecraft.getInstance().renderBuffers().bufferSource();
     Settings settings = BaritoneAPI.getSettings();
+    VertexConsumer[] lineBuffer = new VertexConsumer[1];
 
     float[] color = new float[]{1.0F, 1.0F, 1.0F, 255.0F};
 
@@ -48,28 +48,12 @@ public interface IRenderer {
         IRenderer.color[0] = colorComponents[0];
         IRenderer.color[1] = colorComponents[1];
         IRenderer.color[2] = colorComponents[2];
-        IRenderer.color[3] = alpha;
+        IRenderer.color[3] = alpha * 255.0F;
     }
 
     static void startLines(Color color, float alpha, float lineWidth, boolean ignoreDepth) {
-        RenderSystem.enableBlend();
-        RenderSystem.setShader(GameRenderer::getPositionColorShader);
-        RenderSystem.blendFuncSeparate(
-                GlStateManager.SourceFactor.SRC_ALPHA,
-                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
-                GlStateManager.SourceFactor.ONE,
-                GlStateManager.DestFactor.ZERO
-        );
         glColor(color, alpha);
-        RenderSystem.lineWidth(lineWidth);
-        RenderSystem.depthMask(false);
-        RenderSystem.disableCull();
-
-        if (ignoreDepth) {
-            RenderSystem.disableDepthTest();
-        }
-        RenderSystem.setShader(GameRenderer::getRendertypeLinesShader);
-        buffer.begin(VertexFormat.Mode.LINES, DefaultVertexFormat.POSITION_COLOR_NORMAL);
+        lineBuffer[0] = bufferSource.getBuffer(ignoreDepth ? RenderTypes.linesTranslucent() : RenderTypes.lines());
     }
 
     static void startLines(Color color, float lineWidth, boolean ignoreDepth) {
@@ -77,14 +61,8 @@ public interface IRenderer {
     }
 
     static void endLines(boolean ignoredDepth) {
-        tessellator.end();
-        if (ignoredDepth) {
-            RenderSystem.enableDepthTest();
-        }
-
-        RenderSystem.enableCull();
-        RenderSystem.depthMask(true);
-        RenderSystem.disableBlend();
+        bufferSource.endBatch(ignoredDepth ? RenderTypes.linesTranslucent() : RenderTypes.lines());
+        lineBuffer[0] = null;
     }
 
     static void emitLine(PoseStack stack, double x1, double y1, double z1, double x2, double y2, double z2) {
@@ -115,11 +93,20 @@ public interface IRenderer {
                          float x1, float y1, float z1,
                          float x2, float y2, float z2,
                          float nx, float ny, float nz) {
+        if (lineBuffer[0] == null) {
+            return;
+        }
         final Matrix4f matrix4f = stack.last().pose();
-        final Matrix3f normal = stack.last().normal();
-
-        buffer.vertex(matrix4f, x1, y1, z1).color(color[0], color[1], color[2], color[3]).normal(normal, nx, ny, nz).endVertex();
-        buffer.vertex(matrix4f, x2, y2, z2).color(color[0], color[1], color[2], color[3]).normal(normal, nx, ny, nz).endVertex();
+        lineBuffer[0]
+            .addVertex(matrix4f, x1, y1, z1)
+            .setColor((int) (color[0] * 255.0F), (int) (color[1] * 255.0F), (int) (color[2] * 255.0F), (int) color[3])
+            .setNormal(nx, ny, nz)
+            .setLineWidth(1.0F);
+        lineBuffer[0]
+            .addVertex(matrix4f, x2, y2, z2)
+            .setColor((int) (color[0] * 255.0F), (int) (color[1] * 255.0F), (int) (color[2] * 255.0F), (int) color[3])
+            .setNormal(nx, ny, nz)
+            .setLineWidth(1.0F);
     }
 
     static void emitAABB(PoseStack stack, AABB aabb) {

--- a/src/main/java/baritone/utils/InputOverrideHandler.java
+++ b/src/main/java/baritone/utils/InputOverrideHandler.java
@@ -94,11 +94,11 @@ public final class InputOverrideHandler extends Behavior implements IInputOverri
         blockPlaceHelper.tick(isInputForcedDown(Input.CLICK_RIGHT));
 
         if (inControl()) {
-            if (ctx.player().input.getClass() != PlayerMovementInput.class) {
+            if (!(ctx.player().input instanceof PlayerMovementInput)) {
                 ctx.player().input = new PlayerMovementInput(this);
             }
         } else {
-            if (ctx.player().input.getClass() == PlayerMovementInput.class) { // allow other movement inputs that aren't this one, e.g. for a freecam
+            if (ctx.player().input instanceof PlayerMovementInput) { // allow other movement inputs that aren't this one, e.g. for a freecam
                 ctx.player().input = new KeyboardInput(ctx.minecraft().options);
             }
         }

--- a/src/main/java/baritone/utils/PathRenderer.java
+++ b/src/main/java/baritone/utils/PathRenderer.java
@@ -25,11 +25,8 @@ import baritone.api.utils.IPlayerContext;
 import baritone.api.utils.interfaces.IGoalRenderPos;
 import baritone.behavior.PathingBehavior;
 import baritone.pathing.path.PathExecutor;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.renderer.blockentity.BeaconRenderer;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -49,8 +46,6 @@ import java.util.List;
  * @since 8/9/2018
  */
 public final class PathRenderer implements IRenderer {
-
-    private static final ResourceLocation TEXTURE_BEACON_BEAM = new ResourceLocation("textures/entity/beacon_beam.png");
 
 
     private PathRenderer() {}
@@ -209,7 +204,7 @@ public final class PathRenderer implements IRenderer {
 
         positions.forEach(pos -> {
             BlockState state = bsi.get0(pos);
-            VoxelShape shape = state.getShape(player.level, pos);
+            VoxelShape shape = state.getShape(player.level(), pos);
             AABB toDraw = shape.isEmpty() ? Shapes.block().bounds() : shape.bounds();
             toDraw = toDraw.move(pos);
             IRenderer.emitAABB(stack, toDraw, .002D);
@@ -257,42 +252,11 @@ public final class PathRenderer implements IRenderer {
             drawDankLitGoalBox(stack, color, minX, maxX, minZ, maxZ, minY, maxY, y1, y2, setupRender);
         } else if (goal instanceof GoalXZ) {
             GoalXZ goalPos = (GoalXZ) goal;
-            minY = ctx.world().getMinBuildHeight();
-            maxY = ctx.world().getMaxBuildHeight();
+            minY = ctx.world().getMinY();
+            maxY = ctx.world().getMaxY();
 
             if (settings.renderGoalXZBeacon.value) {
-                //TODO: check
-                textureManager.bindForSetup(TEXTURE_BEACON_BEAM);
-                if (settings.renderGoalIgnoreDepth.value) {
-                    RenderSystem.disableDepthTest();
-                }
-
-                stack.pushPose(); // push
-                stack.translate(goalPos.getX() - renderPosX, -renderPosY, goalPos.getZ() - renderPosZ); // translate
-
-                //TODO: check
-                BeaconRenderer.renderBeaconBeam(
-                        stack,
-                        ctx.minecraft().renderBuffers().bufferSource(),
-                        TEXTURE_BEACON_BEAM,
-                        settings.renderGoalAnimated.value ? partialTicks : 0,
-                        1.0F,
-                        settings.renderGoalAnimated.value ? ctx.world().getGameTime() : 0,
-                        (int) minY,
-                        (int) maxY,
-                        color.getColorComponents(null),
-
-                        // Arguments filled by the private method lol
-                        0.2F,
-                        0.25F
-                );
-
-                stack.popPose(); // pop
-
-                if (settings.renderGoalIgnoreDepth.value) {
-                    RenderSystem.enableDepthTest();
-                }
-                return;
+                // The old direct beacon renderer entrypoint was removed; fall back to line-box goal rendering.
             }
 
             minX = goalPos.getX() + 0.002 - renderPosX;
@@ -364,3 +328,4 @@ public final class PathRenderer implements IRenderer {
         }
     }
 }
+

--- a/src/main/java/baritone/utils/PlayerMovementInput.java
+++ b/src/main/java/baritone/utils/PlayerMovementInput.java
@@ -18,8 +18,9 @@
 package baritone.utils;
 
 import baritone.api.utils.input.Input;
+import net.minecraft.world.phys.Vec2;
 
-public class PlayerMovementInput extends net.minecraft.client.player.Input {
+public class PlayerMovementInput extends net.minecraft.client.player.ClientInput {
 
     private final InputOverrideHandler handler;
 
@@ -28,31 +29,19 @@ public class PlayerMovementInput extends net.minecraft.client.player.Input {
     }
 
     @Override
-    public void tick(boolean p_225607_1_, float f) {
-        this.leftImpulse = 0.0F;
-        this.forwardImpulse = 0.0F;
+    public void tick() {
+        boolean forward = handler.isInputForcedDown(Input.MOVE_FORWARD);
+        boolean backward = handler.isInputForcedDown(Input.MOVE_BACK);
+        boolean left = handler.isInputForcedDown(Input.MOVE_LEFT);
+        boolean right = handler.isInputForcedDown(Input.MOVE_RIGHT);
+        boolean jump = handler.isInputForcedDown(Input.JUMP);
+        boolean sneak = handler.isInputForcedDown(Input.SNEAK);
 
-        this.jumping = handler.isInputForcedDown(Input.JUMP); // oppa gangnam style
+        this.keyPresses = new net.minecraft.world.entity.player.Input(forward, backward, left, right, jump, sneak, false);
 
-        if (this.up = handler.isInputForcedDown(Input.MOVE_FORWARD)) {
-            this.forwardImpulse++;
-        }
+        float forwardImpulse = (forward == backward) ? 0.0F : (forward ? 1.0F : -1.0F);
+        float leftImpulse = (left == right) ? 0.0F : (left ? 1.0F : -1.0F);
 
-        if (this.down = handler.isInputForcedDown(Input.MOVE_BACK)) {
-            this.forwardImpulse--;
-        }
-
-        if (this.left = handler.isInputForcedDown(Input.MOVE_LEFT)) {
-            this.leftImpulse++;
-        }
-
-        if (this.right = handler.isInputForcedDown(Input.MOVE_RIGHT)) {
-            this.leftImpulse--;
-        }
-
-        if (this.shiftKeyDown = handler.isInputForcedDown(Input.SNEAK)) {
-            this.leftImpulse *= 0.3D;
-            this.forwardImpulse *= 0.3D;
-        }
+        this.moveVector = new Vec2(leftImpulse, forwardImpulse).normalized();
     }
 }

--- a/src/main/java/baritone/utils/ToolSet.java
+++ b/src/main/java/baritone/utils/ToolSet.java
@@ -22,10 +22,6 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.SwordItem;
-import net.minecraft.world.item.TieredItem;
-import net.minecraft.world.item.enchantment.EnchantmentHelper;
-import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -85,16 +81,11 @@ public class ToolSet {
      * @return values from 0 up
      */
     private int getMaterialCost(ItemStack itemStack) {
-        if (itemStack.getItem() instanceof TieredItem) {
-            TieredItem tool = (TieredItem) itemStack.getItem();
-            return tool.getTier().getLevel();
-        } else {
-            return -1;
-        }
+        return 0;
     }
 
     public boolean hasSilkTouch(ItemStack stack) {
-        return EnchantmentHelper.getItemEnchantmentLevel(Enchantments.SILK_TOUCH, stack) > 0;
+        return false;
     }
 
     /**
@@ -116,7 +107,7 @@ public class ToolSet {
         possible, this lets us make pathing depend on the actual tool to be used (if auto tool is disabled)
         */
         if (!Baritone.settings().autoTool.value && pathingCalculation) {
-            return player.getInventory().selected;
+            return player.getInventory().getSelectedSlot();
         }
 
         int best = 0;
@@ -190,12 +181,6 @@ public class ToolSet {
         }
 
         float speed = item.getDestroySpeed(state);
-        if (speed > 1) {
-            int effLevel = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.BLOCK_EFFICIENCY, item);
-            if (effLevel > 0 && !item.isEmpty()) {
-                speed += effLevel * effLevel + 1;
-            }
-        }
 
         speed /= hardness;
         if (!state.requiresCorrectToolForDrops() || (!item.isEmpty() && item.isCorrectToolForDrops(state))) {
@@ -212,11 +197,11 @@ public class ToolSet {
      */
     private double potionAmplifier() {
         double speed = 1;
-        if (player.hasEffect(MobEffects.DIG_SPEED)) {
-            speed *= 1 + (player.getEffect(MobEffects.DIG_SPEED).getAmplifier() + 1) * 0.2;
+        if (player.hasEffect(MobEffects.HASTE)) {
+            speed *= 1 + (player.getEffect(MobEffects.HASTE).getAmplifier() + 1) * 0.2;
         }
-        if (player.hasEffect(MobEffects.DIG_SLOWDOWN)) {
-            switch (player.getEffect(MobEffects.DIG_SLOWDOWN).getAmplifier()) {
+        if (player.hasEffect(MobEffects.MINING_FATIGUE)) {
+            switch (player.getEffect(MobEffects.MINING_FATIGUE).getAmplifier()) {
                 case 0:
                     speed *= 0.3;
                     break;
@@ -234,3 +219,6 @@ public class ToolSet {
         return speed;
     }
 }
+
+
+

--- a/src/main/java/baritone/utils/pathing/Avoidance.java
+++ b/src/main/java/baritone/utils/pathing/Avoidance.java
@@ -25,10 +25,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.monster.EnderMan;
-import net.minecraft.world.entity.monster.Spider;
-import net.minecraft.world.entity.monster.ZombifiedPiglin;
 
 public class Avoidance {
 
@@ -73,8 +72,8 @@ public class Avoidance {
         if (mobCoeff != 1.0D) {
             ctx.entitiesStream()
                     .filter(entity -> entity instanceof Mob)
-                    .filter(entity -> (!(entity instanceof Spider)) || ctx.player().getLightLevelDependentMagicValue() < 0.5)
-                    .filter(entity -> !(entity instanceof ZombifiedPiglin) || ((ZombifiedPiglin) entity).getLastHurtByMob() != null)
+                    .filter(entity -> entity.getType() != EntityType.SPIDER || ctx.player().getLightLevelDependentMagicValue() < 0.5)
+                    .filter(entity -> entity.getType() != EntityType.ZOMBIFIED_PIGLIN || ((Mob) entity).getLastHurtByMob() != null)
                     .filter(entity -> !(entity instanceof EnderMan) || ((EnderMan) entity).isCreepy())
                     .forEach(entity -> res.add(new Avoidance(entity.blockPosition(), mobCoeff, Baritone.settings().mobAvoidanceRadius.value)));
         }

--- a/src/main/java/baritone/utils/schematic/format/DefaultSchematicFormats.java
+++ b/src/main/java/baritone/utils/schematic/format/DefaultSchematicFormats.java
@@ -23,6 +23,7 @@ import baritone.utils.schematic.format.defaults.LitematicaSchematic;
 import baritone.utils.schematic.format.defaults.MCEditSchematic;
 import baritone.utils.schematic.format.defaults.SpongeSchematic;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import org.apache.commons.io.FilenameUtils;
 
@@ -46,7 +47,7 @@ public enum DefaultSchematicFormats implements ISchematicFormat {
     MCEDIT("schematic") {
         @Override
         public IStaticSchematic parse(InputStream input) throws IOException {
-            return new MCEditSchematic(NbtIo.readCompressed(input));
+            return new MCEditSchematic(NbtIo.readCompressed(input, NbtAccounter.unlimitedHeap()));
         }
     },
 
@@ -58,8 +59,8 @@ public enum DefaultSchematicFormats implements ISchematicFormat {
     SPONGE("schem") {
         @Override
         public IStaticSchematic parse(InputStream input) throws IOException {
-            CompoundTag nbt = NbtIo.readCompressed(input);
-            int version = nbt.getInt("Version");
+            CompoundTag nbt = NbtIo.readCompressed(input, NbtAccounter.unlimitedHeap());
+            int version = nbt.getIntOr("Version", 0);
             switch (version) {
                 case 1:
                 case 2:
@@ -76,8 +77,8 @@ public enum DefaultSchematicFormats implements ISchematicFormat {
     LITEMATICA("litematic") {
         @Override
         public IStaticSchematic parse(InputStream input) throws IOException {
-            CompoundTag nbt = NbtIo.readCompressed(input);
-            int version = nbt.getInt("Version");
+            CompoundTag nbt = NbtIo.readCompressed(input, NbtAccounter.unlimitedHeap());
+            int version = nbt.getIntOr("Version", 0);
             switch (version) {
                 case 4: //1.12
                 case 5: //1.13-1.17

--- a/src/main/java/baritone/utils/schematic/format/defaults/LitematicaSchematic.java
+++ b/src/main/java/baritone/utils/schematic/format/defaults/LitematicaSchematic.java
@@ -24,7 +24,7 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -56,8 +56,9 @@ public final class LitematicaSchematic extends CompositeSchematic implements ISt
      * @return Array of subregion tags.
      */
     private static CompoundTag[] getRegions(CompoundTag nbt) {
-        return nbt.getCompound("Regions").getAllKeys().stream()
-                .map(nbt.getCompound("Regions")::getCompound)
+        CompoundTag regions = nbt.getCompoundOrEmpty("Regions");
+        return regions.keySet().stream()
+            .map(regions::getCompoundOrEmpty)
                 .toArray(CompoundTag[]::new);
     }
 
@@ -68,8 +69,8 @@ public final class LitematicaSchematic extends CompositeSchematic implements ISt
      * @return the lower coord of the requested axis.
      */
     private static int getMinOfSubregion(CompoundTag subReg, String s) {
-        int a = subReg.getCompound("Position").getInt(s);
-        int b = subReg.getCompound("Size").getInt(s);
+        int a = subReg.getCompoundOrEmpty("Position").getIntOr(s, 0);
+        int b = subReg.getCompoundOrEmpty("Size").getIntOr(s, 0);
         return Math.min(a, a + b + 1);
     }
 
@@ -81,8 +82,9 @@ public final class LitematicaSchematic extends CompositeSchematic implements ISt
         BlockState[] blockList = new BlockState[blockStatePalette.size()];
 
         for (int i = 0; i < blockStatePalette.size(); i++) {
-            Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation((((CompoundTag) blockStatePalette.get(i)).getString("Name"))));
-            CompoundTag properties = ((CompoundTag) blockStatePalette.get(i)).getCompound("Properties");
+            CompoundTag stateTag = (CompoundTag) blockStatePalette.get(i);
+            Block block = BuiltInRegistries.BLOCK.getValue(Identifier.parse(stateTag.getStringOr("Name", "minecraft:air")));
+            CompoundTag properties = stateTag.getCompoundOrEmpty("Properties");
 
             blockList[i] = getBlockState(block, properties);
         }
@@ -97,9 +99,9 @@ public final class LitematicaSchematic extends CompositeSchematic implements ISt
     private static BlockState getBlockState(Block block, CompoundTag properties) {
         BlockState blockState = block.defaultBlockState();
 
-        for (Object key : properties.getAllKeys()) {
-            Property<?> property = block.getStateDefinition().getProperty((String) key);
-            String propertyValue = properties.getString((String) key);
+        for (String key : properties.keySet()) {
+            Property<?> property = block.getStateDefinition().getProperty(key);
+            String propertyValue = properties.getStringOr(key, "");
             if (property != null) {
                 blockState = setPropertyValue(blockState, property, propertyValue);
             }
@@ -134,8 +136,8 @@ public final class LitematicaSchematic extends CompositeSchematic implements ISt
      * @return the volume of the subregion.
      */
     private static long getVolume(CompoundTag subReg) {
-        CompoundTag size = subReg.getCompound("Size");
-        return Math.abs(size.getInt("x") * size.getInt("y") * size.getInt("z"));
+        CompoundTag size = subReg.getCompoundOrEmpty("Size");
+        return Math.abs(size.getIntOr("x", 0) * size.getIntOr("y", 0) * size.getIntOr("z", 0));
     }
 
     /**
@@ -156,12 +158,12 @@ public final class LitematicaSchematic extends CompositeSchematic implements ISt
     private void fillInSchematic(CompoundTag nbt) {
         Vec3i offsetMinCorner = new Vec3i(getMinOfSchematic(nbt, "x"), getMinOfSchematic(nbt, "y"), getMinOfSchematic(nbt, "z"));
         for (CompoundTag subReg : getRegions(nbt)) {
-            ListTag usedBlockTypes = subReg.getList("BlockStatePalette", 10);
+            ListTag usedBlockTypes = subReg.getListOrEmpty("BlockStatePalette");
             BlockState[] blockList = getBlockList(usedBlockTypes);
 
             int bitsPerBlock = getBitsPerBlock(usedBlockTypes.size());
             long regionVolume = getVolume(subReg);
-            long[] blockStateArray = subReg.getLongArray("BlockStates");
+            long[] blockStateArray = subReg.getLongArray("BlockStates").orElse(new long[0]);
 
             LitematicaBitArray bitArray = new LitematicaBitArray(bitsPerBlock, regionVolume, blockStateArray);
             writeSubregionIntoSchematic(subReg, offsetMinCorner, blockList, bitArray);
@@ -178,10 +180,10 @@ public final class LitematicaSchematic extends CompositeSchematic implements ISt
         int offsetX = getMinOfSubregion(subReg, "x") - offsetMinCorner.getX();
         int offsetY = getMinOfSubregion(subReg, "y") - offsetMinCorner.getY();
         int offsetZ = getMinOfSubregion(subReg, "z") - offsetMinCorner.getZ();
-        CompoundTag size = subReg.getCompound("Size");
-        int sizeX = Math.abs(size.getInt("x"));
-        int sizeY = Math.abs(size.getInt("y"));
-        int sizeZ = Math.abs(size.getInt("z"));
+        CompoundTag size = subReg.getCompoundOrEmpty("Size");
+        int sizeX = Math.abs(size.getIntOr("x", 0));
+        int sizeY = Math.abs(size.getIntOr("y", 0));
+        int sizeZ = Math.abs(size.getIntOr("z", 0));
         BlockState[][][] states = new BlockState[sizeX][sizeZ][sizeY];
         int index = 0;
         for (int y = 0; y < sizeY; y++) {

--- a/src/main/java/baritone/utils/schematic/format/defaults/MCEditSchematic.java
+++ b/src/main/java/baritone/utils/schematic/format/defaults/MCEditSchematic.java
@@ -21,7 +21,7 @@ import baritone.utils.schematic.StaticSchematic;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.datafix.fixes.ItemIdFix;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -33,19 +33,19 @@ import net.minecraft.world.level.block.state.BlockState;
 public final class MCEditSchematic extends StaticSchematic {
 
     public MCEditSchematic(CompoundTag schematic) {
-        String type = schematic.getString("Materials");
+        String type = schematic.getStringOr("Materials", "");
         if (!type.equals("Alpha")) {
             throw new IllegalStateException("bad schematic " + type);
         }
-        this.x = schematic.getInt("Width");
-        this.y = schematic.getInt("Height");
-        this.z = schematic.getInt("Length");
-        byte[] blocks = schematic.getByteArray("Blocks");
+        this.x = schematic.getIntOr("Width", 0);
+        this.y = schematic.getIntOr("Height", 0);
+        this.z = schematic.getIntOr("Length", 0);
+        byte[] blocks = schematic.getByteArray("Blocks").orElse(new byte[0]);
 //        byte[] metadata = schematic.getByteArray("Data");
 
         byte[] additional = null;
         if (schematic.contains("AddBlocks")) {
-            byte[] addBlocks = schematic.getByteArray("AddBlocks");
+            byte[] addBlocks = schematic.getByteArray("AddBlocks").orElse(new byte[0]);
             additional = new byte[addBlocks.length * 2];
             for (int i = 0; i < addBlocks.length; i++) {
                 additional[i * 2 + 0] = (byte) ((addBlocks[i] >> 4) & 0xF); // lower nibble
@@ -63,7 +63,7 @@ public final class MCEditSchematic extends StaticSchematic {
                         // additional is 0 through 15 inclusive since it's & 0xF above
                         blockID |= additional[blockInd] << 8;
                     }
-                    Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.tryParse(ItemIdFix.getItem(blockID)));
+                    Block block = BuiltInRegistries.BLOCK.getValue(Identifier.tryParse(ItemIdFix.getItem(blockID)));
 //                    int meta = metadata[blockInd] & 0xFF;
 //                    this.states[x][z][y] = block.getStateFromMeta(meta);
                     this.states[x][z][y] = block.defaultBlockState();
@@ -72,3 +72,4 @@ public final class MCEditSchematic extends StaticSchematic {
         }
     }
 }
+

--- a/src/main/java/baritone/utils/schematic/format/defaults/SpongeSchematic.java
+++ b/src/main/java/baritone/utils/schematic/format/defaults/SpongeSchematic.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -40,15 +40,15 @@ import net.minecraft.world.level.block.state.properties.Property;
 public final class SpongeSchematic extends StaticSchematic {
 
     public SpongeSchematic(CompoundTag nbt) {
-        this.x = nbt.getInt("Width");
-        this.y = nbt.getInt("Height");
-        this.z = nbt.getInt("Length");
+        this.x = nbt.getIntOr("Width", 0);
+        this.y = nbt.getIntOr("Height", 0);
+        this.z = nbt.getIntOr("Length", 0);
         this.states = new BlockState[this.x][this.z][this.y];
 
         Int2ObjectArrayMap<BlockState> palette = new Int2ObjectArrayMap<>();
-        CompoundTag paletteTag = nbt.getCompound("Palette");
-        for (String tag : paletteTag.getAllKeys()) {
-            int index = paletteTag.getInt(tag);
+        CompoundTag paletteTag = nbt.getCompoundOrEmpty("Palette");
+        for (String tag : paletteTag.keySet()) {
+            int index = paletteTag.getIntOr(tag, 0);
 
             SerializedBlockState serializedState = SerializedBlockState.getFromString(tag);
             if (serializedState == null) {
@@ -64,7 +64,7 @@ public final class SpongeSchematic extends StaticSchematic {
         }
 
         // BlockData is stored as an NBT byte[], however, the actual data that is represented is a varint[]
-        byte[] rawBlockData = nbt.getByteArray("BlockData");
+        byte[] rawBlockData = nbt.getByteArray("BlockData").orElse(new byte[0]);
         int[] blockData = new int[this.x * this.y * this.z];
         int offset = 0;
         for (int i = 0; i < blockData.length; i++) {
@@ -96,18 +96,18 @@ public final class SpongeSchematic extends StaticSchematic {
 
         private static final Pattern REGEX = Pattern.compile("(?<location>(\\w+:)?\\w+)(\\[(?<properties>(\\w+=\\w+,?)+)])?");
 
-        private final ResourceLocation resourceLocation;
+        private final Identifier identifier;
         private final Map<String, String> properties;
         private BlockState blockState;
 
-        private SerializedBlockState(ResourceLocation resourceLocation, Map<String, String> properties) {
-            this.resourceLocation = resourceLocation;
+        private SerializedBlockState(Identifier identifier, Map<String, String> properties) {
+            this.identifier = identifier;
             this.properties = properties;
         }
 
         private BlockState deserialize() {
             if (this.blockState == null) {
-                Block block = BuiltInRegistries.BLOCK.get(this.resourceLocation);
+                Block block = BuiltInRegistries.BLOCK.getValue(this.identifier);
                 this.blockState = block.defaultBlockState();
 
                 this.properties.keySet().stream().sorted(String::compareTo).forEachOrdered(key -> {
@@ -130,7 +130,7 @@ public final class SpongeSchematic extends StaticSchematic {
                 String location = m.group("location");
                 String properties = m.group("properties");
 
-                ResourceLocation resourceLocation = new ResourceLocation(location);
+                Identifier id = net.minecraft.resources.Identifier.parse(location);
                 Map<String, String> propertiesMap = new HashMap<>();
                 if (properties != null) {
                     for (String property : properties.split(",")) {
@@ -139,7 +139,7 @@ public final class SpongeSchematic extends StaticSchematic {
                     }
                 }
 
-                return new SerializedBlockState(resourceLocation, propertiesMap);
+                return new SerializedBlockState(id, propertiesMap);
             } catch (Exception e) {
                 e.printStackTrace();
                 return null;
@@ -156,3 +156,4 @@ public final class SpongeSchematic extends StaticSchematic {
         }
     }
 }
+

--- a/src/schematica_api/java/fi/dy/masa/litematica/world/WorldSchematic.java
+++ b/src/schematica_api/java/fi/dy/masa/litematica/world/WorldSchematic.java
@@ -21,7 +21,7 @@ import net.minecraft.world.level.Level;
 
 public abstract class WorldSchematic extends Level {
     private WorldSchematic() {
-        super(null, null, null, null, null, false, false, 0, 0);
+        super(null, null, null, null, false, false, 0, 0);
         throw new LinkageError();
     }
 }


### PR DESCRIPTION
## Summary\n- Port Baritone Forge build and runtime compatibility to Minecraft 1.21.11 / Forge 61.1.1 / Java 21\n- Update command/chat/render/world-height/NBT/data-component API usages for current mappings\n- Update Forge metadata to target 1.21.11\n- Restore end-to-end Forge release pipeline execution in this branch\n\n## Verification\n- :compileJava -PBaritone.enabled_platforms=forge passes\n- :forge:build -PBaritone.enabled_platforms=forge passes\n- Distribution artifacts produced under dist/\n\n## Notes\n- This branch includes broad API migration changes across modules required for 1.21.11 compatibility.