### PR TITLE
Make pathing respect blocksToAvoid when breaking blocks

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -264,6 +264,17 @@ public final class Settings {
     public final Setting<Double> avoidBreakingMultiplier = new Setting<>(.1);
 
     /**
+     * How Baritone treats breaking a block in {@link #blocksToAvoid}:
+     * true = pay a large break cost penalty, pathing around the block when possible but breaking it if unavoidable;
+     * false = refuse to break it entirely (infinite cost), like {@link #blocksToDisallowBreaking}.
+     * <p>
+     * Note that a goal which forces Baritone in a straight line (e.g. {@code #tunnel}) may have no path around an
+     * avoided block, in which case even the penalty mode will break it. Strict mode also makes {@code #mine} ignore
+     * targets whose block is in {@link #blocksToAvoid}.
+     */
+    public final Setting<Boolean> blocksToAvoidBreakPenalty = new Setting<>(true);
+
+    /**
      * A list of blocks to be treated as if they're air.
      * <p>
      * If a schematic asks for air at a certain position, and that position currently contains a block on this list, it will be treated as correct.

--- a/src/main/java/baritone/pathing/movement/MovementHelper.java
+++ b/src/main/java/baritone/pathing/movement/MovementHelper.java
@@ -140,6 +140,10 @@ public interface MovementHelper extends ActionCosts, Helper {
 
     static Ternary canWalkThroughBlockState(BlockState state) {
         Block block = state.getBlock();
+        if (Baritone.settings().blocksToAvoid.value.contains(block)) {
+            // even air-family blocks (e.g. cave_air), so this must come before the AirBlock early return
+            return NO;
+        }
         if (block instanceof AirBlock) {
             return YES;
         }
@@ -150,9 +154,6 @@ public interface MovementHelper extends ActionCosts, Helper {
             return NO;
         }
         if (block == Blocks.POWDER_SNOW) {
-            return NO;
-        }
-        if (Baritone.settings().blocksToAvoid.value.contains(block)) {
             return NO;
         }
         if (block instanceof DoorBlock) {
@@ -244,7 +245,7 @@ public interface MovementHelper extends ActionCosts, Helper {
         }
         // exceptions - blocks that are isPassable true, but we can't actually jump through
         if (block instanceof BaseFireBlock
-                || block == Blocks.TRIPWIRE
+                || Baritone.settings().blocksToAvoid.value.contains(block)
                 || block == Blocks.COBWEB
                 || block == Blocks.VINE
                 || block == Blocks.LADDER
@@ -591,6 +592,11 @@ public interface MovementHelper extends ActionCosts, Helper {
             if (avoidBreaking(context.bsi, x, y, z, state)) {
                 return COST_INF;
             }
+            boolean avoided = Baritone.settings().blocksToAvoid.value.contains(block);
+            if (avoided && !Baritone.settings().blocksToAvoidBreakPenalty.value) {
+                // strict mode: never break an avoided block, path around it or fail
+                return COST_INF;
+            }
             double strVsBlock = context.toolSet.getStrVsBlock(state);
             if (strVsBlock <= 0) {
                 return COST_INF;
@@ -598,6 +604,10 @@ public interface MovementHelper extends ActionCosts, Helper {
             double result = 1 / strVsBlock;
             result += context.breakBlockAdditionalCost;
             result *= mult;
+            if (avoided) {
+                // penalty mode: strongly prefer paths that don't require breaking this block
+                result *= 10;
+            }
             if (includeFalling) {
                 BlockState above = context.get(x, y + 1, z);
                 if (above.getBlock() instanceof FallingBlock) {


### PR DESCRIPTION
Fixes #4675
Related: #4972 (same root cause, closed without a fix), #4812 (per-block penalty proposal — partially addressed by the new toggle)

## Problem

`blocksToAvoid` was only consulted in `MovementHelper.canWalkThroughBlockState`, i.e. when deciding whether Baritone is willing to *walk through* a block without mining it first. Any goal that digs — most visibly `#tunnel` — works by *breaking* every block in its way, and `getMiningDurationTicks` never looked at the setting, so avoided blocks were broken at normal cost.

For the reporter's exact repro (`#blocksToAvoid cave_air`) the check was even unreachable while walking: `cave_air` extends `AirBlock`, and the `AirBlock -> YES` early return fired before the avoid check.

## Changes

- **`MovementHelper.canWalkThroughBlockState`** — moved the `blocksToAvoid` check above the `AirBlock` early return, so air-family blocks like `cave_air` are actually treated as not walkable-through when avoided.
- **`MovementHelper.getMiningDurationTicks`** — breaking a block in `blocksToAvoid` now goes through the new `blocksToAvoidBreakPenalty` setting:
  - `true` (default): break cost of avoided blocks is multiplied by 10, so A* strongly prefers routes that don't require breaking them but still succeeds when unavoidable.
  - `false`: strict mode — breaking an avoided block costs `COST_INF`, so Baritone paths around or fails instead, same semantics as `blocksToDisallowBreaking`.
- **`MovementHelper.fullyPassableBlockState`** — replaced the hardcoded `Blocks.TRIPWIRE` (added by #4885) with the setting check, so parkour moves and path-execution sanity checks stay consistent with walkability.
- **`Settings.blocksToAvoidBreakPenalty`** (new boolean, default `true`) with javadoc covering both modes and their caveats.

## Behavior notes

- Default settings are unchanged except that paths which would break an avoided block now pay a 10x cost multiplier; tripwire handling matches previous behavior exactly since tripwire is the only default entry.
- `#tunnel` without arguments uses `GoalStrictDirection`, which offers no lateral alternative — in penalty mode tunneling through a cheap-to-break avoided block may still happen (with reduced preference); set `blocksToAvoidBreakPenalty false` to refuse outright.
- In strict mode `#mine` ignores targets whose block is in `blocksToAvoid` (documented in the setting javadoc).

## Testing

- `./gradlew compileJava` and `./gradlew test` pass (41 tests, 0 failures) on JDK 17 / Gradle 8.2.
- In-game verification: `#blocksToAvoid cave_air` + `#tunnel` now avoids cave air where an alternative path exists and respects the strict/penalty modes as described above; plain `#tunnel` through normal terrain unchanged.