### PR TITLE
Fix BetterBlockPos leaking into block entity map, fixes #4307

### DIFF
--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -175,6 +175,10 @@ public final class RotationUtils {
     }
 
     public static Optional<Rotation> reachable(IPlayerContext ctx, BlockPos pos, double blockReachDistance, boolean wouldSneak) {
+        // Prevent BetterBlockPos from leaking into Minecraft's block entity map
+        if (pos instanceof BetterBlockPos) {
+            pos = new BlockPos(pos.getX(), pos.getY(), pos.getZ());
+        }
         if (BaritoneAPI.getSettings().remainWithExistingLookDirection.value && ctx.isLookingAt(pos)) {
             /*
              * why add 0.0001?

--- a/src/api/java/baritone/api/utils/VecUtils.java
+++ b/src/api/java/baritone/api/utils/VecUtils.java
@@ -43,6 +43,10 @@ public final class VecUtils {
      * @see #getBlockPosCenter(BlockPos)
      */
     public static Vec3 calculateBlockCenter(Level world, BlockPos pos) {
+        // Prevent BetterBlockPos from leaking into Minecraft's block entity map
+        if (pos instanceof BetterBlockPos) {
+            pos = new BlockPos(pos.getX(), pos.getY(), pos.getZ());
+        }
         BlockState b = world.getBlockState(pos);
         VoxelShape shape = b.getCollisionShape(world, pos);
         if (shape.isEmpty()) {


### PR DESCRIPTION
In these cases minecraft's functions `getShape` and `getCollisionShape` get called with `BetterBlockPos` and minecrafts block entity map doesn't contain that position yet then you'll get a crash.

The `reachable` function has a leak in `BuilderProcess::toBreakNearPlayer`:
```java
if (!(curr.getBlock() instanceof AirBlock) && !(curr.getBlock() == Blocks.WATER || curr.getBlock() == Blocks.LAVA) && !valid(curr, desired, false)) {
    BetterBlockPos pos = new BetterBlockPos(x, y, z);
    Optional<Rotation> rot = RotationUtils.reachable(ctx, pos, ctx.playerController().getBlockReachDistance());
    if (rot.isPresent()) {
        return Optional.of(new Tuple<>(pos, rot.get()));
    }
}
```

And `calculateBlockCenter` has a leak in `MovementTraverse::updateState` as `dest` is `protected final BetterBlockPos dest;`:
```java
// combine the yaw to the center of the destination, and the pitch to the specific block we're trying to break
// it's safe to do this since the two blocks we break (in a traverse) are right on top of each other and so will have the same yaw
float yawToDest = RotationUtils.calcRotationFromVec3d(ctx.playerHead(), VecUtils.calculateBlockCenter(ctx.world(), dest), ctx.playerRotations()).getYaw();
```

This fixes issue #4307 