### PR TITLE
fix: use game registries for modded loot table resolution in BlockOptionalMeta

### DIFF
--- a/src/api/java/baritone/api/utils/BlockOptionalMeta.java
+++ b/src/api/java/baritone/api/utils/BlockOptionalMeta.java
@@ -244,7 +244,7 @@ public final class BlockOptionalMeta {
                         .withParameter(LootContextParams.BLOCK_STATE, b.defaultBlockState())
                         .withParameter(LootContextParams.TOOL, new ItemStack(Items.NETHERITE_PICKAXE, 1));
                     getDrops(block, lv5).stream().map(ItemStack::getItem).forEach(items::add);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     e.printStackTrace();
                 }
                 return items;
@@ -289,6 +289,9 @@ public final class BlockOptionalMeta {
 
         @Override
         public RegistryAccess registryAccess() {
+            if (client.level != null) {
+                return client.level.registryAccess();
+            }
             return registryAccess.join();
         }
 


### PR DESCRIPTION
 ## What does this PR do?                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                      
  When you run `#mine` on a modded block like `create:zinc_ore`, Baritone crashes because it can't find the block's loot table. The loot table exists — but Baritone was only loading vanilla resource packs when looking it up.                                      
                                                                                                                                                                                                                                                                      
  This fixes that by using the game's own registries (which already have all mod data loaded) instead of creating a separate vanilla-only registry.
                                                                                                                                                                                                                                                                      
  ## What was the problem?       
                                                                                                                                                                                                                                                                      
  Baritone tries to figure out what items a block drops by looking up its loot table. On NeoForge 1.21.1, it was doing this with a `ServerLevelStub` that only loaded the vanilla `Minecraft` resource pack. Mods like Create put their loot tables in their own packs
   (`data/create/loot_tables/...`), which were never loaded. So the lookup failed with an exception.                                                                                                                                                                  
                                                                                                    
  On 1.19.4 there was a Mixin (`MixinLootContext`) that patched around this issue. It was removed on 1.21.1, which exposed the real problem.                                                                                                                          
                                                                                                                                                                                                                                                                      
  ## What changed?            
                                                                                                                                                                                                                                                                      
  Two small changes in `src/api/java/baritone/api/utils/BlockOptionalMeta.java`:
                                                                                                                                                                                                                                                                      
  1. `registryAccess()` now uses `client.level.registryAccess()` (which has everything) instead of loading only vanilla packs. Falls back to vanilla if the game level isn't available.
                                                                                                                                                                                                                                                                      
  2. The catch block in `drops()` changed from `catch (Exception)` to `catch (Throwable)` as a safety net — if something else goes wrong with loot table resolution, Baritone degrades gracefully instead of crashing.
                                                                                                                                                                                                                                                                      
  ## Testing                     
                                                                                                                                                                                                                                                                      
  - `#mine create:zinc_ore` with Create installed: mines without crash, item pickup works
  - `#mine stone` in a modded environment: works                                                                                                                                                                                                                      
  - Vanilla `#mine diamond_ore`: no regression  
  - `./gradlew test`: all tests pass                                                                                                                                                                                                                                  
                                    
  Closes #5056      

<!-- No UwU's or OwO's allowed -->
