### PR TITLE
Only move pickaxe/throwaway to hotbar when active

### DIFF
--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -65,12 +65,14 @@ public final class InventoryBehavior extends Behavior implements Helper {
             return;
         }
         ticksSinceLastInventoryMove++;
-        if (firstValidThrowaway() >= 9) { // aka there are none on the hotbar, but there are some in main inventory
-            requestSwapWithHotBar(firstValidThrowaway(), 8);
-        }
-        int pick = bestToolAgainst(Blocks.STONE, PickaxeItem.class);
-        if (pick >= 9) {
-            requestSwapWithHotBar(pick, 0);
+        if (baritone.getPathingBehavior().isPathing()) {
+            if (firstValidThrowaway() >= 9) { // aka there are none on the hotbar, but there are some in main inventory
+                requestSwapWithHotBar(firstValidThrowaway(), 8);
+            }
+            int pick = bestToolAgainst(Blocks.STONE, PickaxeItem.class);
+            if (pick >= 9) {
+                requestSwapWithHotBar(pick, 0);
+            }
         }
         if (lastTickRequestedMove != null) {
             logDebug("Remembering to move " + lastTickRequestedMove[0] + " " + lastTickRequestedMove[1] + " from a previous tick");


### PR DESCRIPTION
Alternative to https://github.com/cabaletta/baritone/pull/5014

Processes do their own inventory management anyway so I've made the check stricter to only apply while searching or executing a path. This means merely setting a goal (and thereby activating `CustomGoalProcess`) will not move items around.
I've also changed the check to only prevent automatically requesting pickaxe and throwaways while idle instead of ignoring all requests.

cc @meqativ because this duplicates part of your pr

Closes https://github.com/cabaletta/baritone/pull/5014
Closes https://github.com/cabaletta/baritone/issues/3409
Closes https://github.com/cabaletta/baritone/issues/3000

Partially addresses https://github.com/cabaletta/baritone/issues/4020

<!-- No UwU's or OwO's allowed -->
