### PR TITLE
feat: support slash-prefixed Baritone commands (e.g. /#goto)

### DIFF
--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
@@ -95,6 +95,42 @@ public class MixinClientPlayNetHandler {
         }
     }
 
+    /**
+     * Intercepts commands (messages starting with '/') that match a Baritone prefix
+     * starting with '/'. For example, if prefix is "/#", typing "/#goto" will be
+     * intercepted here as "#goto" (the '/' is stripped by ChatScreen before this method).
+     *
+     * @see <a href="https://github.com/cabaletta/baritone/issues/5045">Issue #5045</a>
+     */
+    @Inject(
+            method = "sendCommand(Ljava/lang/String;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void sendCommandMessage(String command, CallbackInfo ci) {
+        if (!Baritone.settings().prefixControl.value) {
+            return;
+        }
+        String prefix = Baritone.settings().prefix.value;
+        if (!prefix.startsWith("/")) {
+            return;
+        }
+        // command arrives without '/' (ChatScreen strips it), compare against prefix without '/'
+        String prefixWithoutSlash = prefix.substring(1);
+        if (command.startsWith(prefixWithoutSlash)) {
+            // Reconstruct the full message with '/' so ExampleBaritoneControl handles it correctly
+            ChatEvent event = new ChatEvent("/" + command);
+            IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(this.minecraft.player);
+            if (baritone == null) {
+                return;
+            }
+            baritone.getGameEventHandler().onSendChatMessage(event);
+            if (event.isCancelled()) {
+                ci.cancel();
+            }
+        }
+    }
+
     @Inject(
             method = "handleLevelChunkWithLight",
             at = @At("RETURN")


### PR DESCRIPTION
## Summary
Adds support for Baritone command prefixes that start with `/` (e.g. `/#`). When the prefix is set to `/#`, typing `/#goto 100 64 100` in chat now correctly executes as a Baritone command instead of being sent to the server as an unknown vanilla command.
## Problem
When a user sets `prefix` to a string starting with `/` (like `/#`), Minecraft's `ChatScreen` intercepts the message, strips the leading `/`, and routes it to `sendCommand()` instead of `sendChat()`. Baritone's existing mixin only hooks into `sendChat()`, so slash-prefixed commands were never seen by Baritone.
This is useful for **privacy** — if Baritone is inactive, `/#goto` becomes an unknown server command (only visible to the user), whereas `#goto` would be broadcast as regular chat to all players.
## Solution
Added a new `@Inject` mixin in `MixinClientPlayNetHandler` targeting `ClientPacketListener.sendCommand(String)`:
- Checks if the configured prefix starts with `/`
- Compares the command (without `/`) against the prefix (without `/`)
- If matched, reconstructs the full message with `/` and dispatches a `ChatEvent`
- `ExampleBaritoneControl` handles it normally from there
## What's NOT affected
- Default prefix `#` — new mixin returns early (no `/` prefix)
- Vanilla commands (`/tp`, `/give`, etc.) — don't match the Baritone prefix
- `FORCE_COMMAND_PREFIX` — goes through `sendChat()`, untouched
- Tab completion — already worked via `MixinCommandSuggestionHelper`
## Testing
Video attached demonstrating:
1. Setting prefix to `/#` via `#set prefix /#`
2. Executing `/#goto` — Baritone intercepts correctly
3. Vanilla commands like `/tp` still work normally
Fixes #5045


https://github.com/user-attachments/assets/54cae05a-2e5a-4397-9b05-8f0c036725b9

