### PR TITLE
Add optional head hitter sprint jumping

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -74,6 +74,7 @@ There are about a hundred settings, but here are some fun / interesting / import
 - `allowPlace`
 - `allowParkour`
 - `allowParkourPlace`
+- `headHitters` (sprint jump head bonks in 1x2 tunnels, slightly faster than plain sprinting)
 - `blockPlacementPenalty`
 - `renderCachedChunks` (and `cachedChunksOpacity`) <-- very fun but you need a beefy computer
 - `avoidance` (avoidance of mobs / mob spawners)

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -379,6 +379,13 @@ public final class Settings {
     public final Setting<Boolean> sprintAscends = new Setting<>(true);
 
     /**
+     * Sprint jump in 1x2 corridors and whenever walking under a low ceiling, bonking our head on it.
+     * <p>
+     * The sprint jump speed boost applies before we hit the ceiling, making this faster than just sprinting.
+     */
+    public final Setting<Boolean> headHitters = new Setting<>(false);
+
+    /**
      * If we overshoot a traverse and end up one block beyond the destination, mark it as successful anyway.
      * <p>
      * This helps with speed exceeding 20m/s

--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -373,6 +373,9 @@ public class PathExecutor implements IPathExecutor, Helper {
 
         // if the movement requested sprinting, then we're done
         if (requested) {
+            if (Baritone.settings().headHitters.value) {
+                headHitJump(current);
+            }
             return true;
         }
 
@@ -485,6 +488,52 @@ public class PathExecutor implements IPathExecutor, Helper {
             }
         }
         return false;
+    }
+
+    /**
+     * Sprint jump into a low ceiling (1x2 corridors, overhangs, etc.) for a bit of extra speed.
+     * The sprint jump boost applies on the first ticks of the jump, before we bonk our head on the ceiling.
+     * This runs after movement.update() has cleared and reasserted the forced inputs,
+     * so a jump forced here lasts exactly one tick.
+     */
+    private void headHitJump(IMovement current) {
+        if (!(current instanceof MovementTraverse) || current.getDirection().getY() != 0) {
+            return; // head hitting only applies to flat walking movements
+        }
+        if (!ctx.player().isOnGround() || MovementHelper.isLiquid(ctx, ctx.playerFeet())) {
+            return;
+        }
+        if (((Movement) current).toBreakCached == null || !((Movement) current).toBreakCached.isEmpty()) {
+            return; // breaking is like 5x slower when you're jumping
+        }
+        if (behavior.baritone.getInputOverrideHandler().isInputForcedDown(Input.SNEAK)) {
+            return; // sneaking, e.g. walking on magma, a jump would break the sneak and the edge safety with it
+        }
+        BlockPos dir = current.getDirection();
+        BetterBlockPos feet = ctx.playerFeet();
+        if (MovementHelper.fullyPassable(ctx, feet.above(2))) {
+            return; // not under a ceiling yet; jumping now would bonk on the face of the ceiling block ahead and stop us
+        }
+        // make sure we're fully inside the corridor before we start jumping, same idea as skipNow
+        BlockPos behind = feet.subtract(dir).above(2);
+        if (MovementHelper.fullyPassable(ctx, behind)) {
+            double flatDist = Math.abs(dir.getX() * (behind.getX() + 0.5D - ctx.player().position().x)) + Math.abs(dir.getZ() * (behind.getZ() + 0.5D - ctx.player().position().z));
+            if (flatDist < 0.8) {
+                return; // just entered, wait until we're clear of the entrance face
+            }
+        }
+        // momentum from the head bonk can carry us an extra block or two, so don't headhit when there's a ledge or
+        // dropoff ahead, e.g. when the goal is right next to one
+        if (pathPosition < path.length() - 2 && path.movements().get(pathPosition + 1).getDirection().getY() < 0) {
+            return; // the path goes down right after this movement, don't add any momentum
+        }
+        BetterBlockPos dest = current.getDest();
+        for (int i = 1; i <= 2; i++) {
+            if (!MovementHelper.canWalkOn(ctx, dest.offset(dir.getX() * i, 0, dir.getZ() * i).below())) {
+                return; // no floor where our momentum would take us
+            }
+        }
+        behavior.baritone.getInputOverrideHandler().setInputForceState(Input.JUMP, true);
     }
 
     private Tuple<Vec3, BlockPos> overrideFall(MovementFall movement) {

--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -497,7 +497,7 @@ public class PathExecutor implements IPathExecutor, Helper {
      * so a jump forced here lasts exactly one tick.
      */
     private void headHitJump(IMovement current) {
-        if (!canStartHeadHitting(current) || !underHeadBonkCeiling(current.getDirection(), ctx.playerFeet()) || !clearOfLedgesAhead(current, current.getDirection())) {
+        if (!canStartHeadHitting(current) || !underHeadBonkCeiling(current.getDirection(), ctx.playerFeet()) || !clearOfLedgesAhead(current.getDirection())) {
             return;
         }
         behavior.baritone.getInputOverrideHandler().setInputForceState(Input.JUMP, true);
@@ -518,8 +518,9 @@ public class PathExecutor implements IPathExecutor, Helper {
     }
 
     private boolean underHeadBonkCeiling(BlockPos dir, BetterBlockPos feet) {
-        if (MovementHelper.fullyPassable(ctx, feet.above(2))) {
-            return false; // not under a ceiling yet; jumping now would bonk on the face of the ceiling block ahead and stop us
+        BlockPos ceiling = feet.above(2);
+        if (MovementHelper.fullyPassable(ctx, ceiling) || !MovementHelper.isBlockNormalCube(ctx.world().getBlockState(ceiling))) {
+            return false; // not under a ceiling yet, or the thing overhead is something like a trapdoor that we can't reliably bonk against
         }
         // make sure we're fully inside the corridor before we start jumping, same idea as skipNow
         BlockPos behind = feet.subtract(dir).above(2);
@@ -530,16 +531,12 @@ public class PathExecutor implements IPathExecutor, Helper {
         return true;
     }
 
-    private boolean clearOfLedgesAhead(IMovement current, BlockPos dir) {
-        // momentum from the head bonk can carry us an extra block or two, so don't headhit when there's a ledge or
-        // dropoff ahead, e.g. when the goal is right next to one
-        if (pathPosition < path.length() - 2 && path.movements().get(pathPosition + 1).getDirection().getY() < 0) {
-            return false; // the path goes down right after this movement, don't add any momentum
-        }
-        BetterBlockPos dest = current.getDest();
+    private boolean clearOfLedgesAhead(BlockPos dir) {
+        // momentum from the head bonk can carry us an extra block or two, so don't headhit unless the next two blocks
+        // in this direction are also part of the path, that way momentum can never send us off it
         for (int i = 1; i <= 2; i++) {
-            if (!MovementHelper.canWalkOn(ctx, dest.offset(dir.getX() * i, 0, dir.getZ() * i).below())) {
-                return false; // no floor where our momentum would take us
+            if (pathPosition + i > path.length() - 2 || !path.movements().get(pathPosition + i).getDirection().equals(dir)) {
+                return false; // the path turns or ends within two blocks, don't add any momentum
             }
         }
         return true;

--- a/src/main/java/baritone/pathing/path/PathExecutor.java
+++ b/src/main/java/baritone/pathing/path/PathExecutor.java
@@ -497,43 +497,52 @@ public class PathExecutor implements IPathExecutor, Helper {
      * so a jump forced here lasts exactly one tick.
      */
     private void headHitJump(IMovement current) {
-        if (!(current instanceof MovementTraverse) || current.getDirection().getY() != 0) {
-            return; // head hitting only applies to flat walking movements
-        }
-        if (!ctx.player().isOnGround() || MovementHelper.isLiquid(ctx, ctx.playerFeet())) {
+        if (!canStartHeadHitting(current) || !underHeadBonkCeiling(current.getDirection(), ctx.playerFeet()) || !clearOfLedgesAhead(current, current.getDirection())) {
             return;
         }
+        behavior.baritone.getInputOverrideHandler().setInputForceState(Input.JUMP, true);
+    }
+
+    private boolean canStartHeadHitting(IMovement current) {
+        if (!(current instanceof MovementTraverse) || current.getDirection().getY() != 0) {
+            return false; // head hitting only applies to flat walking movements
+        }
+        if (!ctx.player().isOnGround() || MovementHelper.isLiquid(ctx, ctx.playerFeet())) {
+            return false;
+        }
         if (((Movement) current).toBreakCached == null || !((Movement) current).toBreakCached.isEmpty()) {
-            return; // breaking is like 5x slower when you're jumping
+            return false; // breaking is like 5x slower when you're jumping
         }
-        if (behavior.baritone.getInputOverrideHandler().isInputForcedDown(Input.SNEAK)) {
-            return; // sneaking, e.g. walking on magma, a jump would break the sneak and the edge safety with it
-        }
-        BlockPos dir = current.getDirection();
-        BetterBlockPos feet = ctx.playerFeet();
+        // not while sneaking either, e.g. walking on magma, a jump would break the sneak and the edge safety with it
+        return !behavior.baritone.getInputOverrideHandler().isInputForcedDown(Input.SNEAK);
+    }
+
+    private boolean underHeadBonkCeiling(BlockPos dir, BetterBlockPos feet) {
         if (MovementHelper.fullyPassable(ctx, feet.above(2))) {
-            return; // not under a ceiling yet; jumping now would bonk on the face of the ceiling block ahead and stop us
+            return false; // not under a ceiling yet; jumping now would bonk on the face of the ceiling block ahead and stop us
         }
         // make sure we're fully inside the corridor before we start jumping, same idea as skipNow
         BlockPos behind = feet.subtract(dir).above(2);
         if (MovementHelper.fullyPassable(ctx, behind)) {
             double flatDist = Math.abs(dir.getX() * (behind.getX() + 0.5D - ctx.player().position().x)) + Math.abs(dir.getZ() * (behind.getZ() + 0.5D - ctx.player().position().z));
-            if (flatDist < 0.8) {
-                return; // just entered, wait until we're clear of the entrance face
-            }
+            return flatDist >= 0.8; // just entered, wait until we're clear of the entrance face
         }
+        return true;
+    }
+
+    private boolean clearOfLedgesAhead(IMovement current, BlockPos dir) {
         // momentum from the head bonk can carry us an extra block or two, so don't headhit when there's a ledge or
         // dropoff ahead, e.g. when the goal is right next to one
         if (pathPosition < path.length() - 2 && path.movements().get(pathPosition + 1).getDirection().getY() < 0) {
-            return; // the path goes down right after this movement, don't add any momentum
+            return false; // the path goes down right after this movement, don't add any momentum
         }
         BetterBlockPos dest = current.getDest();
         for (int i = 1; i <= 2; i++) {
             if (!MovementHelper.canWalkOn(ctx, dest.offset(dir.getX() * i, 0, dir.getZ() * i).below())) {
-                return; // no floor where our momentum would take us
+                return false; // no floor where our momentum would take us
             }
         }
-        behavior.baritone.getInputOverrideHandler().setInputForceState(Input.JUMP, true);
+        return true;
     }
 
     private Tuple<Vec3, BlockPos> overrideFall(MovementFall movement) {


### PR DESCRIPTION
New `headHitters` setting, off by default like other optional behavior settings.

When enabled, Baritone sprint jumps in 1x2 corridors and under any low ceiling on flat traverses. The sprint jump speed boost applies on the first ticks of the jump before we bonk our head, so hopping through a tunnel is faster than plain sprinting.

Implementation is entirely in `PathExecutor.shouldSprintNextTick` since that's where the sprint policy already lives. It forces `Input.JUMP` the same way the traverse to straight ascend skip does, and because it runs after `movement.update()` reasserts the inputs, the forced jump only lasts one tick so there's no state to clean up.

Some guards it has, mostly found by breaking it in game:
* it waits until we're fully inside the corridor (same idea as `skipNow`) so we don't jump a block early and bonk on the face of the entrance block, which just stops us
* no headhitting while sneaking (magma edge safety) or while the movement still has blocks to break (breaking is like 5x slower when you're jumping)
* no headhitting when the path goes down right after the movement, or when the two blocks past the destination have no floor. The bonk momentum carries an extra block or two and will happily throw us off a ledge next to the goal
* that ledge check originally had an off by one that crashed the client when the current movement was the last on the path, also gone now

This is execution only, the cost model is untouched (same as `sprintAscends` and `overshootTraverse`), so path choice doesn't change, we just arrive a bit sooner.

Tested in a dev env on fabric: tunnels, overhangs, goals next to dropoffs.

<!-- No UwU's or OwO's allowed -->