### PR TITLE
add `inventoryManagementOnlyWhilePathing` setting

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -101,6 +101,11 @@ public final class Settings {
      * Come to a halt before doing any inventory moves. Intended for anticheat such as 2b2t
      */
     public final Setting<Boolean> inventoryMoveOnlyIfStationary = new Setting<>(false);
+		
+		/**
+		 * Only manage inventory while Baritone is active.
+		 */
+		public final Setting<Boolean> inventoryManagementOnlyWhilePathing = new Setting<>(true);
 
     /**
      * Disable baritone's auto-tool at runtime, but still assume that another mod will provide auto tool functionality

--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -60,6 +60,11 @@ public final class InventoryBehavior extends Behavior implements Helper {
         if (event.getType() == TickEvent.Type.OUT) {
             return;
         }
+				if (Baritone.settings().inventoryManagementOnlyWhilePathing.value) {
+						if (!baritone.getPathingBehavior().isPathing() && !baritone.getPathingControlManager().mostRecentInControl().isPresent()) {
+								return;
+						}
+				}
         if (ctx.player().containerMenu != ctx.player().inventoryMenu) {
             // we have a crafting table or a chest or something open
             return;

--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -60,10 +60,8 @@ public final class InventoryBehavior extends Behavior implements Helper {
         if (event.getType() == TickEvent.Type.OUT) {
             return;
         }
-				if (Baritone.settings().inventoryManagementOnlyWhilePathing.value) {
-						if (!baritone.getPathingBehavior().isPathing() && !baritone.getPathingControlManager().mostRecentInControl().isPresent()) {
-								return;
-						}
+				if (Baritone.settings().inventoryManagementOnlyWhilePathing.value && !baritone.getPathingBehavior().isPathing() && !baritone.getPathingControlManager().mostRecentInControl().isPresent()) {
+						return;
 				}
         if (ctx.player().containerMenu != ctx.player().inventoryMenu) {
             // we have a crafting table or a chest or something open


### PR DESCRIPTION
self explanatory name

for example this disables pickaxe being always forced into the first slot while baritone is idling && `allowInventory` is true. personally found this annoying