### PR TITLE
Add support for nether vines v2

### DIFF
--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -522,7 +522,7 @@ public interface MovementHelper extends ActionCosts, Helper {
      */
     static boolean mustBeSolidToWalkOn(CalculationContext context, int x, int y, int z, BlockState state) {
         Block block = state.getBlock();
-        if (block == Blocks.LADDER || block == Blocks.VINE) {
+        if (isClimbable(block)) {
             return false;
         }
         if (!state.getFluidState().isEmpty()) {
@@ -583,6 +583,8 @@ public interface MovementHelper extends ActionCosts, Helper {
 
     /**
      * Can we climb up this block by pressing space while inside it?
+     * Also doubles as "If I start a movement on this, can weird things happen?"
+     * because movements can end/start on these blocks despite them not being canWalkOn.
      */
     static boolean isClimbable(Block block) {
         return block == Blocks.LADDER

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -581,6 +581,18 @@ public interface MovementHelper extends ActionCosts, Helper {
         return isBlockNormalCube(state) || state.getBlock() == Blocks.GLASS || state.getBlock() instanceof StainedGlassBlock;
     }
 
+    /**
+     * Can we climb up this block by pressing space while inside it?
+     */
+    static boolean isClimbable(Block block) {
+        return block == Blocks.LADDER
+            || block == Blocks.VINE
+            || block == Blocks.WEEPING_VINES
+            || block == Blocks.WEEPING_VINES_PLANT
+            || block == Blocks.TWISTING_VINES
+            || block == Blocks.TWISTING_VINES_PLANT;
+    }
+
     static double getMiningDurationTicks(CalculationContext context, int x, int y, int z, boolean includeFalling) {
         return getMiningDurationTicks(context, x, y, z, context.get(x, y, z), includeFalling);
     }

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -330,11 +330,6 @@ public interface MovementHelper extends ActionCosts, Helper {
         return state.getMaterial().isReplaceable();
     }
 
-    @Deprecated
-    static boolean isReplacable(int x, int y, int z, BlockState state, BlockStateInterface bsi) {
-        return isReplaceable(x, y, z, state, bsi);
-    }
-
     static boolean isDoorPassable(IPlayerContext ctx, BlockPos doorPos, BlockPos playerPos) {
         if (playerPos.equals(doorPos)) {
             return false;

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -421,7 +421,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         if (block instanceof AzaleaBlock) {
             return YES;
         }
-        if (block == Blocks.LADDER || (block == Blocks.VINE && Baritone.settings().allowVines.value)) { // TODO reconsider this
+        if (block == Blocks.LADDER || (isClimbable(block) && Baritone.settings().allowVines.value)) { // TODO reconsider this
             return YES;
         }
         if (block == Blocks.FARMLAND || block == Blocks.DIRT_PATH) {

--- a/src/main/java/baritone/pathing/movement/movements/MovementAscend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementAscend.java
@@ -112,7 +112,7 @@ public class MovementAscend extends Movement {
             // and in that scenario, when we arrive and break srcUp2, that lets srcUp3 fall on us and suffocate us
         }
         BlockState srcDown = context.get(x, y - 1, z);
-        if (srcDown.getBlock() == Blocks.LADDER || srcDown.getBlock() == Blocks.VINE) {
+        if (MovementHelper.isClimbable(srcDown.getBlock())) {
             return COST_INF;
         }
         // we can jump from soul sand, but not from a bottom slab

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -185,7 +185,7 @@ public class MovementDescend extends Movement {
                 res.cost = tentativeCost;
                 return false;
             }
-            if (unprotectedFallHeight <= 11 && (ontoBlock.getBlock() == Blocks.VINE || ontoBlock.getBlock() == Blocks.LADDER)) {
+            if (unprotectedFallHeight <= 11 && MovementHelper.isClimbable(ontoBlock.getBlock())) {
                 // if fall height is greater than or equal to 11, we don't actually grab on to vines or ladders. the more you know
                 // this effectively "resets" our falling speed
                 costSoFar += FALL_N_BLOCKS_COST[unprotectedFallHeight - 1];// we fall until the top of this block (not including this block)

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -93,7 +93,7 @@ public class MovementDescend extends Movement {
         }
 
         Block fromDown = context.get(x, y - 1, z).getBlock();
-        if (fromDown == Blocks.LADDER || fromDown == Blocks.VINE) {
+        if (MovementHelper.isClimbable(fromDown)) {
             return;
         }
 

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -148,7 +148,7 @@ public class MovementDiagonal extends Movement {
             multiplier += context.walkOnWaterOnePenalty * SQRT_2;
         }
         Block fromDownBlock = fromDown.getBlock();
-        if (fromDownBlock == Blocks.LADDER || fromDownBlock == Blocks.VINE) {
+        if (MovementHelper.isClimbable(fromDownBlock)) {
             return;
         }
         if (fromDownBlock == Blocks.SOUL_SAND) {
@@ -228,7 +228,7 @@ public class MovementDiagonal extends Movement {
         }
         if (optionA != 0 || optionB != 0) {
             multiplier *= SQRT_2 - 0.001; // TODO tune
-            if (startIn == Blocks.LADDER || startIn == Blocks.VINE) {
+            if (MovementHelper.isClimbable(startIn)) {
                 // edging around doesn't work if doing so would climb a ladder or vine instead of moving sideways
                 return;
             }

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -92,7 +92,7 @@ public class MovementParkour extends Movement {
             return;
         }
         BlockState standingOn = context.get(x, y - 1, z);
-        if (standingOn.getBlock() == Blocks.VINE || standingOn.getBlock() == Blocks.LADDER || standingOn.getBlock() instanceof StairBlock || MovementHelper.isBottomSlab(standingOn)) {
+        if (MovementHelper.isClimbable(standingOn.getBlock()) || standingOn.getBlock() instanceof StairBlock || MovementHelper.isBottomSlab(standingOn)) {
             return;
         }
         // we can't jump from (frozen) water with assumeWalkOnWater because we can't be sure it will be frozen

--- a/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
@@ -65,7 +65,7 @@ public class MovementPillar extends Movement {
     public static double cost(CalculationContext context, int x, int y, int z) {
         BlockState fromState = context.get(x, y, z);
         Block from = fromState.getBlock();
-        boolean ladder = from == Blocks.LADDER || from == Blocks.VINE;
+        boolean ladder = from == Blocks.LADDER || from == Blocks.VINE || from == Blocks.WEEPING_VINES || from == Blocks.TWISTING_VINES || from == Blocks.WEEPING_VINES_PLANT || from == Blocks.TWISTING_VINES_PLANT;
         BlockState fromDown = context.get(x, y - 1, z);
         if (!ladder) {
             if (fromDown.getBlock() == Blocks.LADDER || fromDown.getBlock() == Blocks.VINE) {
@@ -116,7 +116,7 @@ public class MovementPillar extends Movement {
             return COST_INF;
         }
         if (hardness != 0) {
-            if (toBreakBlock == Blocks.LADDER || toBreakBlock == Blocks.VINE) {
+            if (toBreakBlock == Blocks.LADDER || toBreakBlock == Blocks.VINE || toBreakBlock == Blocks.WEEPING_VINES || toBreakBlock == Blocks.TWISTING_VINES) {
                 hardness = 0; // we won't actually need to break the ladder / vine because we're going to use it
             } else {
                 BlockState check = context.get(x, y + 3, z); // the block on top of the one we're going to break, could it fall on us?
@@ -194,10 +194,12 @@ public class MovementPillar extends Movement {
         }
         boolean ladder = fromDown.getBlock() == Blocks.LADDER || fromDown.getBlock() == Blocks.VINE;
         boolean vine = fromDown.getBlock() == Blocks.VINE;
+        boolean nether_vine = fromDown.getBlock() == Blocks.WEEPING_VINES || fromDown.getBlock() == Blocks.TWISTING_VINES || fromDown.getBlock() == Blocks.WEEPING_VINES_PLANT || fromDown.getBlock() == Blocks.TWISTING_VINES_PLANT;
+
         Rotation rotation = RotationUtils.calcRotationFromVec3d(ctx.playerHead(),
                 VecUtils.getBlockPosCenter(positionToPlace),
                 ctx.playerRotations());
-        if (!ladder) {
+        if (!(ladder || nether_vine)) {
             state.setTarget(new MovementState.MovementTarget(ctx.playerRotations().withPitch(rotation.getPitch()), true));
         }
 
@@ -222,6 +224,13 @@ public class MovementPillar extends Movement {
              */
 
             MovementHelper.moveTowards(ctx, state, against);
+            return state;
+        } else if (nether_vine) {
+            if (ctx.playerFeet().equals(dest)) {
+                return state.setStatus(MovementStatus.SUCCESS);
+            }
+            MovementHelper.moveTowards(ctx, state, dest);
+            state.setInput(Input.JUMP, true);
             return state;
         } else {
             // Get ready to place a throwaway block

--- a/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
@@ -142,22 +142,6 @@ public class MovementPillar extends Movement {
         }
     }
 
-    public static BlockPos getAgainst(CalculationContext context, BetterBlockPos vine) {
-        if (MovementHelper.isBlockNormalCube(context.get(vine.north()))) {
-            return vine.north();
-        }
-        if (MovementHelper.isBlockNormalCube(context.get(vine.south()))) {
-            return vine.south();
-        }
-        if (MovementHelper.isBlockNormalCube(context.get(vine.east()))) {
-            return vine.east();
-        }
-        if (MovementHelper.isBlockNormalCube(context.get(vine.west()))) {
-            return vine.west();
-        }
-        return null;
-    }
-
     @Override
     public MovementState updateState(MovementState state) {
         super.updateState(state);

--- a/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
@@ -258,7 +258,7 @@ public class MovementPillar extends Movement {
     protected boolean prepared(MovementState state) {
         if (ctx.playerFeet().equals(src) || ctx.playerFeet().equals(src.below())) {
             Block block = BlockStateInterface.getBlock(ctx, src.below());
-            if (block == Blocks.LADDER || block == Blocks.VINE) {
+            if (MovementHelper.isClimbable(block)) {
                 state.setInput(Input.SNEAK, true);
             }
         }

--- a/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
@@ -65,10 +65,10 @@ public class MovementPillar extends Movement {
     public static double cost(CalculationContext context, int x, int y, int z) {
         BlockState fromState = context.get(x, y, z);
         Block from = fromState.getBlock();
-        boolean ladder = from == Blocks.LADDER || from == Blocks.VINE || from == Blocks.WEEPING_VINES || from == Blocks.TWISTING_VINES || from == Blocks.WEEPING_VINES_PLANT || from == Blocks.TWISTING_VINES_PLANT;
+        boolean ladder = MovementHelper.isClimbable(from);
         BlockState fromDown = context.get(x, y - 1, z);
         if (!ladder) {
-            if (fromDown.getBlock() == Blocks.LADDER || fromDown.getBlock() == Blocks.VINE) {
+            if (MovementHelper.isClimbable(fromDown.getBlock())) {
                 return COST_INF; // can't pillar from a ladder or vine onto something that isn't also climbable
             }
             if (fromDown.getBlock() instanceof SlabBlock && fromDown.getValue(SlabBlock.TYPE) == SlabType.BOTTOM) {
@@ -113,7 +113,7 @@ public class MovementPillar extends Movement {
             return COST_INF;
         }
         if (hardness != 0) {
-            if (toBreakBlock == Blocks.LADDER || toBreakBlock == Blocks.VINE || toBreakBlock == Blocks.WEEPING_VINES || toBreakBlock == Blocks.TWISTING_VINES) {
+            if (MovementHelper.isClimbable(toBreakBlock)) {
                 hardness = 0; // we won't actually need to break the ladder / vine because we're going to use it
             } else {
                 BlockState check = context.get(x, y + 3, z); // the block on top of the one we're going to break, could it fall on us?
@@ -182,18 +182,17 @@ public class MovementPillar extends Movement {
             }
             return state;
         }
-        boolean ladder = fromDown.getBlock() == Blocks.LADDER || fromDown.getBlock() == Blocks.VINE;
-        boolean nether_vine = fromDown.getBlock() == Blocks.WEEPING_VINES || fromDown.getBlock() == Blocks.TWISTING_VINES || fromDown.getBlock() == Blocks.WEEPING_VINES_PLANT || fromDown.getBlock() == Blocks.TWISTING_VINES_PLANT;
+        boolean ladder = MovementHelper.isClimbable(fromDown.getBlock());
 
         Rotation rotation = RotationUtils.calcRotationFromVec3d(ctx.playerHead(),
                 VecUtils.getBlockPosCenter(positionToPlace),
                 ctx.playerRotations());
-        if (!(ladder || nether_vine)) {
+        if (!ladder) {
             state.setTarget(new MovementState.MovementTarget(ctx.playerRotations().withPitch(rotation.getPitch()), true));
         }
 
         boolean blockIsThere = MovementHelper.canWalkOn(ctx, src) || ladder;
-        if (ladder || nether_vine) {
+        if (ladder) {
             if (ctx.playerFeet().equals(dest)) {
                 return state.setStatus(MovementStatus.SUCCESS);
             }

--- a/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementPillar.java
@@ -75,9 +75,6 @@ public class MovementPillar extends Movement {
                 return COST_INF; // can't pillar up from a bottom slab onto a non ladder
             }
         }
-        if (from == Blocks.VINE && !hasAgainst(context, x, y, z)) { // TODO this vine can't be climbed, but we could place a pillar still since vines are replacable, no? perhaps the pillar jump would be impossible because of the slowdown actually.
-            return COST_INF;
-        }
         BlockState toBreak = context.get(x, y + 2, z);
         Block toBreakBlock = toBreak.getBlock();
         if (toBreakBlock instanceof FenceGateBlock) { // see issue #172
@@ -145,13 +142,6 @@ public class MovementPillar extends Movement {
         }
     }
 
-    public static boolean hasAgainst(CalculationContext context, int x, int y, int z) {
-        return MovementHelper.isBlockNormalCube(context.get(x + 1, y, z)) ||
-                MovementHelper.isBlockNormalCube(context.get(x - 1, y, z)) ||
-                MovementHelper.isBlockNormalCube(context.get(x, y, z + 1)) ||
-                MovementHelper.isBlockNormalCube(context.get(x, y, z - 1));
-    }
-
     public static BlockPos getAgainst(CalculationContext context, BetterBlockPos vine) {
         if (MovementHelper.isBlockNormalCube(context.get(vine.north()))) {
             return vine.north();
@@ -193,7 +183,6 @@ public class MovementPillar extends Movement {
             return state;
         }
         boolean ladder = fromDown.getBlock() == Blocks.LADDER || fromDown.getBlock() == Blocks.VINE;
-        boolean vine = fromDown.getBlock() == Blocks.VINE;
         boolean nether_vine = fromDown.getBlock() == Blocks.WEEPING_VINES || fromDown.getBlock() == Blocks.TWISTING_VINES || fromDown.getBlock() == Blocks.WEEPING_VINES_PLANT || fromDown.getBlock() == Blocks.TWISTING_VINES_PLANT;
 
         Rotation rotation = RotationUtils.calcRotationFromVec3d(ctx.playerHead(),
@@ -204,31 +193,11 @@ public class MovementPillar extends Movement {
         }
 
         boolean blockIsThere = MovementHelper.canWalkOn(ctx, src) || ladder;
-        if (ladder) {
-            BlockPos against = vine ? getAgainst(new CalculationContext(baritone), src) : src.relative(fromDown.getValue(LadderBlock.FACING).getOpposite());
-            if (against == null) {
-                logDirect("Unable to climb vines. Consider disabling allowVines.");
-                return state.setStatus(MovementStatus.UNREACHABLE);
-            }
-
-            if (ctx.playerFeet().equals(against.above()) || ctx.playerFeet().equals(dest)) {
-                return state.setStatus(MovementStatus.SUCCESS);
-            }
-            if (MovementHelper.isBottomSlab(BlockStateInterface.get(ctx, src.below()))) {
-                state.setInput(Input.JUMP, true);
-            }
-            /*
-            if (thePlayer.getPosition0().getX() != from.getX() || thePlayer.getPosition0().getZ() != from.getZ()) {
-                Baritone.moveTowardsBlock(from);
-            }
-             */
-
-            MovementHelper.moveTowards(ctx, state, against);
-            return state;
-        } else if (nether_vine) {
+        if (ladder || nether_vine) {
             if (ctx.playerFeet().equals(dest)) {
                 return state.setStatus(MovementStatus.SUCCESS);
             }
+
             MovementHelper.moveTowards(ctx, state, dest);
             state.setInput(Input.JUMP, true);
             return state;

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -114,13 +114,13 @@ public class MovementTraverse extends Movement {
                 }
                 return WC;
             }
-            if (srcDownBlock == Blocks.LADDER || srcDownBlock == Blocks.VINE) {
+            if (srcDownBlock == Blocks.LADDER || srcDownBlock == Blocks.VINE || srcDownBlock == Blocks.WEEPING_VINES || srcDownBlock == Blocks.TWISTING_VINES || srcDownBlock == Blocks.WEEPING_VINES_PLANT || srcDownBlock == Blocks.TWISTING_VINES_PLANT) {
                 hardness1 *= 5;
                 hardness2 *= 5;
             }
             return WC + hardness1 + hardness2;
         } else {//this is a bridge, so we need to place a block
-            if (srcDownBlock == Blocks.LADDER || srcDownBlock == Blocks.VINE) {
+            if (srcDownBlock == Blocks.LADDER || srcDownBlock == Blocks.VINE || srcDownBlock == Blocks.WEEPING_VINES || srcDownBlock == Blocks.TWISTING_VINES || srcDownBlock == Blocks.WEEPING_VINES_PLANT || srcDownBlock == Blocks.TWISTING_VINES_PLANT) {
                 return COST_INF;
             }
             if (MovementHelper.isReplaceable(destX, y - 1, destZ, destOn, context.bsi)) {
@@ -217,7 +217,7 @@ public class MovementTraverse extends Movement {
         state.setInput(Input.SNEAK, false);
 
         Block fd = BlockStateInterface.get(ctx, src.below()).getBlock();
-        boolean ladder = fd == Blocks.LADDER || fd == Blocks.VINE;
+        boolean ladder = fd == Blocks.LADDER || fd == Blocks.VINE || fd == Blocks.WEEPING_VINES || fd == Blocks.TWISTING_VINES || fd == Blocks.WEEPING_VINES_PLANT || fd == Blocks.TWISTING_VINES_PLANT;
 
         if (pb0.getBlock() instanceof DoorBlock || pb1.getBlock() instanceof DoorBlock) {
             boolean notPassable = pb0.getBlock() instanceof DoorBlock && !MovementHelper.isDoorPassable(ctx, src, dest) || pb1.getBlock() instanceof DoorBlock && !MovementHelper.isDoorPassable(ctx, dest, src);
@@ -370,7 +370,7 @@ public class MovementTraverse extends Movement {
     protected boolean prepared(MovementState state) {
         if (ctx.playerFeet().equals(src) || ctx.playerFeet().equals(src.below())) {
             Block block = BlockStateInterface.getBlock(ctx, src.below());
-            if (block == Blocks.LADDER || block == Blocks.VINE) {
+            if (block == Blocks.LADDER || block == Blocks.VINE || block == Blocks.WEEPING_VINES || block == Blocks.TWISTING_VINES || block == Blocks.WEEPING_VINES_PLANT || block == Blocks.TWISTING_VINES_PLANT) {
                 state.setInput(Input.SNEAK, true);
             }
         }

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -114,13 +114,13 @@ public class MovementTraverse extends Movement {
                 }
                 return WC;
             }
-            if (srcDownBlock == Blocks.LADDER || srcDownBlock == Blocks.VINE || srcDownBlock == Blocks.WEEPING_VINES || srcDownBlock == Blocks.TWISTING_VINES || srcDownBlock == Blocks.WEEPING_VINES_PLANT || srcDownBlock == Blocks.TWISTING_VINES_PLANT) {
+            if (MovementHelper.isClimbable(srcDownBlock)) {
                 hardness1 *= 5;
                 hardness2 *= 5;
             }
             return WC + hardness1 + hardness2;
         } else {//this is a bridge, so we need to place a block
-            if (srcDownBlock == Blocks.LADDER || srcDownBlock == Blocks.VINE || srcDownBlock == Blocks.WEEPING_VINES || srcDownBlock == Blocks.TWISTING_VINES || srcDownBlock == Blocks.WEEPING_VINES_PLANT || srcDownBlock == Blocks.TWISTING_VINES_PLANT) {
+            if (MovementHelper.isClimbable(srcDownBlock)) {
                 return COST_INF;
             }
             if (MovementHelper.isReplaceable(destX, y - 1, destZ, destOn, context.bsi)) {
@@ -217,7 +217,7 @@ public class MovementTraverse extends Movement {
         state.setInput(Input.SNEAK, false);
 
         Block fd = BlockStateInterface.get(ctx, src.below()).getBlock();
-        boolean ladder = fd == Blocks.LADDER || fd == Blocks.VINE || fd == Blocks.WEEPING_VINES || fd == Blocks.TWISTING_VINES || fd == Blocks.WEEPING_VINES_PLANT || fd == Blocks.TWISTING_VINES_PLANT;
+        boolean ladder = MovementHelper.isClimbable(fd);
 
         if (pb0.getBlock() instanceof DoorBlock || pb1.getBlock() instanceof DoorBlock) {
             boolean notPassable = pb0.getBlock() instanceof DoorBlock && !MovementHelper.isDoorPassable(ctx, src, dest) || pb1.getBlock() instanceof DoorBlock && !MovementHelper.isDoorPassable(ctx, dest, src);
@@ -370,7 +370,7 @@ public class MovementTraverse extends Movement {
     protected boolean prepared(MovementState state) {
         if (ctx.playerFeet().equals(src) || ctx.playerFeet().equals(src.below())) {
             Block block = BlockStateInterface.getBlock(ctx, src.below());
-            if (block == Blocks.LADDER || block == Blocks.VINE || block == Blocks.WEEPING_VINES || block == Blocks.TWISTING_VINES || block == Blocks.WEEPING_VINES_PLANT || block == Blocks.TWISTING_VINES_PLANT) {
+            if (MovementHelper.isClimbable(block)) {
                 state.setInput(Input.SNEAK, true);
             }
         }

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -274,15 +274,10 @@ public class MovementTraverse extends Movement {
             }
 
             BlockState destDown = BlockStateInterface.get(ctx, dest.below());
-            BlockPos against = positionsToBreak[0];
-            if (feet.getY() != dest.getY() && ladder && (destDown.getBlock() == Blocks.VINE || destDown.getBlock() == Blocks.LADDER)) {
-                against = destDown.getBlock() == Blocks.VINE ? MovementPillar.getAgainst(new CalculationContext(baritone), dest.below()) : dest.relative(destDown.getValue(LadderBlock.FACING).getOpposite());
-                if (against == null) {
-                    logDirect("Unable to climb vines. Consider disabling allowVines.");
-                    return state.setStatus(MovementStatus.UNREACHABLE);
-                }
+            if (feet.getY() != dest.getY() && ladder && MovementHelper.isClimbable(destDown.getBlock())) {
+                state.setInput(Input.JUMP, true);
             }
-            MovementHelper.moveTowards(ctx, state, against);
+            MovementHelper.moveTowards(ctx, state, positionsToBreak[0]);
             return state;
         } else {
             wasTheBridgeBlockAlwaysThere = false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -261,7 +261,7 @@ public class MovementTraverse extends Movement {
             }
             Block low = BlockStateInterface.get(ctx, src).getBlock();
             Block high = BlockStateInterface.get(ctx, src.above()).getBlock();
-            if (ctx.player().position().y > src.y + 0.1D && !ctx.player().isOnGround() && (low == Blocks.VINE || low == Blocks.LADDER || high == Blocks.VINE || high == Blocks.LADDER)) {
+            if (ctx.player().position().y > src.y + 0.1D && !ctx.player().isOnGround() && (MovementHelper.isClimbable(low) || MovementHelper.isClimbable(high))) {
                 // hitting W could cause us to climb the ladder instead of going forward
                 // wait until we're on the ground
                 return state;


### PR DESCRIPTION
Directly based on https://github.com/cabaletta/baritone/pull/4111. This is a crazy long lived branch, but somehow still merges cleanly.

* Most movements explicitly refuse to start on normal vines or ladders. Now they also refuse to start on nether vines.
* `MovementFall` now knows that nether vines reset fall damage, so Baritone can climb down on them
* `MovementPillar` and `MovementTraverse` now press the jump button instead of walking into an adjacent block
  * Traversing on vines/ladders is much less janky
  * Climbing up unsupported vines is possible
  * It can climb up mixed vines/ladders without getting stuck against the bottom face of a ladder
* `allowVines` now applies to nether vines as well, including the unreliability

Would really like if someone else could also try breaking this. I don't trust myself to find the edge case regressions I missed.

<!-- No UwU's or OwO's allowed -->
