### PR TITLE
Don't get stuck on doors as much

### DIFF
--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -155,11 +155,10 @@ public interface MovementHelper extends ActionCosts, Helper {
         if (Baritone.settings().blocksToAvoid.value.contains(block)) {
             return NO;
         }
-        if (block instanceof DoorBlock || block instanceof FenceGateBlock) {
-            // TODO this assumes that all doors in all mods are openable
-            if (block == Blocks.IRON_DOOR) {
-                return NO;
-            }
+        if (block instanceof DoorBlock) {
+            return DoorBlock.isWoodenDoor(state) ? YES : NO;
+        }
+        if (block instanceof FenceGateBlock) {
             return YES;
         }
         if (block instanceof CarpetBlock) {
@@ -779,7 +778,7 @@ public interface MovementHelper extends ActionCosts, Helper {
 
     static boolean openDoors(IPlayerContext ctx, MovementState state, BetterBlockPos from, BetterBlockPos to) {
         for (BetterBlockPos[] poss : new BetterBlockPos[][]{{from, to}, {to, from}, {from.above(), to.above()}, {to.above(), from.above()}}) {
-            if (!isDoorPassable(ctx, poss[0], poss[1]) && !Blocks.IRON_DOOR.equals(BlockStateInterface.getBlock(ctx, poss[0]))) {
+            if (!isDoorPassable(ctx, poss[0], poss[1]) && DoorBlock.isWoodenDoor(BlockStateInterface.get(ctx, poss[0]))) {
                 state.setTarget(new MovementState.MovementTarget(RotationUtils.calcRotationFromVec3d(ctx.playerHead(), VecUtils.calculateBlockCenter(ctx.world(), poss[0]), ctx.playerRotations()), true))
                         .setInput(Input.CLICK_RIGHT, true);
                 return false;

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -37,6 +37,7 @@ import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.piston.MovingPistonBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.DoorHingeSide;
 import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.block.state.properties.StairsShape;
@@ -52,6 +53,7 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import static baritone.api.utils.RotationUtils.DEG_TO_RAD_F;
 import static baritone.pathing.movement.Movement.HORIZONTALS_BUT_ALSO_DOWN_____SO_EVERY_DIRECTION_EXCEPT_UP;
@@ -332,16 +334,24 @@ public interface MovementHelper extends ActionCosts, Helper {
     }
 
     static boolean isDoorPassable(IPlayerContext ctx, BlockPos doorPos, BlockPos playerPos) {
-        if (playerPos.equals(doorPos)) {
-            return false;
-        }
+        Direction dir = Stream.of(Direction.values())
+                .filter(d -> playerPos.relative(d).equals(doorPos))
+                .findFirst()
+                .get();
 
         BlockState state = BlockStateInterface.get(ctx, doorPos);
+
         if (!(state.getBlock() instanceof DoorBlock)) {
             return true;
         }
 
-        return isHorizontalBlockPassable(doorPos, state, playerPos, DoorBlock.OPEN);
+        boolean open = state.getValue(DoorBlock.OPEN);
+        Direction closedFacing = state.getValue(HorizontalDirectionalBlock.FACING);
+        Direction openFacing = state.getValue(DoorBlock.HINGE) == DoorHingeSide.LEFT
+                ? closedFacing.getClockWise()
+                : closedFacing.getCounterClockWise();
+
+        return dir != (open ? openFacing : closedFacing);
     }
 
     static boolean isGatePassable(IPlayerContext ctx, BlockPos gatePos, BlockPos playerPos) {
@@ -355,26 +365,6 @@ public interface MovementHelper extends ActionCosts, Helper {
         }
 
         return state.getValue(FenceGateBlock.OPEN);
-    }
-
-    static boolean isHorizontalBlockPassable(BlockPos blockPos, BlockState blockState, BlockPos playerPos, BooleanProperty propertyOpen) {
-        if (playerPos.equals(blockPos)) {
-            return false;
-        }
-
-        Direction.Axis facing = blockState.getValue(HorizontalDirectionalBlock.FACING).getAxis();
-        boolean open = blockState.getValue(propertyOpen);
-
-        Direction.Axis playerFacing;
-        if (playerPos.north().equals(blockPos) || playerPos.south().equals(blockPos)) {
-            playerFacing = Direction.Axis.Z;
-        } else if (playerPos.east().equals(blockPos) || playerPos.west().equals(blockPos)) {
-            playerFacing = Direction.Axis.X;
-        } else {
-            return true;
-        }
-
-        return (facing == playerFacing) == open;
     }
 
     static boolean avoidWalkingInto(BlockState state) {

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -777,6 +777,17 @@ public interface MovementHelper extends ActionCosts, Helper {
         return false;
     }
 
+    static boolean openDoors(IPlayerContext ctx, MovementState state, BetterBlockPos from, BetterBlockPos to) {
+        for (BetterBlockPos[] poss : new BetterBlockPos[][]{{from, to}, {to, from}, {from.above(), to.above()}, {to.above(), from.above()}}) {
+            if (!isDoorPassable(ctx, poss[0], poss[1]) && !Blocks.IRON_DOOR.equals(BlockStateInterface.getBlock(ctx, poss[0]))) {
+                state.setTarget(new MovementState.MovementTarget(RotationUtils.calcRotationFromVec3d(ctx.playerHead(), VecUtils.calculateBlockCenter(ctx.world(), poss[0]), ctx.playerRotations()), true))
+                        .setInput(Input.CLICK_RIGHT, true);
+                return false;
+            }
+        }
+        return true;
+    }
+
     static PlaceResult attemptToPlaceABlock(MovementState state, IBaritone baritone, BlockPos placeAt, boolean preferDown, boolean wouldSneak) {
         IPlayerContext ctx = baritone.getPlayerContext();
         Optional<Rotation> direct = RotationUtils.reachable(ctx, placeAt, wouldSneak); // we assume that if there is a block there, it must be replacable

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -332,25 +332,14 @@ public interface MovementHelper extends ActionCosts, Helper {
         return state.getMaterial().isReplaceable();
     }
 
-    static boolean isDoorPassable(IPlayerContext ctx, BlockPos doorPos, BlockPos playerPos) {
-        Direction dir = Stream.of(Direction.values())
-                .filter(d -> playerPos.relative(d).equals(doorPos))
-                .findFirst()
-                .get();
-
-        BlockState state = BlockStateInterface.get(ctx, doorPos);
-
-        if (!(state.getBlock() instanceof DoorBlock)) {
-            return true;
-        }
-
+    static boolean isDoorPassable(BlockState state, Direction side) {
         boolean open = state.getValue(DoorBlock.OPEN);
         Direction closedFacing = state.getValue(HorizontalDirectionalBlock.FACING);
         Direction openFacing = state.getValue(DoorBlock.HINGE) == DoorHingeSide.LEFT
                 ? closedFacing.getClockWise()
                 : closedFacing.getCounterClockWise();
 
-        return dir != (open ? openFacing : closedFacing);
+        return side != (open ? openFacing : closedFacing);
     }
 
     static boolean isGatePassable(IPlayerContext ctx, BlockPos gatePos, BlockPos playerPos) {
@@ -777,9 +766,16 @@ public interface MovementHelper extends ActionCosts, Helper {
     }
 
     static boolean openDoors(IPlayerContext ctx, MovementState state, BetterBlockPos from, BetterBlockPos to) {
-        for (BetterBlockPos[] poss : new BetterBlockPos[][]{{from, to}, {to, from}, {from.above(), to.above()}, {to.above(), from.above()}}) {
-            if (!isDoorPassable(ctx, poss[0], poss[1]) && DoorBlock.isWoodenDoor(BlockStateInterface.get(ctx, poss[0]))) {
-                state.setTarget(new MovementState.MovementTarget(RotationUtils.calcRotationFromVec3d(ctx.playerHead(), VecUtils.calculateBlockCenter(ctx.world(), poss[0]), ctx.playerRotations()), true))
+        Direction direction = Stream.of(Direction.values())
+                .filter(d -> from.relative(d).equals(to))
+                .findFirst()
+                .get();
+
+        for (BetterBlockPos pos : new BetterBlockPos[]{from, to, from.above(), to.above()}) {
+            Direction side = pos.equals(to) || pos.equals(to.above()) ? direction : direction.getOpposite();
+            BlockState door = BlockStateInterface.get(ctx, pos);
+            if (DoorBlock.isWoodenDoor(door) && !isDoorPassable(door, side)) {
+                state.setTarget(new MovementState.MovementTarget(RotationUtils.calcRotationFromVec3d(ctx.playerHead(), VecUtils.calculateBlockCenter(ctx.world(), pos), ctx.playerRotations()), true))
                         .setInput(Input.CLICK_RIGHT, true);
                 return false;
             }

--- a/src/main/java/baritone/pathing/movement/movements/MovementAscend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementAscend.java
@@ -173,6 +173,10 @@ public class MovementAscend extends Movement {
             return state.setStatus(MovementStatus.SUCCESS);
         }
 
+        if (!MovementHelper.openDoors(ctx, state, src.above(), dest)) {
+            return state;
+        }
+
         BlockState jumpingOnto = BlockStateInterface.get(ctx, positionToPlace);
         if (!MovementHelper.canWalkOn(ctx, positionToPlace, jumpingOnto)) {
             ticksWithoutPlacement++;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDescend.java
@@ -239,6 +239,11 @@ public class MovementDescend extends Movement {
                 // System.out.println(player().position().y + " " + playerFeet.getY() + " " + (player().position().y - playerFeet.getY()));
             }*/
         }
+
+        if (!MovementHelper.openDoors(ctx, state, src, dest.above())) {
+            return state;
+        }
+
         if (safeMode()) {
             double destX = (src.getX() + 0.5) * 0.17 + (dest.getX() + 0.5) * 0.83;
             double destZ = (src.getZ() + 0.5) * 0.17 + (dest.getZ() + 0.5) * 0.83;

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -29,15 +29,20 @@ import baritone.pathing.movement.MovementState;
 import baritone.utils.BlockStateInterface;
 import baritone.utils.pathing.MutableMoveResult;
 import com.google.common.collect.ImmutableSet;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.DoorBlock;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.DoorHingeSide;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 public class MovementDiagonal extends Movement {
 
@@ -109,7 +114,8 @@ public class MovementDiagonal extends Movement {
     }
 
     public static void cost(CalculationContext context, int x, int y, int z, int destX, int destZ, MutableMoveResult res) {
-        if (!MovementHelper.canWalkThrough(context, destX, y + 1, destZ)) {
+        BlockState destIntoUpper = context.get(destX, y + 1, destZ);
+        if (!MovementHelper.canWalkThrough(context, destX, y + 1, destZ, destIntoUpper)) {
             return;
         }
         BlockState destInto = context.get(destX, y, destZ);
@@ -138,6 +144,10 @@ public class MovementDiagonal extends Movement {
                 }
             }
             frostWalker &= !context.assumeWalkOnWater; // do this after checking for descends because jesus can't prevent the water from freezing, it just prevents us from relying on the water freezing
+        }
+        BlockState startState = context.get(x, y, z);
+        if (isBlockingDoor(startState, x, z, destX, destZ) || isBlockingDoor(ascend ? destIntoUpper : destInto, destX, destZ, x, y)) {
+            return; // Easier to just traverse instead
         }
         double multiplier = WALK_ONE_BLOCK_COST;
         // For either possible soul sand, that affects half of our walking
@@ -170,7 +180,6 @@ public class MovementDiagonal extends Movement {
             return;
         }
         boolean water = false;
-        BlockState startState = context.get(x, y, z);
         Block startIn = startState.getBlock();
         if (MovementHelper.isWater(startState) || MovementHelper.isWater(destInto)) {
             if (ascend) {
@@ -191,6 +200,8 @@ public class MovementDiagonal extends Movement {
             boolean BTop = MovementHelper.canWalkThrough(context, destX, y + 2, z);
             boolean BMid = MovementHelper.canWalkThrough(context, destX, y + 1, z);
             boolean BLow = MovementHelper.canWalkThrough(context, destX, y, z, pb2);
+            ALow &= !isBlockingDoor(pb0, x, destZ, destX, z);
+            BLow &= !isBlockingDoor(pb2, destX, z, x, destZ);
             if ((!(ATop && AMid && ALow) && !(BTop && BMid && BLow)) // no option
                     || MovementHelper.avoidWalkingInto(pb0) // bad
                     || MovementHelper.avoidWalkingInto(pb2) // bad
@@ -208,6 +219,8 @@ public class MovementDiagonal extends Movement {
         }
         double optionA = MovementHelper.getMiningDurationTicks(context, x, y, destZ, pb0, false);
         double optionB = MovementHelper.getMiningDurationTicks(context, destX, y, z, pb2, false);
+        optionA += isBlockingDoor(pb0, x, destZ, destX, z) ? 1 : 0;
+        optionB += isBlockingDoor(pb2, destX, z, x, destZ) ? 1 : 0;
         if (optionA != 0 && optionB != 0) {
             // check these one at a time -- if pb0 and pb2 were nonzero, we already know that (optionA != 0 && optionB != 0)
             // so no need to check pb1 as well, might as well return early here
@@ -271,6 +284,20 @@ public class MovementDiagonal extends Movement {
         } else if (!playerInValidPosition() && !(MovementHelper.isLiquid(ctx, src) && getValidPositions().contains(ctx.playerFeet().above()))) {
             return state.setStatus(MovementStatus.UNREACHABLE);
         }
+
+        if (!isBlockingDoor(BlockStateInterface.get(ctx, new BetterBlockPos(src.x, src.y, dest.z)), src.x, dest.z, dest.x, src.z)
+            && (!MovementHelper.openDoors(ctx, state, src, new BetterBlockPos(src.x, src.y, dest.z))
+                || !MovementHelper.openDoors(ctx, state, new BetterBlockPos(src.x, dest.y, dest.z), dest)
+        )) {
+            return state;
+        }
+        if (!isBlockingDoor(BlockStateInterface.get(ctx, new BetterBlockPos(dest.x, src.y, src.z)), dest.x, src.z, src.x, dest.z)
+            && (!MovementHelper.openDoors(ctx, state, src, new BetterBlockPos(dest.x, src.y, src.z))
+                || !MovementHelper.openDoors(ctx, state, new BetterBlockPos(dest.x, dest.y, src.z), dest)
+        )) {
+            return state;
+        }
+
         if (dest.y > src.y && ctx.player().position().y < src.y + 0.1 && ctx.player().horizontalCollision) {
             state.setInput(Input.JUMP, true);
         }
@@ -327,5 +354,33 @@ public class MovementDiagonal extends Movement {
         }
         toWalkIntoCached = result;
         return toWalkIntoCached;
+    }
+
+    /**
+     * We can always pass wooden doors in src or dest and we can also pass
+     * wooden doors in the A or B columns, unless their hinge points towards
+     * the other column.
+     * This function checks whether {@code other} is the diagonal neighbor of
+     * {@code door} in the direction of the hinge of {@code state}.
+     */
+    private static boolean isBlockingDoor(BlockState state, int doorX, int doorZ, int otherX, int otherZ) {
+        if (!(state.getBlock() instanceof DoorBlock)) {
+            return false;
+        }
+
+        Vec3i offset = state.getValue(HorizontalDirectionalBlock.FACING).getNormal();
+        int ox = offset.getX();
+        int oz = offset.getZ();
+
+        int nbrX, nbrZ;
+        if (state.getValue(DoorBlock.HINGE) == DoorHingeSide.LEFT) {
+            nbrX = doorX - ox + oz;
+            nbrZ = doorZ - oz - ox;
+        } else {
+            nbrX = doorX - ox - oz;
+            nbrZ = doorZ - oz + ox;
+        }
+
+        return nbrX == otherX && nbrZ == otherZ;
     }
 }

--- a/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementDiagonal.java
@@ -176,7 +176,7 @@ public class MovementDiagonal extends Movement {
             return;
         }
         BlockState cuttingOver2 = context.get(destX, y - 1, z);
-        if ((!context.allowWalkOnMagmaBlocks && cuttingOver1.is(Blocks.MAGMA_BLOCK)) || MovementHelper.isLava(cuttingOver2)) {
+        if ((!context.allowWalkOnMagmaBlocks && cuttingOver2.is(Blocks.MAGMA_BLOCK)) || MovementHelper.isLava(cuttingOver2)) {
             return;
         }
         boolean water = false;

--- a/src/main/java/baritone/pathing/movement/movements/MovementFall.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementFall.java
@@ -115,6 +115,11 @@ public class MovementFall extends Movement {
                 }
             }
         }
+
+        if (!MovementHelper.openDoors(ctx, state, src, new BetterBlockPos(dest.x, src.y, dest.z))) {
+            return state;
+        }
+
         if (targetRotation != null) {
             state.setTarget(new MovementTarget(targetRotation, true));
         } else {

--- a/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementParkour.java
@@ -259,6 +259,9 @@ public class MovementParkour extends Movement {
             logDebug("sorry");
             return state.setStatus(MovementStatus.UNREACHABLE);
         }
+        if (!MovementHelper.openDoors(ctx, state, src, src.relative(direction))) {
+            return state;
+        }
         if (dist >= 4 || ascend) {
             state.setInput(Input.SPRINT, true);
         }

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -36,7 +36,6 @@ import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CarpetBlock;
-import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.LadderBlock;
 import net.minecraft.world.level.block.SlabBlock;

--- a/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
+++ b/src/main/java/baritone/pathing/movement/movements/MovementTraverse.java
@@ -223,14 +223,8 @@ public class MovementTraverse extends Movement {
         //sneak may have been set to true in the PREPPING state while mining an adjacent block, but we still want it to be true if the player is about to go on magma
         state.setInput(Input.SNEAK, Baritone.settings().allowWalkOnMagmaBlocks.value && MovementHelper.steppingOnBlocks(ctx).stream().anyMatch(block -> ctx.world().getBlockState(block).is(Blocks.MAGMA_BLOCK)));
 
-        if (pb0.getBlock() instanceof DoorBlock || pb1.getBlock() instanceof DoorBlock) {
-            boolean notPassable = pb0.getBlock() instanceof DoorBlock && !MovementHelper.isDoorPassable(ctx, src, dest) || pb1.getBlock() instanceof DoorBlock && !MovementHelper.isDoorPassable(ctx, dest, src);
-            boolean canOpen = !(Blocks.IRON_DOOR.equals(pb0.getBlock()) || Blocks.IRON_DOOR.equals(pb1.getBlock()));
-
-            if (notPassable && canOpen) {
-                return state.setTarget(new MovementState.MovementTarget(RotationUtils.calcRotationFromVec3d(ctx.playerHead(), VecUtils.calculateBlockCenter(ctx.world(), positionsToBreak[0]), ctx.playerRotations()), true))
-                        .setInput(Input.CLICK_RIGHT, true);
-            }
+        if (!MovementHelper.openDoors(ctx, state, src, dest)) {
+            return state;
         }
 
         if (pb0.getBlock() instanceof FenceGateBlock || pb1.getBlock() instanceof FenceGateBlock) {

--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -30,6 +30,7 @@ import baritone.pathing.calc.AbstractNodeCostSearch;
 import baritone.pathing.movement.CalculationContext;
 import baritone.pathing.movement.Movement;
 import baritone.pathing.movement.MovementHelper;
+import baritone.pathing.movement.MovementState;
 import baritone.pathing.movement.movements.*;
 import baritone.utils.BlockStateInterface;
 import net.minecraft.core.BlockPos;
@@ -466,6 +467,18 @@ public class PathExecutor implements IPathExecutor, Helper {
                     return true;
                 }
                 clearKeys();
+                // we are not ticking the movement, so we gotta do this ourselves
+                BetterBlockPos src = current.getSrc();
+                BetterBlockPos dest = current.getDest();
+                MovementState fakeState = new MovementState();
+                if (!MovementHelper.openDoors(ctx, fakeState, src, new BetterBlockPos(dest.x, src.y, dest.z))) {
+                    boolean forceRotations = fakeState.getTarget().hasToForceRotations();
+                    fakeState.getTarget().getRotation().ifPresent(rotation ->
+                            behavior.baritone.getLookBehavior().updateTarget(rotation, forceRotations));
+                    fakeState.getInputStates().forEach(behavior.baritone.getInputOverrideHandler()::setInputForceState);
+                    fakeState.getInputStates().clear();
+                    return true;
+                }
                 behavior.baritone.getLookBehavior().updateTarget(RotationUtils.calcRotationFromVec3d(ctx.playerHead(), data.getA(), ctx.playerRotations()), false);
                 behavior.baritone.getInputOverrideHandler().setInputForceState(Input.MOVE_FORWARD, true);
                 return true;


### PR DESCRIPTION
Basically everything can open doors next to the source block now. `MovementDiagonal` is a bit hairy, but just making it bail as soon as a door is involved doesn't make it much better, so I left it in. Can yeet it again if you want.

It treats opening doors as a zero cost operation, but as you can see in the video opening multiple doors in a row does take a significant amount of time. This is still an improvement, so I'm fine with it as is and won't bother fixing the costs for now.

Before | After
-|-
<video src="https://github.com/user-attachments/assets/1186dfdb-2b89-4eef-bf1c-1f90452236f3"> | <video src="https://github.com/user-attachments/assets/ddbb778e-02c1-49cd-b47c-9666562f36a4">

Also changed the iron door check to maybe be compatible with other mods.

Also snuck in a typo fix where `MovementDiagonal` checked the wrong block for magma.

Fixes https://github.com/cabaletta/baritone/issues/391

<!-- No UwU's or OwO's allowed -->
