### PR TITLE
26.1.x

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -17,11 +17,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '21'
-        distribution: 'temurin'
+        java-version: '25'
+        distribution: 'zulu'
         cache: gradle
 
     - name: Grant execute permission for gradlew

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '21'
-        distribution: 'temurin'
+        java-version: '25'
+        distribution: 'zulu'
         
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -94,9 +94,7 @@ allprojects {
         version rootProject.minecraft_version
 
         mappings {
-            intermediary()
             mojmap()
-            parchment(rootProject.minecraft_version, "2025.12.20")
         }
     }
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -80,7 +80,7 @@ components.java {
 }
 
 task proguard(type: ProguardTask) {
-    proguardVersion "7.4.2"
+    proguardVersion "7.9.1"
     compType "fabric"
 }
 

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -24,8 +24,8 @@
       "mixins.baritone.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.22",
-    "minecraft": ["1.21.11"]
+    "fabricloader": ">=0.19.3",
+    "minecraft": ["26.1.*"]
   },
   "custom": {
     "modmenu": {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -97,7 +97,7 @@ components.java {
 }
 
 task proguard(type: ProguardTask) {
-    proguardVersion "7.4.2"
+    proguardVersion "7.9.1"
     compType "forge"
 }
 

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[48,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[62,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 license="https://raw.githubusercontent.com/cabaletta/baritone/1.16.2/LICENSE"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/cabaletta/baritone/issues" #optional
@@ -35,6 +35,6 @@ A Minecraft pathfinder bot.
 modId="minecraft"
 mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange="[1.21.11]"
+versionRange="[26.1, 26.1.2]"
 ordering="NONE"
 side="BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,19 +2,19 @@ org.gradle.jvmargs=-Xmx4G
 
 available_loaders=fabric,forge,neoforge,tweaker
 
-mod_version=1.17.0
+mod_version=1.18.0
 maven_group=baritone
 archives_base_name=baritone
 
-java_version=21
+java_version=25
 
-minecraft_version=1.21.11
+minecraft_version=26.1.2
 
-forge_version=61.1.5
+forge_version=64.0.11
 
-neoforge_version=42
+neoforge_version=78
 
-fabric_version=0.18.5
+fabric_version=0.19.3
 
 nether_pathfinder_version=1.6
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -105,7 +105,7 @@ components.java {
 }
 
 task proguard(type: ProguardTask) {
-    proguardVersion "7.4.2"
+    proguardVersion "7.9.1"
     compType "neoforge"
 }
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -35,7 +35,7 @@ A Minecraft pathfinder bot.
 modId="minecraft"
 type="required"
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange="[1.21.11]"
+versionRange="[26.1, 26.1.2]"
 ordering="NONE"
 side="BOTH"
 

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -22,8 +22,8 @@ import baritone.api.utils.NotificationHelper;
 import baritone.api.utils.SettingsUtil;
 import baritone.api.utils.TypeUtils;
 import baritone.api.utils.gui.BaritoneToast;
-import net.minecraft.client.GuiMessageTag;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.chat.GuiMessageTag;
 import net.minecraft.core.Vec3i;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
@@ -1281,7 +1281,7 @@ public final class Settings {
     public final Setting<Consumer<Component>> logger = new Setting<>((msg) -> {
         try {
             final GuiMessageTag tag = useMessageTag.value ? Helper.MESSAGE_TAG : null;
-            Minecraft.getInstance().gui.getChat().addMessage(msg, null, tag);
+            Minecraft.getInstance().gui.getChat().addPlayerMessage(msg, null, tag);
         } catch (Throwable t) {
             LOGGER.warn("Failed to log message to chat: " + msg.getString(), t);
         }

--- a/src/api/java/baritone/api/utils/BlockOptionalMeta.java
+++ b/src/api/java/baritone/api/utils/BlockOptionalMeta.java
@@ -38,7 +38,6 @@ import net.minecraft.server.packs.repository.ServerPacksSource;
 import net.minecraft.server.packs.resources.CloseableResourceManager;
 import net.minecraft.server.packs.resources.MultiPackResourceManager;
 import net.minecraft.tags.TagLoader;
-import net.minecraft.world.RandomSequences;
 import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -262,8 +261,8 @@ public final class BlockOptionalMeta {
         private static Unsafe unsafe = getUnsafe();
         private static CompletableFuture<RegistryAccess> registryAccess = load();
 
-        public ServerLevelStub(MinecraftServer $$0, Executor $$1, LevelStorageSource.LevelStorageAccess $$2, ServerLevelData $$3, ResourceKey<Level> $$4, LevelStem $$5, boolean $$6, long $$7, List<CustomSpawner> $$8, boolean $$9, @Nullable RandomSequences $$10) {
-            super($$0, $$1, $$2, $$3, $$4, $$5, $$6, $$7, $$8, $$9, $$10);
+        public ServerLevelStub(MinecraftServer $$0, Executor $$1, LevelStorageSource.LevelStorageAccess $$2, ServerLevelData $$3, ResourceKey<Level> $$4, LevelStem $$5, boolean $$6, long $$7, List<CustomSpawner> $$8, boolean $$9) {
+            super($$0, $$1, $$2, $$3, $$4, $$5, $$6, $$7, $$8, $$9);
         }
 
         @Override
@@ -321,8 +320,9 @@ public final class BlockOptionalMeta {
                 RegistryDataLoader.load(
                     closeableResourceManager,
                     worldGenRegistryLookupList,
-                    RegistryDataLoader.WORLDGEN_REGISTRIES
-                )
+                    RegistryDataLoader.WORLDGEN_REGISTRIES,
+                    ForkJoinPool.commonPool()
+                ).join()
             );
             return ReloadableServerRegistries.reload(
                 layeredRegistryAccess,

--- a/src/api/java/baritone/api/utils/Helper.java
+++ b/src/api/java/baritone/api/utils/Helper.java
@@ -20,8 +20,8 @@ package baritone.api.utils;
 import baritone.api.BaritoneAPI;
 import baritone.api.Settings;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.GuiMessageTag;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.chat.GuiMessageTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 

--- a/src/api/java/baritone/api/utils/IPlayerController.java
+++ b/src/api/java/baritone/api/utils/IPlayerController.java
@@ -24,7 +24,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
@@ -43,7 +43,7 @@ public interface IPlayerController {
 
     void resetBlockRemoving();
 
-    void windowClick(int windowId, int slotId, int mouseButton, ClickType type, Player player);
+    void windowClick(int windowId, int slotId, int mouseButton, ContainerInput type, Player player);
 
     GameType getGameType();
 

--- a/src/launch/java/baritone/launch/mixins/MixinChunkArray.java
+++ b/src/launch/java/baritone/launch/mixins/MixinChunkArray.java
@@ -84,8 +84,8 @@ public abstract class MixinChunkArray implements IChunkArray {
             LevelChunk chunk = copyingFrom.get(k);
             if (chunk != null) {
                 ChunkPos chunkpos = chunk.getPos();
-                if (inRange(chunkpos.x, chunkpos.z)) {
-                    int index = getIndex(chunkpos.x, chunkpos.z);
+                if (inRange(chunkpos.x(), chunkpos.z())) {
+                    int index = getIndex(chunkpos.x(), chunkpos.z());
                     if (chunks.get(index) != null) {
                         throw new IllegalStateException("Doing this would mutate the client's REAL loaded chunks?!");
                     }

--- a/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
+++ b/src/launch/java/baritone/launch/mixins/MixinClientPlayNetHandler.java
@@ -125,7 +125,7 @@ public abstract class MixinClientPlayNetHandler extends ClientCommonPacketListen
             LocalPlayer player = ibaritone.getPlayerContext().player();
             if (player != null && player.connection == (ClientPacketListener) (Object) this) {
                 ibaritone.getGameEventHandler().onChunkEvent(
-                        new ChunkEvent(EventState.PRE, ChunkEvent.Type.UNLOAD, packet.pos().x, packet.pos().z)
+                        new ChunkEvent(EventState.PRE, ChunkEvent.Type.UNLOAD, packet.pos().x(), packet.pos().z())
                 );
             }
         }
@@ -140,7 +140,7 @@ public abstract class MixinClientPlayNetHandler extends ClientCommonPacketListen
             LocalPlayer player = ibaritone.getPlayerContext().player();
             if (player != null && player.connection == (ClientPacketListener) (Object) this) {
                 ibaritone.getGameEventHandler().onChunkEvent(
-                        new ChunkEvent(EventState.POST, ChunkEvent.Type.UNLOAD, packet.pos().x, packet.pos().z)
+                        new ChunkEvent(EventState.POST, ChunkEvent.Type.UNLOAD, packet.pos().x(), packet.pos().z())
                 );
             }
         }
@@ -190,7 +190,7 @@ public abstract class MixinClientPlayNetHandler extends ClientCommonPacketListen
             return;
         }
         baritone.getGameEventHandler().onBlockChange(new BlockChangeEvent(
-                new ChunkPos(changes.get(0).first()),
+                ChunkPos.containing(changes.get(0).first()),
                 changes
         ));
     }

--- a/src/launch/java/baritone/launch/mixins/MixinItemStack.java
+++ b/src/launch/java/baritone/launch/mixins/MixinItemStack.java
@@ -20,7 +20,6 @@ package baritone.launch.mixins;
 import baritone.api.utils.accessor.IItemStack;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -31,17 +30,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ItemStack.class)
 public abstract class MixinItemStack implements IItemStack {
 
-    @Shadow
-    @Final
-    private Item item;
-
     @Unique
     private int baritoneHash;
 
     @Shadow
     public abstract int getDamageValue();
 
+    @Shadow
+    public abstract Item getItem();
+
     private void recalculateHash() {
+        Item item = getItem();
         baritoneHash = item == null ? -1 : item.hashCode() + getDamageValue();
     }
 

--- a/src/launch/java/baritone/launch/mixins/MixinWorldRenderer.java
+++ b/src/launch/java/baritone/launch/mixins/MixinWorldRenderer.java
@@ -23,10 +23,11 @@ import baritone.api.event.events.RenderEvent;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.LevelRenderer;
-import org.joml.Matrix4f;
+import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import org.joml.Matrix4fc;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -44,11 +45,11 @@ public class MixinWorldRenderer {
             method = "renderLevel",
             at = @At("RETURN")
     )
-    private void onStartHand(final GraphicsResourceAllocator graphicsResourceAllocator, final DeltaTracker deltaTracker, final boolean bl, final Camera camera, final Matrix4f matrix4f, final Matrix4f matrix4f2, final Matrix4f matrix4f3, final GpuBufferSlice gpuBufferSlice, final Vector4f vector4f, final boolean bl2, final CallbackInfo ci) {
+    private void onStartHand(final GraphicsResourceAllocator allocator, final DeltaTracker deltaTracker, final boolean outline, final CameraRenderState camera, final Matrix4fc modelViewMatrix, final GpuBufferSlice fog, final Vector4f fogColor, final boolean sky, final ChunkSectionsToRender chunkSectionsToRender, final CallbackInfo ci) {
         for (IBaritone ibaritone : BaritoneAPI.getProvider().getAllBaritones()) {
             PoseStack poseStack = new PoseStack();
-            poseStack.mulPose(matrix4f);
-            ibaritone.getGameEventHandler().onRenderPass(new RenderEvent(deltaTracker.getGameTimeDeltaPartialTick(false), poseStack, matrix4f2));
+            poseStack.mulPose(modelViewMatrix);
+            ibaritone.getGameEventHandler().onRenderPass(new RenderEvent(deltaTracker.getGameTimeDeltaPartialTick(false), poseStack, camera.projectionMatrix));
         }
     }
 }

--- a/src/main/java/baritone/behavior/InventoryBehavior.java
+++ b/src/main/java/baritone/behavior/InventoryBehavior.java
@@ -27,7 +27,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -120,7 +120,7 @@ public final class InventoryBehavior extends Behavior implements Helper {
             logDebug("Inventory move requested but delaying until stationary");
             return false;
         }
-        ctx.playerController().windowClick(ctx.player().inventoryMenu.containerId, inInventory < 9 ? inInventory + 36 : inInventory, inHotbar, ClickType.SWAP, ctx.player());
+        ctx.playerController().windowClick(ctx.player().inventoryMenu.containerId, inInventory < 9 ? inInventory + 36 : inInventory, inHotbar, ContainerInput.SWAP, ctx.player());
         ticksSinceLastInventoryMove = 0;
         lastTickRequestedMove = null;
         return true;

--- a/src/main/java/baritone/cache/ChunkPacker.java
+++ b/src/main/java/baritone/cache/ChunkPacker.java
@@ -109,7 +109,7 @@ public final class ChunkPacker {
             }
         }
         // @formatter:on
-        return new CachedChunk(chunk.getPos().x, chunk.getPos().z, height, bitSet, blocks, specialBlocks, System.currentTimeMillis());
+        return new CachedChunk(chunk.getPos().x(), chunk.getPos().z(), height, bitSet, blocks, specialBlocks, System.currentTimeMillis());
     }
 
     private static PathingBlockType getPathingBlockType(BlockState state, LevelChunk chunk, int x, int y, int z) {
@@ -130,7 +130,7 @@ public final class ChunkPacker {
                 return PathingBlockType.AVOID;
             }
             if (x == 0 || x == 15 || z == 0 || z == 15) {
-                Vec3 flow = state.getFluidState().getFlow(chunk.getLevel(), new BlockPos(x + (chunk.getPos().x << 4), y, z + (chunk.getPos().z << 4)));
+                Vec3 flow = state.getFluidState().getFlow(chunk.getLevel(), new BlockPos(x + (chunk.getPos().x() << 4), y, z + (chunk.getPos().z() << 4)));
                 if (flow.x != 0.0 || flow.z != 0.0) {
                     return PathingBlockType.WATER;
                 }

--- a/src/main/java/baritone/cache/FasterWorldScanner.java
+++ b/src/main/java/baritone/cache/FasterWorldScanner.java
@@ -142,16 +142,16 @@ public enum FasterWorldScanner implements IWorldScanner {
     private Stream<BlockPos> scanChunkInternal(IPlayerContext ctx, BlockOptionalMetaLookup lookup, ChunkPos pos) {
         ChunkSource chunkProvider = ctx.world().getChunkSource();
         // if chunk is not loaded, return empty stream
-        if (!chunkProvider.hasChunk(pos.x, pos.z)) {
+        if (!chunkProvider.hasChunk(pos.x(), pos.z())) {
             return Stream.empty();
         }
 
-        long chunkX = (long) pos.x << 4;
-        long chunkZ = (long) pos.z << 4;
+        long chunkX = (long) pos.x() << 4;
+        long chunkZ = (long) pos.z() << 4;
 
         int playerSectionY = (ctx.playerFeet().y - ctx.world().getMinY()) >> 4;
 
-        return collectChunkSections(lookup, chunkProvider.getChunk(pos.x, pos.z, false), chunkX, chunkZ, playerSectionY).stream();
+        return collectChunkSections(lookup, chunkProvider.getChunk(pos.x(), pos.z(), false), chunkX, chunkZ, playerSectionY).stream();
     }
 
 

--- a/src/main/java/baritone/cache/WorldScanner.java
+++ b/src/main/java/baritone/cache/WorldScanner.java
@@ -96,7 +96,7 @@ public enum WorldScanner implements IWorldScanner {
         }
 
         ClientChunkCache chunkProvider = (ClientChunkCache) ctx.world().getChunkSource();
-        LevelChunk chunk = chunkProvider.getChunk(pos.x, pos.z, null, false);
+        LevelChunk chunk = chunkProvider.getChunk(pos.x(), pos.z(), null, false);
         int playerY = ctx.playerFeet().getY();
 
         if (chunk == null || chunk.isEmpty()) {
@@ -104,7 +104,7 @@ public enum WorldScanner implements IWorldScanner {
         }
 
         ArrayList<BlockPos> res = new ArrayList<>();
-        scanChunkInto(pos.x << 4, pos.z << 4, ctx.world().dimensionType().minY(), chunk, filter, res, max, yLevelThreshold, playerY, IntStream.range(0, ctx.world().dimensionType().height() / 16).toArray());
+        scanChunkInto(pos.x() << 4, pos.z() << 4, ctx.world().dimensionType().minY(), chunk, filter, res, max, yLevelThreshold, playerY, IntStream.range(0, ctx.world().dimensionType().height() / 16).toArray());
         return res;
     }
 

--- a/src/main/java/baritone/event/GameEventHandler.java
+++ b/src/main/java/baritone/event/GameEventHandler.java
@@ -120,7 +120,7 @@ public final class GameEventHandler implements IEventBus, Helper {
                 baritone.getWorldProvider().ifWorldLoaded(worldData -> {
                     final Level world = baritone.getPlayerContext().world();
                     ChunkPos pos = event.getChunkPos();
-                    worldData.getCachedWorld().queueForPacking(world.getChunk(pos.x, pos.z));
+                    worldData.getCachedWorld().queueForPacking(world.getChunk(pos.x(), pos.z()));
                 });
             }
         }

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -221,7 +221,7 @@ public interface MovementHelper extends ActionCosts, Helper {
             }
 
             BlockState up = bsi.get0(x, y + 1, z);
-            if (!up.getFluidState().isEmpty() || up.getBlock() instanceof WaterlilyBlock) {
+            if (!up.getFluidState().isEmpty() || up.getBlock() instanceof LilyPadBlock) {
                 return false;
             }
             return fluidState.getType() instanceof WaterFluid;

--- a/src/main/java/baritone/process/BuilderProcess.java
+++ b/src/main/java/baritone/process/BuilderProcess.java
@@ -1037,10 +1037,8 @@ public final class BuilderProcess extends BaritoneProcessHelper implements IBuil
         if (!ignoreDirection && ignoredProps.isEmpty()) {
             return first.equals(second); // early return if no properties are being ignored
         }
-        Map<Property<?>, Comparable<?>> map1 = first.getValues();
-        Map<Property<?>, Comparable<?>> map2 = second.getValues();
-        for (Property<?> prop : map1.keySet()) {
-            if (map1.get(prop) != map2.get(prop)
+        for (Property<?> prop : first.getProperties()) {
+            if (first.getValue(prop) != second.getValue(prop)
                     && !(ignoreDirection && ORIENTATION_PROPS.contains(prop))
                     && !ignoredProps.contains(prop.getName())) {
                 return false;

--- a/src/main/java/baritone/process/ExploreProcess.java
+++ b/src/main/java/baritone/process/ExploreProcess.java
@@ -225,13 +225,13 @@ public final class ExploreProcess extends BaritoneProcessHelper implements IExpl
             logDirect("Loaded " + positions.length + " positions");
             inFilter = new LongOpenHashSet();
             for (MyChunkPos mcp : positions) {
-                inFilter.add(ChunkPos.asLong(mcp.x, mcp.z));
+                inFilter.add(ChunkPos.pack(mcp.x, mcp.z));
             }
         }
 
         @Override
         public Status isAlreadyExplored(int chunkX, int chunkZ) {
-            if (inFilter.contains(ChunkPos.asLong(chunkX, chunkZ)) ^ invert) {
+            if (inFilter.contains(ChunkPos.pack(chunkX, chunkZ)) ^ invert) {
                 // either it's on the list of explored chunks, or it's not on the list of unexplored chunks
                 // either way, we have it
                 return Status.EXPLORED;

--- a/src/main/java/baritone/process/FarmProcess.java
+++ b/src/main/java/baritone/process/FarmProcess.java
@@ -267,7 +267,7 @@ public final class FarmProcess extends BaritoneProcessHelper implements IFarmPro
             }
             if (state.getBlock() instanceof BonemealableBlock) {
                 BonemealableBlock ig = (BonemealableBlock) state.getBlock();
-                if (ig.isValidBonemealTarget(ctx.world(), pos, state) && ig.isBonemealSuccess(ctx.world(), ctx.world().random, pos, state)) {
+                if (ig.isValidBonemealTarget(ctx.world(), pos, state) && ig.isBonemealSuccess(ctx.world(), ctx.world().getRandom(), pos, state)) {
                     bonemealable.add(pos);
                 }
             }

--- a/src/main/java/baritone/process/elytra/BuildLimitPathFinder.java
+++ b/src/main/java/baritone/process/elytra/BuildLimitPathFinder.java
@@ -157,7 +157,7 @@ public class BuildLimitPathFinder implements IElytraPathFinder {
     }
 
     public boolean isSkyClear(ChunkPos pos, int y) {
-        if(!playerCtx.world().getChunkSource().hasChunk(pos.x, pos.z)) {
+        if(!playerCtx.world().getChunkSource().hasChunk(pos.x(), pos.z())) {
             return false;
         }
 

--- a/src/main/java/baritone/process/elytra/ElytraBehavior.java
+++ b/src/main/java/baritone/process/elytra/ElytraBehavior.java
@@ -42,7 +42,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.projectile.FireworkRocketEntity;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.Fireworks;
@@ -326,7 +326,7 @@ public final class ElytraBehavior implements Helper {
 
             int rangeStartIncl = playerNear;
             int rangeEndExcl = playerNear;
-            while (rangeEndExcl < path.size() && npfContext.hasChunk(new ChunkPos(path.get(rangeEndExcl)))) {
+            while (rangeEndExcl < path.size() && npfContext.hasChunk(ChunkPos.containing(path.get(rangeEndExcl)))) {
                 rangeEndExcl++;
             }
             // rangeEndExcl now represents an index either not in the path, or just outside render distance
@@ -517,7 +517,7 @@ public final class ElytraBehavior implements Helper {
         }
         final long now = System.currentTimeMillis();
         if ((now - this.timeLastCacheCull) / 1000 > Baritone.settings().elytraTimeBetweenCacheCullSecs.value) {
-            npfContext.queueCacheCulling(ctx.player().chunkPosition().x, ctx.player().chunkPosition().z, Baritone.settings().elytraCacheCullDistance.value);
+            npfContext.queueCacheCulling(ctx.player().chunkPosition().x(), ctx.player().chunkPosition().z(), Baritone.settings().elytraCacheCullDistance.value);
             this.timeLastCacheCull = now;
         }
     }
@@ -1302,7 +1302,7 @@ public final class ElytraBehavior implements Helper {
         if (invTickCountdown > 0) invTickCountdown--;
     }
 
-    private void queueWindowClick(int windowId, int slotId, int button, ClickType type) {
+    private void queueWindowClick(int windowId, int slotId, int button, ContainerInput type) {
         invTransactionQueue.add(() -> ctx.playerController().windowClick(windowId, slotId, button, type, ctx.player()));
     }
 
@@ -1332,9 +1332,9 @@ public final class ElytraBehavior implements Helper {
         if (goodElytraSlot != -1) {
             final int CHEST_SLOT = 6;
             final int slotId = goodElytraSlot < 9 ? goodElytraSlot + 36 : goodElytraSlot;
-            queueWindowClick(ctx.player().inventoryMenu.containerId, slotId, 0, ClickType.PICKUP);
-            queueWindowClick(ctx.player().inventoryMenu.containerId, CHEST_SLOT, 0, ClickType.PICKUP);
-            queueWindowClick(ctx.player().inventoryMenu.containerId, slotId, 0, ClickType.PICKUP);
+            queueWindowClick(ctx.player().inventoryMenu.containerId, slotId, 0, ContainerInput.PICKUP);
+            queueWindowClick(ctx.player().inventoryMenu.containerId, CHEST_SLOT, 0, ContainerInput.PICKUP);
+            queueWindowClick(ctx.player().inventoryMenu.containerId, slotId, 0, ContainerInput.PICKUP);
         }
     }
 

--- a/src/main/java/baritone/process/elytra/NetherPathfinderContext.java
+++ b/src/main/java/baritone/process/elytra/NetherPathfinderContext.java
@@ -99,7 +99,7 @@ public final class NetherPathfinderContext implements IElytraPathFinder {
     }
 
     public boolean hasChunk(ChunkPos pos) {
-        return NetherPathfinder.hasChunkFromJava(this.context, pos.x, pos.z);
+        return NetherPathfinder.hasChunkFromJava(this.context, pos.x(), pos.z());
     }
 
     public void queueCacheCulling(int chunkX, int chunkZ, int maxDistanceBlocks) {
@@ -125,7 +125,7 @@ public final class NetherPathfinderContext implements IElytraPathFinder {
                 try {
                     // we might free this chunk
                     this.boi.chunkPtr = 0L;
-                    long ptr = NetherPathfinder.allocateAndInsertChunk(this.context, chunk.getPos().x, chunk.getPos().z);
+                    long ptr = NetherPathfinder.allocateAndInsertChunk(this.context, chunk.getPos().x(), chunk.getPos().z());
                     writeChunkData(chunk, ptr);
                 } finally {
                     writeLock.unlock();
@@ -140,7 +140,7 @@ public final class NetherPathfinderContext implements IElytraPathFinder {
             // not inserting or deleting from the cache hashmap but it would still be bad for this function to race with itself
             writeLock.lock();
             try {
-                long ptr = NetherPathfinder.getChunk(this.context, chunkPos.x, chunkPos.z);
+                long ptr = NetherPathfinder.getChunk(this.context, chunkPos.x(), chunkPos.z());
                 if (ptr == 0) return; // this shouldn't ever happen
                 event.getBlocks().forEach(pair -> {
                     BlockPos pos = pair.first().below(minY);

--- a/src/main/java/baritone/utils/BlockStateInterface.java
+++ b/src/main/java/baritone/utils/BlockStateInterface.java
@@ -109,7 +109,7 @@ public class BlockStateInterface {
             // we can just skip the mc.world.getChunk lookup
             // which is a Long2ObjectOpenHashMap.get
             // see issue #113
-            if (cached != null && cached.getPos().x == x >> 4 && cached.getPos().z == z >> 4) {
+            if (cached != null && cached.getPos().x() == x >> 4 && cached.getPos().z() == z >> 4) {
                 return getFromChunk(cached, x, y, z);
             }
             LevelChunk chunk = provider.getChunk(x >> 4, z >> 4, ChunkStatus.FULL, false);
@@ -141,7 +141,7 @@ public class BlockStateInterface {
 
     public boolean isLoaded(int x, int z) {
         LevelChunk prevChunk = prev;
-        if (prevChunk != null && prevChunk.getPos().x == x >> 4 && prevChunk.getPos().z == z >> 4) {
+        if (prevChunk != null && prevChunk.getPos().x() == x >> 4 && prevChunk.getPos().z() == z >> 4) {
             return true;
         }
         prevChunk = provider.getChunk(x >> 4, z >> 4, ChunkStatus.FULL, false);

--- a/src/main/java/baritone/utils/GuiClick.java
+++ b/src/main/java/baritone/utils/GuiClick.java
@@ -25,7 +25,7 @@ import baritone.api.utils.Helper;
 import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.player.LocalPlayer;
@@ -64,7 +64,7 @@ public class GuiClick extends Screen implements Helper {
     }
 
     @Override
-    public void render(GuiGraphics stack, int mouseX, int mouseY, float partialTicks) {
+    public void extractRenderState(GuiGraphicsExtractor grapics, int mouseX, int mouseY, float partialTicks) {
         double mx = mc.mouseHandler.xpos();
         double my = mc.mouseHandler.ypos();
 
@@ -85,7 +85,7 @@ public class GuiClick extends Screen implements Helper {
     }
 
     @Override
-    public void renderBackground(GuiGraphics stack, int mouseX, int mouseY, float partialTicks) {
+    public void extractBackground(GuiGraphicsExtractor grapics, int mouseX, int mouseY, float partialTicks) {
         // Prevent default background rendering
     }
 

--- a/src/main/java/baritone/utils/IRenderer.java
+++ b/src/main/java/baritone/utils/IRenderer.java
@@ -23,8 +23,10 @@ import baritone.utils.accessor.IEntityRenderManager;
 import baritone.utils.accessor.IRenderPipelines;
 import baritone.utils.accessor.IRenderType;
 import com.mojang.blaze3d.pipeline.BlendFunction;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-import com.mojang.blaze3d.platform.DepthTestFunction;
+import com.mojang.blaze3d.platform.CompareOp;
 import com.mojang.blaze3d.platform.DestFactor;
 import com.mojang.blaze3d.platform.SourceFactor;
 import com.mojang.blaze3d.vertex.*;
@@ -49,13 +51,13 @@ public interface IRenderer {
     IEntityRenderManager renderManager = (IEntityRenderManager) Minecraft.getInstance().getEntityRenderDispatcher();
     Settings settings = BaritoneAPI.getSettings();
     RenderPipeline.Snippet BARITONE_LINES_SNIPPET = RenderPipeline.builder(((IRenderPipelines) new RenderPipelines()).getLinesSnippet())
-        .withBlend(new BlendFunction(
+        .withColorTargetState(new ColorTargetState(new BlendFunction(
             SourceFactor.SRC_ALPHA,
             DestFactor.ONE_MINUS_SRC_ALPHA,
             SourceFactor.ONE,
             DestFactor.ZERO
-        ))
-        .withDepthWrite(false)
+        )))
+        .withDepthStencilState(new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, false))
         .withCull(false)
         .buildSnippet();
 
@@ -68,16 +70,14 @@ public interface IRenderer {
 
     RenderPipeline BEACON_BEAM_OPAQUE = ((IRenderPipelines) new RenderPipelines()).baritone$registerPipeline(RenderPipeline.builder(BARITONE_BEACON_BEAM_SNIPPET)
             .withLocation("pipeline/baritone_beacon_beam_opaque")
-            .withDepthWrite(false)
-            .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
+            .withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, false))
             .withCull(true)
             .build());
 
     RenderPipeline BEACON_BEAM_TRANSLUCENT = ((IRenderPipelines) new RenderPipelines()).baritone$registerPipeline(RenderPipeline.builder(BARITONE_BEACON_BEAM_SNIPPET)
             .withLocation("pipeline/baritone_beacon_beam_translucent")
-            .withDepthWrite(false)
-            .withBlend(BlendFunction.TRANSLUCENT)
-            .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
+            .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
+            .withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, false))
             .withCull(true)
             .build());
 
@@ -85,7 +85,7 @@ public interface IRenderer {
         "renderType/baritone_lines_with_depth",
         RenderSetup.builder(RenderPipeline.builder(BARITONE_LINES_SNIPPET)
             .withLocation("pipelines/baritone_lines_with_depth")
-            .withDepthTestFunction(DepthTestFunction.LEQUAL_DEPTH_TEST)
+            .withDepthStencilState(new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, false))
             .build())
             .bufferSize(256)
             .createRenderSetup()
@@ -94,7 +94,7 @@ public interface IRenderer {
         "renderType/baritone_lines_no_depth",
         RenderSetup.builder(RenderPipeline.builder(BARITONE_LINES_SNIPPET)
                 .withLocation("pipelines/baritone_lines_no_depth")
-                .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
+                .withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, false))
                 .build())
             .bufferSize(256)
             .createRenderSetup()

--- a/src/main/java/baritone/utils/player/BaritonePlayerController.java
+++ b/src/main/java/baritone/utils/player/BaritonePlayerController.java
@@ -26,7 +26,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
@@ -67,8 +67,8 @@ public final class BaritonePlayerController implements IPlayerController {
     }
 
     @Override
-    public void windowClick(int windowId, int slotId, int mouseButton, ClickType type, Player player) {
-        mc.gameMode.handleInventoryMouseClick(windowId, slotId, mouseButton, type, player);
+    public void windowClick(int windowId, int slotId, int mouseButton, ContainerInput type, Player player) {
+        mc.gameMode.handleContainerInput(windowId, slotId, mouseButton, type, player);
     }
 
     @Override

--- a/tweaker/build.gradle
+++ b/tweaker/build.gradle
@@ -97,7 +97,7 @@ jar {
 }
 
 task proguard(type: ProguardTask) {
-    proguardVersion "7.4.2"
+    proguardVersion "7.9.1"
 }
 
 task createDist(type: CreateDistTask, dependsOn: proguard)


### PR DESCRIPTION
To be put on a new branch.

This was done by starting from clean state, but I did compare to #4990 a lot, so adding @fnltochka as a co-author. This pr is nearly the same except it has fewer unrelated changes, is up to date with 1.19.4 code, marks all of the 26.1.x versions as supported and NeoForge is enabled again.

Tested base functionality on all twelve builds for 26.1.2 with NeoForge/LexForge/Fabric.
Tested base functionality on api builds for 26.1.1with NeoForge/LexForge/Fabric.
Tested base functionality on api builds for 26.1 with NeoForge/Fabric, LexForge failed to start even without Baritone.

Goal rendering looks a bit off with goals near the render distance and `elytraAutoJump` seem super unreliable, but both of these problems also exist on 1.21.11 so nothing to do here.

Download via nightly.link: https://nightly.link/cabaletta/baritone/actions/runs/29350927744/Artifacts.zip
Download via GitHub (must be logged in): https://github.com/cabaletta/baritone/actions/runs/29350927744/artifacts/8318277370

<!-- No UwU's or OwO's allowed -->
