### PR TITLE
Fix BetterBlockPos leaking into block entity map

### DIFF
--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -175,6 +175,10 @@ public final class RotationUtils {
     }
 
     public static Optional<Rotation> reachable(IPlayerContext ctx, BlockPos pos, double blockReachDistance, boolean wouldSneak) {
+        // Prevent BetterBlockPos from leaking into Minecraft's block entity map
+        if (pos instanceof BetterBlockPos) {
+            pos = new BlockPos(pos.getX(), pos.getY(), pos.getZ());
+        }
         if (BaritoneAPI.getSettings().remainWithExistingLookDirection.value && ctx.isLookingAt(pos)) {
             /*
              * why add 0.0001?

--- a/src/api/java/baritone/api/utils/VecUtils.java
+++ b/src/api/java/baritone/api/utils/VecUtils.java
@@ -43,6 +43,10 @@ public final class VecUtils {
      * @see #getBlockPosCenter(BlockPos)
      */
     public static Vec3 calculateBlockCenter(Level world, BlockPos pos) {
+        // Prevent BetterBlockPos from leaking into Minecraft's block entity map
+        if (pos instanceof BetterBlockPos) {
+            pos = new BlockPos(pos.getX(), pos.getY(), pos.getZ());
+        }
         BlockState b = world.getBlockState(pos);
         VoxelShape shape = b.getCollisionShape(world, pos);
         if (shape.isEmpty()) {


### PR DESCRIPTION
Made my initial PR #4999 for the `1.21.11` branch which was incorrect, so this one targets the correct `1.19.4` branch.