### PR TITLE
Add configurable humanized look rotations

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,5 +1,7 @@
 <emoji> <title> (<ticket>)
 
+# trigger workfow
+
 # 📝 Update README.md (WD-1234)
 # ✅ Add unit test for inputs (WD-1234)
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -782,6 +782,71 @@ public final class Settings {
     public final Setting<Integer> smoothLookTicks = new Setting<>(5);
 
     /**
+     * Smooth Baritone-controlled rotations over multiple ticks instead of snapping to the target instantly.
+     */
+    public final Setting<Boolean> humanizeLook = new Setting<>(true);
+
+    /**
+     * Maximum yaw/pitch angular speed in degrees per tick while humanized look is active.
+     */
+    public final Setting<Double> humanizeLookMaxDegreesPerTick = new Setting<>(18.0d);
+
+    /**
+     * Minimum yaw/pitch angular speed in degrees per tick while still meaningfully away from the target.
+     */
+    public final Setting<Double> humanizeLookMinDegreesPerTick = new Setting<>(1.0d);
+
+    /**
+     * Maximum per-tick change in humanized look angular speed.
+     */
+    public final Setting<Double> humanizeLookAcceleration = new Setting<>(6.0d);
+
+    /**
+     * Small extra yaw/pitch jitter, in degrees, applied to humanized look targets.
+     */
+    public final Setting<Double> humanizeLookJitter = new Setting<>(0.08d);
+
+    /**
+     * Chance that a long humanized turn will aim slightly past its target before settling.
+     */
+    public final Setting<Double> humanizeLookOvershootChance = new Setting<>(0.15d);
+
+    /**
+     * Maximum degrees of target overshoot for long humanized turns.
+     */
+    public final Setting<Double> humanizeLookMaxOvershoot = new Setting<>(1.0d);
+
+    /**
+     * Maximum yaw/pitch angular speed in degrees per tick while elytra flying.
+     */
+    public final Setting<Double> humanizeLookElytraMaxDegreesPerTick = new Setting<>(35.0d);
+
+    /**
+     * Smooth visible Baritone camera movement between game ticks.
+     */
+    public final Setting<Boolean> humanizeLookVisualInterpolation = new Setting<>(true);
+
+    /**
+     * Return the visible camera to a forward-looking posture while Baritone is moving but not interacting with blocks.
+     */
+    public final Setting<Boolean> humanizeLookMovementPosture = new Setting<>(true);
+
+    /**
+     * Visible camera pitch used while Baritone is moving but not interacting with blocks.
+     */
+    public final Setting<Double> humanizeLookMovementPitch = new Setting<>(10.0d);
+
+    /**
+     * Maximum visible camera angular speed in degrees per tick when returning to movement posture.
+     */
+    public final Setting<Double> humanizeLookMovementMaxDegreesPerTick = new Setting<>(8.0d);
+
+    /**
+     * Low-pass factor for visible camera jitter. Lower values change more slowly.
+     */
+    public final Setting<Double> humanizeLookVisualJitterFrequency = new Setting<>(0.05d);
+
+    /**
      * When true, the player will remain with its existing look direction as often as possible.
      * Although, in some cases this can get it stuck, hence this setting to disable that behavior.
      */

--- a/src/api/java/baritone/api/behavior/look/IAimProcessor.java
+++ b/src/api/java/baritone/api/behavior/look/IAimProcessor.java
@@ -36,6 +36,18 @@ public interface IAimProcessor {
     Rotation peekRotation(Rotation desired);
 
     /**
+     * Returns the rotation to use for eventual reachability checks. Unlike {@link #peekRotation(Rotation)}, this may
+     * project past temporary smoothing so callers can answer "can this be aimed at once the look has settled?" without
+     * mutating the processor state.
+     *
+     * @param desired The desired rotation to set
+     * @return The eventual reachable rotation
+     */
+    default Rotation peekRotationForReachability(Rotation desired) {
+        return this.peekRotation(desired);
+    }
+
+    /**
      * Returns a copy of this {@link IAimProcessor} which has its own internal state and is manually tickable.
      *
      * @return The forked processor

--- a/src/api/java/baritone/api/utils/RotationUtils.java
+++ b/src/api/java/baritone/api/utils/RotationUtils.java
@@ -234,7 +234,7 @@ public final class RotationUtils {
     public static Optional<Rotation> reachableOffset(IPlayerContext ctx, BlockPos pos, Vec3 offsetPos, double blockReachDistance, boolean wouldSneak) {
         Vec3 eyes = wouldSneak ? RayTraceUtils.inferSneakingEyePosition(ctx.player()) : ctx.player().getEyePosition(1.0F);
         Rotation rotation = calcRotationFromVec3d(eyes, offsetPos, ctx.playerRotations());
-        Rotation actualRotation = BaritoneAPI.getProvider().getBaritoneForPlayer(ctx.player()).getLookBehavior().getAimProcessor().peekRotation(rotation);
+        Rotation actualRotation = BaritoneAPI.getProvider().getBaritoneForPlayer(ctx.player()).getLookBehavior().getAimProcessor().peekRotationForReachability(rotation);
         HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), actualRotation, blockReachDistance, wouldSneak);
         //System.out.println(result);
         if (result != null && result.getType() == HitResult.Type.BLOCK) {

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -21,15 +21,18 @@ import baritone.Baritone;
 import baritone.api.Settings;
 import baritone.api.behavior.ILookBehavior;
 import baritone.api.behavior.look.IAimProcessor;
-import baritone.api.behavior.look.ITickableAimProcessor;
-import baritone.api.event.events.*;
+import baritone.api.event.events.PacketEvent;
+import baritone.api.event.events.PlayerUpdateEvent;
+import baritone.api.event.events.RotationMoveEvent;
+import baritone.api.event.events.WorldEvent;
 import baritone.api.utils.IPlayerContext;
 import baritone.api.utils.Rotation;
+import baritone.behavior.look.AimProcessor;
 import baritone.behavior.look.ForkableRandom;
+import baritone.behavior.look.HumanizedRotationSmoother;
+import baritone.behavior.look.VisualRotationHelper;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.Optional;
 
 public final class LookBehavior extends Behavior implements ILookBehavior {
@@ -52,20 +55,23 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     private Rotation prevRotation;
 
     private final AimProcessor processor;
-
-    private final Deque<Float> smoothYawBuffer;
-    private final Deque<Float> smoothPitchBuffer;
+    private final HumanizedRotationSmoother visualSmoother;
+    private final ForkableRandom visualRandom;
+    private Rotation effectiveRotation;
+    private Rotation visualRotation;
+    private double visualJitterYaw;
+    private double visualJitterPitch;
 
     public LookBehavior(Baritone baritone) {
         super(baritone);
         this.processor = new AimProcessor(baritone.getPlayerContext());
-        this.smoothYawBuffer = new ArrayDeque<>();
-        this.smoothPitchBuffer = new ArrayDeque<>();
+        this.visualSmoother = new HumanizedRotationSmoother();
+        this.visualRandom = new ForkableRandom();
     }
 
     @Override
     public void updateTarget(Rotation rotation, boolean blockInteract) {
-        this.target = new Target(rotation, Target.Mode.resolve(ctx, blockInteract));
+        this.target = new Target(rotation, Target.Mode.resolve(ctx, blockInteract), blockInteract);
     }
 
     @Override
@@ -74,58 +80,32 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     }
 
     @Override
-    public void onTick(TickEvent event) {
-        if (event.getType() == TickEvent.Type.IN) {
-            this.processor.tick();
-        }
-    }
-
-    @Override
     public void onPlayerUpdate(PlayerUpdateEvent event) {
-
-        if (this.target == null) {
-            return;
-        }
 
         switch (event.getState()) {
             case PRE: {
-                if (this.target.mode == Target.Mode.NONE) {
-                    // Just return for PRE, we still want to set target to null on POST
+                if (this.target == null || this.target.mode == Target.Mode.NONE) {
                     return;
                 }
 
-                this.prevRotation = new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
-                final Rotation actual = this.processor.peekRotation(this.target.rotation);
-                ctx.player().setYRot(actual.getYaw());
-                ctx.player().setXRot(actual.getPitch());
+                this.prevRotation = this.currentVisualRotation();
+                this.effectiveRotation = this.nextEffectiveRotation(this.target);
+                ctx.player().setYRot(this.effectiveRotation.getYaw());
+                ctx.player().setXRot(this.effectiveRotation.getPitch());
                 break;
             }
             case POST: {
-                // Reset the player's rotations back to their original values
-                if (this.prevRotation != null) {
-                    this.smoothYawBuffer.addLast(this.target.rotation.getYaw());
-                    while (this.smoothYawBuffer.size() > Baritone.settings().smoothLookTicks.value) {
-                        this.smoothYawBuffer.removeFirst();
-                    }
-                    this.smoothPitchBuffer.addLast(this.target.rotation.getPitch());
-                    while (this.smoothPitchBuffer.size() > Baritone.settings().smoothLookTicks.value) {
-                        this.smoothPitchBuffer.removeFirst();
-                    }
-                    if (this.target.mode == Target.Mode.SERVER) {
-                        ctx.player().setYRot(this.prevRotation.getYaw());
-                        ctx.player().setXRot(this.prevRotation.getPitch());
-                    } else if (ctx.player().isFallFlying() ? Baritone.settings().elytraSmoothLook.value : Baritone.settings().smoothLook.value) {
-                        ctx.player().setYRot((float) this.smoothYawBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getYaw()));
-                        if (ctx.player().isFallFlying()) {
-                            ctx.player().setXRot((float) this.smoothPitchBuffer.stream().mapToDouble(d -> d).average().orElse(this.prevRotation.getPitch()));
-                        }
-                    }
-                    //ctx.player().xRotO = prevRotation.getPitch();
-                    //ctx.player().yRotO = prevRotation.getYaw();
-                    this.prevRotation = null;
+                Target tickTarget = this.target;
+                Rotation visibleBase = this.prevRotation != null ? this.prevRotation : this.currentVisualRotation();
+                if (tickTarget != null) {
+                    this.updateVisualRotation(tickTarget, visibleBase);
+                } else if (this.prevRotation != null) {
+                    this.applyVisibleRotation(this.prevRotation, this.prevRotation);
                 }
-                // The target is done being used for this game tick, so it can be invalidated
+
+                this.prevRotation = null;
                 this.target = null;
+                this.effectiveRotation = null;
                 break;
             }
             default:
@@ -149,17 +129,22 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     public void onWorldEvent(WorldEvent event) {
         this.serverRotation = null;
         this.target = null;
+        this.effectiveRotation = null;
+        this.visualRotation = null;
     }
 
     public void pig() {
         if (this.target != null) {
-            final Rotation actual = this.processor.peekRotation(this.target.rotation);
+            final Rotation actual = this.effectiveRotation == null ? this.peekEffectiveRotation(this.target) : this.effectiveRotation;
             ctx.player().setYRot(actual.getYaw());
         }
     }
 
     public Optional<Rotation> getEffectiveRotation() {
         if (Baritone.settings().freeLook.value) {
+            if (this.effectiveRotation != null) {
+                return Optional.of(this.effectiveRotation);
+            }
             return Optional.ofNullable(this.serverRotation);
         }
         // If freeLook isn't on, just defer to the player's actual rotations
@@ -169,152 +154,117 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
     @Override
     public void onPlayerRotationMove(RotationMoveEvent event) {
         if (this.target != null) {
-            final Rotation actual = this.processor.peekRotation(this.target.rotation);
+            final Rotation actual = this.effectiveRotation == null ? this.peekEffectiveRotation(this.target) : this.effectiveRotation;
             event.setYaw(actual.getYaw());
             event.setPitch(actual.getPitch());
         }
     }
 
-    private static final class AimProcessor extends AbstractAimProcessor {
-
-        public AimProcessor(final IPlayerContext ctx) {
-            super(ctx);
+    private Rotation nextEffectiveRotation(Target tickTarget) {
+        if (tickTarget.blockInteract || ctx.player().isFallFlying()) {
+            return this.processor.nextRotation(tickTarget.rotation);
         }
-
-        @Override
-        protected Rotation getPrevRotation() {
-            // Implementation will use LookBehavior.serverRotation
-            return ctx.playerRotations();
-        }
+        return this.processor.nextRotationWithoutHumanizer(tickTarget.rotation);
     }
 
-    private static abstract class AbstractAimProcessor implements ITickableAimProcessor {
+    private Rotation peekEffectiveRotation(Target tickTarget) {
+        if (tickTarget.blockInteract || ctx.player().isFallFlying()) {
+            return this.processor.peekRotation(tickTarget.rotation);
+        }
+        return this.processor.peekRotationForReachability(tickTarget.rotation);
+    }
 
-        protected final IPlayerContext ctx;
-        private final ForkableRandom rand;
-        private double randomYawOffset;
-        private double randomPitchOffset;
+    private void updateVisualRotation(Target tickTarget, Rotation visibleBase) {
+        Rotation from = this.visualRotation != null ? this.visualRotation : visibleBase;
+        Rotation to = this.visualTarget(tickTarget, visibleBase);
+        Rotation next = this.visualSmoother.next(from, to, this.visualConfig(tickTarget));
+        this.visualRotation = next;
+        this.applyVisibleRotation(from, next);
+    }
 
-        public AbstractAimProcessor(IPlayerContext ctx) {
-            this.ctx = ctx;
-            this.rand = new ForkableRandom();
+    private Rotation visualTarget(Target tickTarget, Rotation visibleBase) {
+        if (tickTarget != null && tickTarget.mode == Target.Mode.CLIENT && tickTarget.blockInteract && this.effectiveRotation != null) {
+            return this.effectiveRotation;
+        }
+        if (tickTarget != null && tickTarget.blockInteract && tickTarget.mode == Target.Mode.SERVER) {
+            return visibleBase;
+        }
+        if (tickTarget != null && !tickTarget.blockInteract && Baritone.settings().humanizeLookMovementPosture.value && !ctx.player().isFallFlying()) {
+            Rotation posture = VisualRotationHelper.movementPosture(tickTarget.rotation, Baritone.settings().humanizeLookMovementPitch.value);
+            return this.addVisualJitter(posture);
+        }
+        if (this.effectiveRotation != null) {
+            return this.effectiveRotation;
+        }
+        return tickTarget == null ? visibleBase : tickTarget.rotation;
+    }
+
+    private Rotation addVisualJitter(Rotation posture) {
+        double jitter = Baritone.settings().humanizeLookJitter.value;
+        if (jitter <= 0.0D) {
+            this.visualJitterYaw = 0.0D;
+            this.visualJitterPitch = 0.0D;
+            return posture;
         }
 
-        private AbstractAimProcessor(final AbstractAimProcessor source) {
-            this.ctx = source.ctx;
-            this.rand = source.rand.fork();
-            this.randomYawOffset = source.randomYawOffset;
-            this.randomPitchOffset = source.randomPitchOffset;
+        double frequency = Math.max(0.0D, Math.min(1.0D, Baritone.settings().humanizeLookVisualJitterFrequency.value));
+        double targetYaw = (this.visualRandom.nextDouble() - 0.5D) * jitter;
+        double targetPitch = (this.visualRandom.nextDouble() - 0.5D) * jitter;
+        this.visualJitterYaw += (targetYaw - this.visualJitterYaw) * frequency;
+        this.visualJitterPitch += (targetPitch - this.visualJitterPitch) * frequency;
+
+        return new Rotation(
+                posture.getYaw() + (float) this.visualJitterYaw,
+                posture.getPitch() + (float) this.visualJitterPitch
+        ).normalizeAndClamp();
+    }
+
+    private HumanizedRotationSmoother.Config visualConfig(Target tickTarget) {
+        boolean blockInteract = tickTarget != null && tickTarget.mode == Target.Mode.CLIENT && tickTarget.blockInteract;
+        double maxSpeed = blockInteract
+                ? Baritone.settings().humanizeLookMaxDegreesPerTick.value
+                : Baritone.settings().humanizeLookMovementMaxDegreesPerTick.value;
+        return new HumanizedRotationSmoother.Config(
+                Baritone.settings().humanizeLook.value,
+                maxSpeed,
+                Baritone.settings().humanizeLookMinDegreesPerTick.value,
+                Baritone.settings().humanizeLookAcceleration.value,
+                0.0D,
+                0.0D,
+                blockInteract ? Baritone.settings().humanizeLookOvershootChance.value : 0.0D,
+                blockInteract ? Baritone.settings().humanizeLookMaxOvershoot.value : 0.0D
+        );
+    }
+
+    private Rotation currentVisualRotation() {
+        return new Rotation(ctx.player().getYRot(), ctx.player().getXRot());
+    }
+
+    private void applyVisibleRotation(Rotation from, Rotation to) {
+        Rotation current = Baritone.settings().humanizeLookVisualInterpolation.value
+                ? VisualRotationHelper.interpolate(from, to, 1.0F)
+                : to;
+        if (Baritone.settings().humanizeLookVisualInterpolation.value) {
+            ctx.player().yRotO = from.getYaw();
+            ctx.player().xRotO = from.getPitch();
+        } else {
+            ctx.player().yRotO = current.getYaw();
+            ctx.player().xRotO = current.getPitch();
         }
-
-        @Override
-        public final Rotation peekRotation(final Rotation rotation) {
-            final Rotation prev = this.getPrevRotation();
-
-            float desiredYaw = rotation.getYaw();
-            float desiredPitch = rotation.getPitch();
-
-            // In other words, the target doesn't care about the pitch, so it used playerRotations().getPitch()
-            // and it's safe to adjust it to a normal level
-            if (desiredPitch == prev.getPitch()) {
-                desiredPitch = nudgeToLevel(desiredPitch);
-            }
-
-            desiredYaw += this.randomYawOffset;
-            desiredPitch += this.randomPitchOffset;
-
-            return new Rotation(
-                    this.calculateMouseMove(prev.getYaw(), desiredYaw),
-                    this.calculateMouseMove(prev.getPitch(), desiredPitch)
-            ).clamp();
-        }
-
-        @Override
-        public final void tick() {
-            // randomLooking
-            this.randomYawOffset = (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
-            this.randomPitchOffset = (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
-
-            // randomLooking113
-            double random = this.rand.nextDouble() - 0.5;
-            if (Math.abs(random) < 0.1) {
-                random *= 4;
-            }
-            this.randomYawOffset += random * Baritone.settings().randomLooking113.value;
-        }
-
-        @Override
-        public final void advance(int ticks) {
-            for (int i = 0; i < ticks; i++) {
-                this.tick();
-            }
-        }
-
-        @Override
-        public Rotation nextRotation(final Rotation rotation) {
-            final Rotation actual = this.peekRotation(rotation);
-            this.tick();
-            return actual;
-        }
-
-        @Override
-        public final ITickableAimProcessor fork() {
-            return new AbstractAimProcessor(this) {
-
-                private Rotation prev = AbstractAimProcessor.this.getPrevRotation();
-
-                @Override
-                public Rotation nextRotation(final Rotation rotation) {
-                    return (this.prev = super.nextRotation(rotation));
-                }
-
-                @Override
-                protected Rotation getPrevRotation() {
-                    return this.prev;
-                }
-            };
-        }
-
-        protected abstract Rotation getPrevRotation();
-
-        /**
-         * Nudges the player's pitch to a regular level. (Between {@code -20} and {@code 10}, increments are by {@code 1})
-         */
-        private float nudgeToLevel(float pitch) {
-            if (pitch < -20) {
-                return pitch + 1;
-            } else if (pitch > 10) {
-                return pitch - 1;
-            }
-            return pitch;
-        }
-
-        private float calculateMouseMove(float current, float target) {
-            final float delta = target - current;
-            final double deltaPx = angleToMouse(delta); // yes, even the mouse movements use double
-            return current + mouseToAngle(deltaPx);
-        }
-
-        private double angleToMouse(float angleDelta) {
-            final float minAngleChange = mouseToAngle(1);
-            return Math.round(angleDelta / minAngleChange);
-        }
-
-        private float mouseToAngle(double mouseDelta) {
-            // casting float literals to double gets us the precise values used by mc
-            final double f = ctx.minecraft().options.sensitivity().get() * (double) 0.6f + (double) 0.2f;
-            return (float) (mouseDelta * f * f * f * 8.0d) * 0.15f; // yes, one double and one float scaling factor
-        }
+        ctx.player().setYRot(current.getYaw());
+        ctx.player().setXRot(current.getPitch());
     }
 
     private static class Target {
 
         public final Rotation rotation;
         public final Mode mode;
+        public final boolean blockInteract;
 
-        public Target(Rotation rotation, Mode mode) {
+        public Target(Rotation rotation, Mode mode, boolean blockInteract) {
             this.rotation = rotation;
             this.mode = mode;
+            this.blockInteract = blockInteract;
         }
 
         enum Mode {

--- a/src/main/java/baritone/behavior/look/AimProcessor.java
+++ b/src/main/java/baritone/behavior/look/AimProcessor.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior.look;
+
+import baritone.Baritone;
+import baritone.api.behavior.look.ITickableAimProcessor;
+import baritone.api.utils.IPlayerContext;
+import baritone.api.utils.Rotation;
+
+public final class AimProcessor implements ITickableAimProcessor {
+
+    private final IPlayerContext ctx;
+    private final ForkableRandom rand;
+    private final HumanizedRotationSmoother smoother;
+    private double randomYawOffset;
+    private double randomPitchOffset;
+    private Rotation simulatedPrevRotation;
+
+    public AimProcessor(IPlayerContext ctx) {
+        this.ctx = ctx;
+        this.rand = new ForkableRandom();
+        this.smoother = new HumanizedRotationSmoother();
+        this.tick();
+    }
+
+    private AimProcessor(AimProcessor source) {
+        this.ctx = source.ctx;
+        this.rand = source.rand.fork();
+        this.smoother = source.smoother.fork();
+        this.randomYawOffset = source.randomYawOffset;
+        this.randomPitchOffset = source.randomPitchOffset;
+        this.simulatedPrevRotation = source.getPrevRotation();
+    }
+
+    @Override
+    public Rotation peekRotation(final Rotation rotation) {
+        return this.calculate(rotation, false, false, true);
+    }
+
+    @Override
+    public Rotation peekRotationForReachability(Rotation desired) {
+        return this.calculate(desired, false, true, true);
+    }
+
+    @Override
+    public void tick() {
+        this.randomYawOffset = (this.rand.nextDouble() - 0.5D) * Baritone.settings().randomLooking.value;
+        this.randomPitchOffset = (this.rand.nextDouble() - 0.5D) * Baritone.settings().randomLooking.value;
+
+        double random = this.rand.nextDouble() - 0.5D;
+        if (Math.abs(random) < 0.1D) {
+            random *= 4.0D;
+        }
+        this.randomYawOffset += random * Baritone.settings().randomLooking113.value;
+    }
+
+    @Override
+    public void advance(int ticks) {
+        for (int i = 0; i < ticks; i++) {
+            this.tick();
+        }
+    }
+
+    @Override
+    public Rotation nextRotation(final Rotation rotation) {
+        Rotation actual = this.calculate(rotation, true, false, true);
+        if (this.simulatedPrevRotation != null) {
+            this.simulatedPrevRotation = actual;
+        }
+        this.tick();
+        return actual;
+    }
+
+    public Rotation nextRotationWithoutHumanizer(Rotation rotation) {
+        Rotation actual = this.calculate(rotation, false, true, true);
+        if (this.simulatedPrevRotation != null) {
+            this.simulatedPrevRotation = actual;
+        }
+        this.tick();
+        return actual;
+    }
+
+    @Override
+    public ITickableAimProcessor fork() {
+        return new AimProcessor(this);
+    }
+
+    private Rotation calculate(Rotation rotation, boolean mutate, boolean reachability, boolean quantize) {
+        Rotation prev = this.getPrevRotation();
+
+        float desiredYaw = rotation.getYaw();
+        float desiredPitch = rotation.getPitch();
+
+        if (desiredPitch == prev.getPitch()) {
+            desiredPitch = nudgeToLevel(desiredPitch);
+        }
+
+        desiredYaw += this.randomYawOffset;
+        desiredPitch += this.randomPitchOffset;
+
+        Rotation desired = new Rotation(desiredYaw, desiredPitch).normalizeAndClamp();
+        Rotation aimed = reachability ? desired : this.humanized(prev, desired, mutate);
+        if (!quantize) {
+            return aimed;
+        }
+        return new Rotation(
+                this.calculateMouseMove(prev.getYaw(), aimed.getYaw()),
+                this.calculateMouseMove(prev.getPitch(), aimed.getPitch())
+        ).normalizeAndClamp();
+    }
+
+    private Rotation humanized(Rotation prev, Rotation desired, boolean mutate) {
+        HumanizedRotationSmoother.Config config = new HumanizedRotationSmoother.Config(
+                Baritone.settings().humanizeLook.value,
+                this.ctx.player().isFallFlying()
+                        ? Baritone.settings().humanizeLookElytraMaxDegreesPerTick.value
+                        : Baritone.settings().humanizeLookMaxDegreesPerTick.value,
+                Baritone.settings().humanizeLookMinDegreesPerTick.value,
+                Baritone.settings().humanizeLookAcceleration.value,
+                Baritone.settings().humanizeLookJitter.value,
+                0.0D,
+                Baritone.settings().humanizeLookOvershootChance.value,
+                Baritone.settings().humanizeLookMaxOvershoot.value
+        );
+        return mutate ? this.smoother.next(prev, desired, config) : this.smoother.peek(prev, desired, config);
+    }
+
+    private Rotation getPrevRotation() {
+        return this.simulatedPrevRotation != null ? this.simulatedPrevRotation : this.ctx.playerRotations();
+    }
+
+    private static float nudgeToLevel(float pitch) {
+        if (pitch < -20.0F) {
+            return pitch + 1.0F;
+        } else if (pitch > 10.0F) {
+            return pitch - 1.0F;
+        }
+        return pitch;
+    }
+
+    private float calculateMouseMove(float current, float target) {
+        final float delta = target - current;
+        final double deltaPx = this.angleToMouse(delta);
+        return current + this.mouseToAngle(deltaPx);
+    }
+
+    private double angleToMouse(float angleDelta) {
+        final float minAngleChange = this.mouseToAngle(1);
+        return Math.round(angleDelta / minAngleChange);
+    }
+
+    private float mouseToAngle(double mouseDelta) {
+        final double f = this.ctx.minecraft().options.sensitivity().get() * (double) 0.6f + (double) 0.2f;
+        return (float) (mouseDelta * f * f * f * 8.0d) * 0.15f;
+    }
+}

--- a/src/main/java/baritone/behavior/look/HumanizedRotationSmoother.java
+++ b/src/main/java/baritone/behavior/look/HumanizedRotationSmoother.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior.look;
+
+import baritone.api.utils.Rotation;
+
+public final class HumanizedRotationSmoother {
+
+    private double yawVelocity;
+    private double pitchVelocity;
+
+    public Rotation peek(Rotation current, Rotation target, Config config) {
+        return this.step(current, target, config, false);
+    }
+
+    public Rotation next(Rotation current, Rotation target, Config config) {
+        return this.step(current, target, config, true);
+    }
+
+    public HumanizedRotationSmoother fork() {
+        HumanizedRotationSmoother fork = new HumanizedRotationSmoother();
+        fork.yawVelocity = this.yawVelocity;
+        fork.pitchVelocity = this.pitchVelocity;
+        return fork;
+    }
+
+    private Rotation step(Rotation current, Rotation target, Config config, boolean mutate) {
+        Rotation clampedTarget = target.normalizeAndClamp();
+        if (!config.enabled) {
+            if (mutate) {
+                this.yawVelocity = 0.0D;
+                this.pitchVelocity = 0.0D;
+            }
+            return clampedTarget;
+        }
+
+        Rotation adjustedTarget = this.adjustTarget(current, clampedTarget, config);
+        AxisStep yaw = this.axisStep(
+                Rotation.normalizeYaw(adjustedTarget.getYaw() - current.getYaw()),
+                this.yawVelocity,
+                config
+        );
+        AxisStep pitch = this.axisStep(
+                adjustedTarget.getPitch() - current.getPitch(),
+                this.pitchVelocity,
+                config
+        );
+
+        if (mutate) {
+            this.yawVelocity = yaw.velocity;
+            this.pitchVelocity = pitch.velocity;
+        }
+
+        return new Rotation(
+                current.getYaw() + (float) yaw.delta,
+                current.getPitch() + (float) pitch.delta
+        ).normalizeAndClamp();
+    }
+
+    private Rotation adjustTarget(Rotation current, Rotation target, Config config) {
+        double yawDelta = Rotation.normalizeYaw(target.getYaw() - current.getYaw());
+        double pitchDelta = target.getPitch() - current.getPitch();
+        double distance = Math.hypot(yawDelta, pitchDelta);
+
+        double jitterYaw = 0.0D;
+        double jitterPitch = 0.0D;
+        if (config.jitter > 0.0D && distance > 0.01D) {
+            jitterYaw = deterministicNoise(current.getYaw(), target.getYaw(), 11.0D) * config.jitter;
+            jitterPitch = deterministicNoise(current.getPitch(), target.getPitch(), 29.0D) * config.jitter;
+        }
+
+        double overshootYaw = 0.0D;
+        double overshootPitch = 0.0D;
+        if (config.overshootChance > 0.0D && config.maxOvershoot > 0.0D && distance > 12.0D) {
+            double chance = (deterministicNoise(target.getYaw(), target.getPitch(), 47.0D) + 1.0D) * 0.5D;
+            if (chance < clamp(config.overshootChance, 0.0D, 1.0D)) {
+                double amount = config.maxOvershoot * clamp(distance / 90.0D, 0.0D, 1.0D);
+                overshootYaw = Math.signum(yawDelta) * amount;
+                overshootPitch = Math.signum(pitchDelta) * amount;
+            }
+        }
+
+        return new Rotation(
+                target.getYaw() + (float) (jitterYaw + overshootYaw),
+                target.getPitch() + (float) (jitterPitch + overshootPitch)
+        ).normalizeAndClamp();
+    }
+
+    private AxisStep axisStep(double delta, double velocity, Config config) {
+        double distance = Math.abs(delta);
+        if (distance < 0.0001D) {
+            return new AxisStep(0.0D, 0.0D);
+        }
+
+        double requested = Math.signum(delta) * this.requestedSpeed(distance, config);
+        double acceleration = Math.max(0.0D, config.acceleration);
+        double nextVelocity;
+        if (acceleration == 0.0D) {
+            nextVelocity = requested;
+        } else {
+            nextVelocity = velocity + clamp(requested - velocity, -acceleration, acceleration);
+        }
+        nextVelocity = clamp(nextVelocity, -config.maxDegreesPerTick, config.maxDegreesPerTick);
+
+        double step = Math.signum(delta) * Math.min(Math.abs(nextVelocity), distance);
+        return new AxisStep(step, step);
+    }
+
+    private double requestedSpeed(double distance, Config config) {
+        if (config.maxDegreesPerTick <= config.minDegreesPerTick) {
+            return config.maxDegreesPerTick;
+        }
+        double t = clamp(distance / 45.0D, 0.0D, 1.0D);
+        double eased = t * t * (3.0D - 2.0D * t);
+        return config.minDegreesPerTick + (config.maxDegreesPerTick - config.minDegreesPerTick) * eased;
+    }
+
+    public static double angularDistance(Rotation a, Rotation b) {
+        double yaw = Rotation.normalizeYaw(b.getYaw() - a.getYaw());
+        double pitch = b.getPitch() - a.getPitch();
+        return Math.hypot(yaw, pitch);
+    }
+
+    private static double deterministicNoise(double a, double b, double salt) {
+        double value = Math.sin(a * 12.9898D + b * 78.233D + salt * 37.719D) * 43758.5453D;
+        return (value - Math.floor(value)) * 2.0D - 1.0D;
+    }
+
+    private static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static final class AxisStep {
+        private final double delta;
+        private final double velocity;
+
+        private AxisStep(double delta, double velocity) {
+            this.delta = delta;
+            this.velocity = velocity;
+        }
+    }
+
+    public static final class Config {
+        public final boolean enabled;
+        public final double maxDegreesPerTick;
+        public final double minDegreesPerTick;
+        public final double acceleration;
+        public final double jitter;
+        public final double unusedJitterFrequency;
+        public final double overshootChance;
+        public final double maxOvershoot;
+
+        public Config(boolean enabled, double maxDegreesPerTick, double minDegreesPerTick, double acceleration, double jitter, double unusedJitterFrequency, double overshootChance, double maxOvershoot) {
+            this.enabled = enabled;
+            this.maxDegreesPerTick = Math.max(0.0D, maxDegreesPerTick);
+            this.minDegreesPerTick = Math.max(0.0D, minDegreesPerTick);
+            this.acceleration = Math.max(0.0D, acceleration);
+            this.jitter = Math.max(0.0D, jitter);
+            this.unusedJitterFrequency = unusedJitterFrequency;
+            this.overshootChance = overshootChance;
+            this.maxOvershoot = Math.max(0.0D, maxOvershoot);
+        }
+    }
+}

--- a/src/main/java/baritone/behavior/look/VisualRotationHelper.java
+++ b/src/main/java/baritone/behavior/look/VisualRotationHelper.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior.look;
+
+import baritone.api.utils.Rotation;
+
+public final class VisualRotationHelper {
+
+    private VisualRotationHelper() {}
+
+    public static Rotation interpolate(Rotation from, Rotation to, float partialTicks) {
+        float partial = Math.max(0.0F, Math.min(1.0F, partialTicks));
+        float yawDelta = Rotation.normalizeYaw(to.getYaw() - from.getYaw());
+        float pitchDelta = to.getPitch() - from.getPitch();
+        return new Rotation(
+                from.getYaw() + yawDelta * partial,
+                from.getPitch() + pitchDelta * partial
+        ).normalizeAndClamp();
+    }
+
+    public static Rotation movementPosture(Rotation heading, double pitch) {
+        return new Rotation(heading.getYaw(), Rotation.clampPitch((float) pitch));
+    }
+}

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -802,7 +802,7 @@ public interface MovementHelper extends ActionCosts, Helper {
                 double faceY = (placeAt.getY() + against1.getY() + 0.5D) * 0.5D;
                 double faceZ = (placeAt.getZ() + against1.getZ() + 1.0D) * 0.5D;
                 Rotation place = RotationUtils.calcRotationFromVec3d(wouldSneak ? RayTraceUtils.inferSneakingEyePosition(ctx.player()) : ctx.playerHead(), new Vec3(faceX, faceY, faceZ), ctx.playerRotations());
-                Rotation actual = baritone.getLookBehavior().getAimProcessor().peekRotation(place);
+                Rotation actual = baritone.getLookBehavior().getAimProcessor().peekRotationForReachability(place);
                 HitResult res = RayTraceUtils.rayTraceTowards(ctx.player(), actual, ctx.playerController().getBlockReachDistance(), wouldSneak);
                 if (res != null && res.getType() == HitResult.Type.BLOCK && ((BlockHitResult) res).getBlockPos().equals(against1) && ((BlockHitResult) res).getBlockPos().relative(((BlockHitResult) res).getDirection()).equals(placeAt)) {
                     state.setTarget(new MovementTarget(place, true));

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -368,7 +368,7 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
                 double placeY = placeAgainstPos.y + aabb.minY * placementMultiplier.y + aabb.maxY * (1 - placementMultiplier.y);
                 double placeZ = placeAgainstPos.z + aabb.minZ * placementMultiplier.z + aabb.maxZ * (1 - placementMultiplier.z);
                 Rotation rot = RotationUtils.calcRotationFromVec3d(RayTraceUtils.inferSneakingEyePosition(ctx.player()), new Vec3(placeX, placeY, placeZ), ctx.playerRotations());
-                Rotation actualRot = baritone.getLookBehavior().getAimProcessor().peekRotation(rot);
+                Rotation actualRot = baritone.getLookBehavior().getAimProcessor().peekRotationForReachability(rot);
                 HitResult result = RayTraceUtils.rayTraceTowards(ctx.player(), actualRot, ctx.playerController().getBlockReachDistance(), true);
                 if (result != null && result.getType() == HitResult.Type.BLOCK && ((BlockHitResult) result).getBlockPos().equals(placeAgainstPos) && ((BlockHitResult) result).getDirection() == against.getOpposite()) {
                     OptionalInt hotbar = hasAnyItemThatWouldPlace(toPlace, result, actualRot);

--- a/src/test/java/baritone/behavior/look/HumanizedRotationSmootherTest.java
+++ b/src/test/java/baritone/behavior/look/HumanizedRotationSmootherTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior.look;
+
+import baritone.api.utils.Rotation;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HumanizedRotationSmootherTest {
+
+    private static final HumanizedRotationSmoother.Config CONFIG = new HumanizedRotationSmoother.Config(
+            true,
+            18.0D,
+            1.0D,
+            6.0D,
+            0.0D,
+            0.0D,
+            0.0D,
+            0.0D
+    );
+
+    @Test
+    public void respectsMaxSpeedAndAcceleration() {
+        HumanizedRotationSmoother smoother = new HumanizedRotationSmoother();
+        Rotation current = new Rotation(0.0F, 0.0F);
+        Rotation target = new Rotation(90.0F, 0.0F);
+
+        Rotation first = smoother.next(current, target, CONFIG);
+        assertEquals(6.0F, first.getYaw(), 0.0001F);
+
+        Rotation second = smoother.next(first, target, CONFIG);
+        assertEquals(18.0F, second.getYaw(), 0.0001F);
+    }
+
+    @Test
+    public void reachesTargetOverRepeatedTicks() {
+        HumanizedRotationSmoother smoother = new HumanizedRotationSmoother();
+        Rotation current = new Rotation(0.0F, 0.0F);
+        Rotation target = new Rotation(70.0F, 20.0F);
+
+        for (int i = 0; i < 20; i++) {
+            current = smoother.next(current, target, CONFIG);
+        }
+
+        assertEquals(target.getYaw(), current.getYaw(), 0.001F);
+        assertEquals(target.getPitch(), current.getPitch(), 0.001F);
+    }
+
+    @Test
+    public void wrapsYawThroughShortestPath() {
+        HumanizedRotationSmoother smoother = new HumanizedRotationSmoother();
+        Rotation current = new Rotation(179.0F, 0.0F);
+        Rotation target = new Rotation(-179.0F, 0.0F);
+
+        Rotation next = smoother.next(current, target, CONFIG);
+
+        assertTrue(next.getYaw() > 179.0F || next.getYaw() < -179.0F);
+        assertEquals(2.0D, HumanizedRotationSmoother.angularDistance(current, target), 0.0001D);
+    }
+
+    @Test
+    public void clampsPitch() {
+        HumanizedRotationSmoother smoother = new HumanizedRotationSmoother();
+        HumanizedRotationSmoother.Config fast = new HumanizedRotationSmoother.Config(
+                true,
+                180.0D,
+                180.0D,
+                180.0D,
+                0.0D,
+                0.0D,
+                0.0D,
+                0.0D
+        );
+
+        Rotation next = smoother.next(new Rotation(0.0F, 80.0F), new Rotation(0.0F, 120.0F), fast);
+
+        assertEquals(90.0F, next.getPitch(), 0.0001F);
+    }
+
+    @Test
+    public void peekDoesNotMutateVelocity() {
+        HumanizedRotationSmoother smoother = new HumanizedRotationSmoother();
+        Rotation current = new Rotation(0.0F, 0.0F);
+        Rotation target = new Rotation(90.0F, 0.0F);
+
+        Rotation peek = smoother.peek(current, target, CONFIG);
+        Rotation next = smoother.next(current, target, CONFIG);
+
+        assertEquals(peek.getYaw(), next.getYaw(), 0.0001F);
+        assertEquals(6.0F, next.getYaw(), 0.0001F);
+    }
+
+    @Test
+    public void forkIsDeterministicAndIndependent() {
+        HumanizedRotationSmoother smoother = new HumanizedRotationSmoother();
+        Rotation current = smoother.next(new Rotation(0.0F, 0.0F), new Rotation(90.0F, 0.0F), CONFIG);
+        HumanizedRotationSmoother fork = smoother.fork();
+
+        Rotation sourceNext = smoother.next(current, new Rotation(90.0F, 0.0F), CONFIG);
+        Rotation forkNext = fork.next(current, new Rotation(90.0F, 0.0F), CONFIG);
+        assertEquals(sourceNext.getYaw(), forkNext.getYaw(), 0.0001F);
+
+        smoother.next(sourceNext, new Rotation(-90.0F, 0.0F), CONFIG);
+        Rotation stillIndependent = fork.next(forkNext, new Rotation(90.0F, 0.0F), CONFIG);
+        assertTrue(stillIndependent.getYaw() > forkNext.getYaw());
+    }
+
+    @Test
+    public void disabledReturnsTargetImmediately() {
+        HumanizedRotationSmoother smoother = new HumanizedRotationSmoother();
+        HumanizedRotationSmoother.Config disabled = new HumanizedRotationSmoother.Config(
+                false,
+                1.0D,
+                1.0D,
+                1.0D,
+                0.0D,
+                0.0D,
+                0.0D,
+                0.0D
+        );
+
+        Rotation next = smoother.next(new Rotation(0.0F, 0.0F), new Rotation(120.0F, 45.0F), disabled);
+
+        assertEquals(120.0F, next.getYaw(), 0.0001F);
+        assertEquals(45.0F, next.getPitch(), 0.0001F);
+    }
+}

--- a/src/test/java/baritone/behavior/look/VisualRotationHelperTest.java
+++ b/src/test/java/baritone/behavior/look/VisualRotationHelperTest.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior.look;
+
+import baritone.api.utils.Rotation;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VisualRotationHelperTest {
+
+    @Test
+    public void interpolatesYawAcrossBoundaryByShortestPath() {
+        Rotation interpolated = VisualRotationHelper.interpolate(
+                new Rotation(170.0F, 0.0F),
+                new Rotation(-170.0F, 0.0F),
+                0.5F
+        );
+
+        assertEquals(180.0F, Math.abs(interpolated.getYaw()), 0.0001F);
+    }
+
+    @Test
+    public void interpolationIsContinuous() {
+        Rotation from = new Rotation(10.0F, -10.0F);
+        Rotation to = new Rotation(50.0F, 30.0F);
+
+        Rotation start = VisualRotationHelper.interpolate(from, to, 0.0F);
+        Rotation middle = VisualRotationHelper.interpolate(from, to, 0.5F);
+        Rotation end = VisualRotationHelper.interpolate(from, to, 1.0F);
+
+        assertEquals(10.0F, start.getYaw(), 0.0001F);
+        assertEquals(30.0F, middle.getYaw(), 0.0001F);
+        assertEquals(50.0F, end.getYaw(), 0.0001F);
+        assertEquals(10.0F, middle.getPitch(), 0.0001F);
+    }
+
+    @Test
+    public void movementPostureKeepsHeadingYawAndReplacesPitch() {
+        Rotation posture = VisualRotationHelper.movementPosture(new Rotation(42.0F, -70.0F), 10.0D);
+
+        assertEquals(42.0F, posture.getYaw(), 0.0001F);
+        assertEquals(10.0F, posture.getPitch(), 0.0001F);
+    }
+
+    @Test
+    public void movementPostureClampsPitch() {
+        Rotation posture = VisualRotationHelper.movementPosture(new Rotation(42.0F, 0.0F), 120.0D);
+
+        assertEquals(90.0F, posture.getPitch(), 0.0001F);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a configurable humanized look rotation system directly on Baritone.

Instead of snapping instantly to every target rotation, Baritone can now smooth camera movement in a more natural way while preserving the logical rotations needed for pathing, mining, placing, farming, and elytra movement.

## What Changed

- Added new `humanizeLook` settings to control look speed, acceleration, jitter, overshoot, elytra speed, and movement posture.
- Extracted the old aim processing logic into a dedicated `AimProcessor`.
- Added `HumanizedRotationSmoother` for stateful, testable rotation smoothing.
- Added `VisualRotationHelper` for visual-only camera interpolation and movement posture.
- Refactored `LookBehavior` to track:
  - effective/server rotations used for Baritone logic
  - visible camera rotations shown to the player
- Updated reachability probing to use `peekRotationForReachability`, so blocks are not considered unreachable just because the humanized rotation has not arrived yet.
- Added unit tests for the smoother and visual rotation helper.

## Important Behavior

Block interactions use humanized effective rotations, so mining and placing wait until Baritone is actually aimed correctly.

Movement/pathfinder rotations intentionally remain immediate and unhumanized. This is important because delaying movement yaw can make pathing unstable or cause circular movement. For normal movement, only the visible camera is smoothed toward the path heading.

This keeps path execution reliable while making Baritone-controlled look behavior feel much less robotic.