### PR TITLE
Continue task after reconnect or non-user abort (fixes #1007)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -62,6 +62,7 @@ Commands in Baritone:
 - `reloadall` to reload Baritone's world cache or `saveall` to save Baritone's world cache.
 - `find` to search through Baritone's cache and attempt to find the location of the block.
 - `surface` or `top` to tell Baritone to head towards the closest surface-like area, this can be the surface or highest available air space.
+- `resumelast` to re-run the most recent task command (tunnel, mine, goto, farm, etc.), useful for manually continuing a task after a reconnect or after Baritone stopped on its own. With `resumeOnReconnect` enabled, this happens automatically: if a task was running when you got disconnected, it is re-run `resumeDelayTicks` ticks after you rejoin the same server. The command is re-derived from your position and rotation at that time (so `tunnel` continues in the direction you're facing). A pending resume is discarded if you die, cancel, or start something else.
 - `version` to get the version of Baritone you're running
 - `damn` daniel
 
@@ -86,6 +87,8 @@ There are about a hundred settings, but here are some fun / interesting / import
 - `acceptableThrowawayItems`
 - `blocksToAvoidBreaking`
 - `mineScanDroppedItems`
+- `resumeOnReconnect` and `resumeDelayTicks` (automatically continue the last task after reconnecting)
+- `resumeAfterCalcFailure` and `resumeMaxAttempts` (retry the last task when Baritone aborts it on its own because of unloaded chunks)
 - `allowDiagonalAscend`
 
 # Troubleshooting / common issues

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -1193,6 +1193,44 @@ public final class Settings {
     public final Setting<Boolean> disconnectOnArrival = new Setting<>(false);
 
     /**
+     * Automatically re-run the most recent task command (tunnel, mine, goto, farm, follow, explore, thisway, etc.)
+     * after being disconnected from a server, for example after a connection reset or being kicked by lag.
+     * <p>
+     * The command is re-executed {@link #resumeDelayTicks} ticks after joining a world, and only if a task was
+     * actually running at the moment of the disconnect. Switching dimensions does not count as a disconnect.
+     * Commands that depend on your surroundings at execution time (for example {@code tunnel} uses the direction
+     * you are facing when it runs, and {@code build} without explicit coordinates builds at your feet) are
+     * re-derived from your position and rotation after reconnecting.
+     * <p>
+     * A pending resume is discarded if you die, use {@code cancel} / {@code forcecancel}, set a new goal,
+     * or start a different task before it fires.
+     */
+    public final Setting<Boolean> resumeOnReconnect = new Setting<>(false);
+
+    /**
+     * How many ticks to wait after (re)joining a world before re-running the task command saved by
+     * {@link #resumeOnReconnect}. This delay gives chunks time to load so the resumed task doesn't
+     * immediately fail on unloaded chunks again. Increase this on servers with a join queue.
+     */
+    public final Setting<Integer> resumeDelayTicks = new Setting<>(60);
+
+    /**
+     * Re-run the most recent task command after Baritone cancelled it on its own (not by you) because path
+     * calculation failed repeatedly, which typically happens when chunks ahead are unloaded due to lag.
+     * <p>
+     * To avoid an infinite failure loop, this is limited to {@link #resumeMaxAttempts} consecutive automatic
+     * resumes, each waiting twice as long as the previous one. Any manual command, or a disconnect, resets
+     * the attempt counter.
+     */
+    public final Setting<Boolean> resumeAfterCalcFailure = new Setting<>(false);
+
+    /**
+     * The maximum number of consecutive automatic resumes performed by {@link #resumeAfterCalcFailure}
+     * before giving up until you run a task again.
+     */
+    public final Setting<Integer> resumeMaxAttempts = new Setting<>(3);
+
+    /**
      * Disallow MineBehavior from using X-Ray to see where the ores are. Turn this option on to force it to mine "legit"
      * where it will only mine an ore once it can actually see it, so it won't do or know anything that a normal player
      * couldn't. If you don't want it to look like you're X-Raying, turn this on

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -70,6 +70,7 @@ public class Baritone implements IBaritone {
     private final LookBehavior lookBehavior;
     private final InventoryBehavior inventoryBehavior;
     private final InputOverrideHandler inputOverrideHandler;
+    private final ResumeBehavior resumeBehavior;
 
     private final FollowProcess followProcess;
     private final MineProcess mineProcess;
@@ -109,6 +110,7 @@ public class Baritone implements IBaritone {
             this.pathingBehavior      = this.registerBehavior(PathingBehavior::new);
             this.inventoryBehavior    = this.registerBehavior(InventoryBehavior::new);
             this.inputOverrideHandler = this.registerBehavior(InputOverrideHandler::new);
+            this.resumeBehavior       = this.registerBehavior(ResumeBehavior::new);
             this.registerBehavior(WaypointBehavior::new);
         }
 
@@ -184,6 +186,10 @@ public class Baritone implements IBaritone {
 
     public InventoryBehavior getInventoryBehavior() {
         return this.inventoryBehavior;
+    }
+
+    public ResumeBehavior getResumeBehavior() {
+        return this.resumeBehavior;
     }
 
     @Override

--- a/src/main/java/baritone/behavior/ResumeBehavior.java
+++ b/src/main/java/baritone/behavior/ResumeBehavior.java
@@ -151,7 +151,7 @@ public class ResumeBehavior extends Behavior implements Helper {
             return;
         }
         String label = firstWord(trimmed);
-        if (this.handleInterruptingCommand(trimmed, label)) {
+        if (this.handleInterruptingCommand(label)) {
             return;
         }
         if (!this.isRecordableTaskCommand(trimmed, label)) {
@@ -169,7 +169,7 @@ public class ResumeBehavior extends Behavior implements Helper {
      * resume but keeps the saved command for {@code resumelast}; superseding drops both, since the user has
      * re-pointed Baritone at something else entirely.
      */
-    private boolean handleInterruptingCommand(String trimmed, String label) {
+    private boolean handleInterruptingCommand(String label) {
         if (CANCELLING_COMMANDS.contains(label)) {
             this.clearPendingResume();
             this.userCancelledAtTick = this.tickCounter;

--- a/src/main/java/baritone/behavior/ResumeBehavior.java
+++ b/src/main/java/baritone/behavior/ResumeBehavior.java
@@ -186,22 +186,7 @@ public class ResumeBehavior extends Behavior implements Helper {
 
     @Override
     public void onTick(TickEvent event) {
-        Level world = ctx.world();
-        if (world == null) {
-            // The world is gone. If we came from a world, remember whether the server connection actually
-            // dropped while the world was absent; a dimension change keeps the connection but unloads the
-            // world briefly, and those must not count as a disconnect.
-            if (this.lastTickWorld != null) {
-                this.sawConnectionLossWhileWorldNull |= ctx.minecraft().getConnection() == null;
-            }
-        } else if (this.lastTickWorld == null && this.sawConnectionLossWhileWorldNull) {
-            // The world returned after leaving it without the server connection; a real disconnect+rejoin.
-            // Detected by comparing the world object across ticks instead of listening for WorldEvent(s),
-            // because some servers and mods (proxy reconnects, replaymod, etc.) break those events.
-            this.armResumeOnReconnect();
-            this.sawConnectionLossWhileWorldNull = false;
-        }
-        this.lastTickWorld = world;
+        this.detectDisconnect();
         if (event.getType() != TickEvent.Type.IN) {
             return;
         }
@@ -217,25 +202,54 @@ public class ResumeBehavior extends Behavior implements Helper {
             return;
         }
         if (this.resumeTicksRemaining < 0) {
-            // first in-world tick after the disconnect that armed this resume
-            this.resumeTicksRemaining = Math.max(0, Baritone.settings().resumeDelayTicks.value);
-            logDirect(String.format(
-                    "Resuming \"%s\" in %.1f seconds. Use %scancel to stop it.",
-                    this.pendingResumeCommand,
-                    this.resumeTicksRemaining / 20.0,
-                    BaritoneAPI.getSettings().prefix.value
-            ), ChatFormatting.GRAY);
-            return;
-        }
-        if (this.resumeTicksRemaining > 0) {
+            this.startCountdown();
+        } else if (this.resumeTicksRemaining > 0) {
             this.resumeTicksRemaining--;
-            return;
+        } else if (this.readyToFire()) {
+            this.fireResume();
         }
+    }
+
+    /**
+     * Detects the world unloading by comparing the world object across ticks instead of listening for
+     * WorldEvent(s), because some servers and mods (proxy reconnects, replaymod, etc.) break those events.
+     * A dimension change also unloads the world briefly, but keeps the server connection, so only an
+     * unload during which the connection actually dropped counts as a disconnect.
+     */
+    private void detectDisconnect() {
+        Level world = ctx.world();
+        if (world == null) {
+            if (this.lastTickWorld != null) {
+                this.sawConnectionLossWhileWorldNull |= ctx.minecraft().getConnection() == null;
+            }
+        } else if (this.lastTickWorld == null && this.sawConnectionLossWhileWorldNull) {
+            // the world returned after leaving it without the server connection; a real disconnect + rejoin
+            this.armResumeOnReconnect();
+            this.sawConnectionLossWhileWorldNull = false;
+        }
+        this.lastTickWorld = world;
+    }
+
+    private void startCountdown() {
+        // first in-world tick after the disconnect that armed this resume
+        this.resumeTicksRemaining = Math.max(0, Baritone.settings().resumeDelayTicks.value);
+        logDirect(String.format(
+                "Resuming \"%s\" in %.1f seconds. Use %scancel to stop it.",
+                this.pendingResumeCommand,
+                this.resumeTicksRemaining / 20.0,
+                BaritoneAPI.getSettings().prefix.value
+        ), ChatFormatting.GRAY);
+    }
+
+    /**
+     * @return whether the pending resume may fire this tick, logging the reason and disarming it if not
+     */
+    private boolean readyToFire() {
         if (ctx.player() == null || ctx.world() == null) {
-            return; // not actually in a world yet (e.g. sitting in a join queue); keep waiting
+            return false; // not actually in a world yet (e.g. sitting in a join queue); keep waiting
         }
         if (this.playerWasDead) {
-            return; // onPlayerDeath clears the pending resume; don't act while dead regardless
+            return false; // onPlayerDeath clears the pending resume; don't act while dead regardless
         }
         String serverNow = this.currentServerId();
         // proxy servers can briefly report no server while the world is already loaded; only reject on a
@@ -247,7 +261,7 @@ public class ResumeBehavior extends Behavior implements Helper {
                     this.pendingResumeCommand
             ), ChatFormatting.RED);
             this.clearPendingResume();
-            return;
+            return false;
         }
         if (this.anyTaskProcessActive()) {
             logDirect(String.format(
@@ -255,8 +269,12 @@ public class ResumeBehavior extends Behavior implements Helper {
                     this.pendingResumeCommand
             ), ChatFormatting.RED);
             this.clearPendingResume();
-            return;
+            return false;
         }
+        return true;
+    }
+
+    private void fireResume() {
         String command = this.pendingResumeCommand;
         boolean isAutoResume = this.calcFailureResumeAttempts > 0;
         this.clearPendingResume();

--- a/src/main/java/baritone/behavior/ResumeBehavior.java
+++ b/src/main/java/baritone/behavior/ResumeBehavior.java
@@ -57,7 +57,7 @@ public class ResumeBehavior extends Behavior implements Helper {
 
     /**
      * Selections live in memory across a reconnect and use absolute coordinates, so sel commands that start
-     * filling a schematic (\@code sel set air}, {@code sel ca}, ...) continue the same area when re-run and
+     * filling a schematic ({@code sel set air}, {@code sel ca}, ...) continue the same area when re-run and
      * are recorded like any other task. Subcommands are always the second word, so the aliases here cannot
      * collide with top-level command aliases like cancel's "c".
      */
@@ -150,24 +150,51 @@ public class ResumeBehavior extends Behavior implements Helper {
         if (trimmed.isEmpty()) {
             return;
         }
-        String label = trimmed.split("\\s+", 2)[0].toLowerCase(Locale.US);
+        String label = firstWord(trimmed);
+        if (this.handleInterruptingCommand(trimmed, label)) {
+            return;
+        }
+        if (!this.isRecordableTaskCommand(trimmed, label)) {
+            return;
+        }
+        this.recordTaskCommand(trimmed);
+    }
+
+    private static String firstWord(String command) {
+        return command.split("\\s+", 2)[0].toLowerCase(Locale.US);
+    }
+
+    /**
+     * @return whether the command interrupts the resume state, handling it if so. Cancelling drops a pending
+     * resume but keeps the saved command for {@code resumelast}; superseding drops both, since the user has
+     * re-pointed Baritone at something else entirely.
+     */
+    private boolean handleInterruptingCommand(String trimmed, String label) {
         if (CANCELLING_COMMANDS.contains(label)) {
             this.clearPendingResume();
             this.userCancelledAtTick = this.tickCounter;
-            return;
+            return true;
         }
         if (SUPERSEDING_COMMANDS.contains(label)) {
             this.clearPendingResume();
             this.lastTaskCommand = null;
             this.lastTaskServerId = null;
-            return;
+            return true;
         }
-        if (!TASK_COMMANDS.contains(label) && !isSelFillCommand(trimmed, label)) {
-            return;
+        return false;
+    }
+
+    /**
+     * @return whether the command starts a task that is safe and useful to re-run later
+     */
+    private boolean isRecordableTaskCommand(String trimmed, String label) {
+        if (TASK_COMMANDS.contains(label)) {
+            return !label.equals("build") || isResumableBuildCommand(trimmed);
         }
-        if (label.equals("build") && !isResumableBuildCommand(trimmed)) {
-            return;
-        }
+        return isSelFillCommand(trimmed, label);
+    }
+
+    private void recordTaskCommand(String trimmed) {
         this.lastTaskCommand = trimmed;
         this.lastTaskServerId = this.currentServerId();
         if (this.executingAutoResume) {
@@ -311,7 +338,7 @@ public class ResumeBehavior extends Behavior implements Helper {
         }
         logDirect(String.format("Resuming: %s", command), ChatFormatting.GRAY);
         baritone.getCommandManager().execute(command);
-        if (GOAL_ONLY_COMMANDS.contains(command.split("\\s+", 2)[0].toLowerCase(Locale.US))) {
+        if (GOAL_ONLY_COMMANDS.contains(firstWord(command))) {
             baritone.getCommandManager().execute("path");
         }
     }

--- a/src/main/java/baritone/behavior/ResumeBehavior.java
+++ b/src/main/java/baritone/behavior/ResumeBehavior.java
@@ -56,6 +56,18 @@ public class ResumeBehavior extends Behavior implements Helper {
     ));
 
     /**
+     * Selections live in memory across a reconnect and use absolute coordinates, so sel commands that start
+     * filling a schematic (\@code sel set air}, {@code sel ca}, ...) continue the same area when re-run and
+     * are recorded like any other task. Subcommands are always the second word, so the aliases here cannot
+     * collide with top-level command aliases like cancel's "c".
+     */
+    private static final Set<String> SEL_FILL_ACTIONS = new HashSet<>(Arrays.asList(
+            "set", "fill", "s", "f", "walls", "w", "shell", "shl", "sphere", "sph",
+            "hsphere", "hsph", "cylinder", "cyl", "hcylinder", "hcyl",
+            "cleararea", "ca", "replace", "r", "paste", "p"
+    ));
+
+    /**
      * Commands that only set a goal without starting to path towards it, so a resumed task has to be
      * followed by {@code path} for movement to actually start.
      */
@@ -150,7 +162,7 @@ public class ResumeBehavior extends Behavior implements Helper {
             this.lastTaskServerId = null;
             return;
         }
-        if (!TASK_COMMANDS.contains(label)) {
+        if (!TASK_COMMANDS.contains(label) && !isSelFillCommand(trimmed, label)) {
             return;
         }
         if (label.equals("build") && !isResumableBuildCommand(trimmed)) {
@@ -164,6 +176,22 @@ public class ResumeBehavior extends Behavior implements Helper {
             this.calcFailureResumeAttempts = 0;
         }
         this.clearPendingResume();
+    }
+
+    /**
+     * @return whether this is a {@code sel} (or alias) invocation whose subcommand starts filling a
+     * schematic, like {@code sel ca} or {@code sel set air}. Non-filling sel subcommands (pos1, pos2,
+     * copy, expand, ...) must not overwrite a recorded task, since running them again would do nothing.
+     */
+    private static boolean isSelFillCommand(String rawCommand, String label) {
+        if (!label.equals("sel") && !label.equals("selection") && !label.equals("s")) {
+            return false;
+        }
+        String[] tokens = rawCommand.split("\\s+");
+        if (tokens.length < 2) {
+            return false;
+        }
+        return SEL_FILL_ACTIONS.contains(tokens[1].toLowerCase(Locale.US));
     }
 
     /**

--- a/src/main/java/baritone/behavior/ResumeBehavior.java
+++ b/src/main/java/baritone/behavior/ResumeBehavior.java
@@ -1,0 +1,392 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior;
+
+import baritone.Baritone;
+import baritone.api.BaritoneAPI;
+import baritone.api.event.events.PathEvent;
+import baritone.api.event.events.TickEvent;
+import baritone.api.event.events.WorldEvent;
+import baritone.api.event.events.type.EventState;
+import baritone.api.process.IBaritoneProcess;
+import baritone.api.utils.Helper;
+import net.minecraft.ChatFormatting;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.storage.LevelResource;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Records the most recent task-starting command and re-executes it after a non-user-initiated interruption.
+ * <p>
+ * This continues long running tasks after being disconnected from the server (issue #1007), and optionally
+ * after Baritone cancelled a task on its own because path calculation kept failing on unloaded chunks
+ * (issue #1022). The command line is remembered rather than the process itself, because process state holds
+ * world-dependent objects that go stale on disconnect, while the command re-derives everything it needs
+ * (position, facing direction, inventory) from the world at execution time. The server preserves the player's
+ * rotation across a reconnect, so direction dependent commands like {@code tunnel} continue the same way.
+ */
+public class ResumeBehavior extends Behavior implements Helper {
+
+    /**
+     * Commands that start a task worth resuming.
+     */
+    private static final Set<String> TASK_COMMANDS = new HashSet<>(Arrays.asList(
+            "tunnel", "mine", "goto", "farm", "follow", "explore", "come",
+            "thisway", "forward", "axis", "highway", "surface", "top", "litematica", "build"
+    ));
+
+    /**
+     * Commands that only set a goal without starting to path towards it, so a resumed task has to be
+     * followed by {@code path} for movement to actually start.
+     */
+    private static final Set<String> GOAL_ONLY_COMMANDS = new HashSet<>(Arrays.asList(
+            "thisway", "forward", "axis", "highway"
+    ));
+
+    /**
+     * Commands that signal the user changed their mind about what Baritone should be doing. These drop both
+     * a pending resume and the saved command, so a stale task never fires after the new intent.
+     */
+    private static final Set<String> SUPERSEDING_COMMANDS = new HashSet<>(Arrays.asList(
+            "goal", "invert"
+    ));
+
+    /**
+     * Commands that stop Baritone. These drop a pending resume, but keep the saved command so that
+     * {@code #resumelast} can still be used deliberately.
+     */
+    private static final Set<String> CANCELLING_COMMANDS = new HashSet<>(Arrays.asList(
+            "cancel", "c", "stop", "forcecancel"
+    ));
+
+    /**
+     * How long after the user ran a cancel command an abort is still considered user-initiated even if a path
+     * calculation had just failed, since the two often coincide when a task runs into unloaded chunks.
+     */
+    private static final int USER_CANCEL_GRACE_TICKS = 100;
+
+    /**
+     * How many ticks a task process may have been inactive at most when the world unloads for a disconnect
+     * to count as interrupting it. Ticks stop advancing while the client is frozen, so this window is safe
+     * even when the disconnect itself takes a while.
+     */
+    private static final int RECENTLY_ACTIVE_TICKS = 10;
+
+    /**
+     * How many ticks before the process in control gives up a {@link PathEvent#CALC_FAILED} still counts as
+     * the cause. A tick of slack is needed for processes that return a command on the tick they fail and
+     * only disappear from control on the next one.
+     */
+    private static final int CALC_FAILURE_WINDOW_TICKS = 2;
+
+    /**
+     * The backoff of {@code resumeAfterCalcFailure} retries is capped at this many ticks (20 minutes).
+     */
+    private static final int MAX_BACKOFF_TICKS = 24000;
+
+    private String lastTaskCommand;
+    private String lastTaskServerId;
+    private String pendingResumeCommand;
+    private String pendingResumeServerId;
+    private int resumeTicksRemaining = -1; // -1 = armed with no countdown yet, otherwise counting down
+    private int calcFailureResumeAttempts;
+    private int userCancelledAtTick = -1000;
+    private int lastCalcFailureTick = -1000;
+    private int lastTaskActiveTick = -1000;
+    private int tickCounter;
+    private boolean playerWasDead;
+    private boolean executingAutoResume;
+    private IBaritoneProcess inControlPreviousTick;
+    private Level lastTickWorld;
+    private boolean sawConnectionLossWhileWorldNull;
+
+    public ResumeBehavior(Baritone baritone) {
+        super(baritone);
+    }
+
+    /**
+     * Called by {@code CommandManager} for every executed command. Records task-starting commands and
+     * handles the commands that cancel or supersede a resume.
+     *
+     * @param rawCommand the executed command as it was typed, without the prefix
+     */
+    public void recordCandidate(String rawCommand) {
+        if (rawCommand == null) {
+            return;
+        }
+        String trimmed = rawCommand.trim();
+        if (trimmed.isEmpty()) {
+            return;
+        }
+        String label = trimmed.split("\\s+", 2)[0].toLowerCase(Locale.US);
+        if (CANCELLING_COMMANDS.contains(label)) {
+            this.clearPendingResume();
+            this.userCancelledAtTick = this.tickCounter;
+            return;
+        }
+        if (SUPERSEDING_COMMANDS.contains(label)) {
+            this.clearPendingResume();
+            this.lastTaskCommand = null;
+            this.lastTaskServerId = null;
+            return;
+        }
+        if (!TASK_COMMANDS.contains(label)) {
+            return;
+        }
+        if (label.equals("build") && !isResumableBuildCommand(trimmed)) {
+            return;
+        }
+        this.lastTaskCommand = trimmed;
+        this.lastTaskServerId = this.currentServerId();
+        if (this.executingAutoResume) {
+            this.executingAutoResume = false; // re-recording our own retry must not reset the attempt count
+        } else {
+            this.calcFailureResumeAttempts = 0;
+        }
+        this.clearPendingResume();
+    }
+
+    /**
+     * A {@code build} command is only safe to resume if it includes absolute coordinates. Re-running
+     * {@code build <file>} or a build with relative coordinates after reconnecting would start a second
+     * copy of the schematic at the player's new position instead of continuing the old one.
+     */
+    private static boolean isResumableBuildCommand(String rawCommand) {
+        String[] tokens = rawCommand.split("\\s+");
+        if (tokens.length < 5) { // build <file> <x> <y> <z>
+            return false;
+        }
+        for (int i = 2; i < 5; i++) {
+            if (tokens[i].startsWith("~")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void onTick(TickEvent event) {
+        Level world = ctx.world();
+        if (world == null) {
+            // The world is gone. If we came from a world, remember whether the server connection actually
+            // dropped while the world was absent; a dimension change keeps the connection but unloads the
+            // world briefly, and those must not count as a disconnect.
+            if (this.lastTickWorld != null) {
+                this.sawConnectionLossWhileWorldNull |= ctx.minecraft().getConnection() == null;
+            }
+        } else if (this.lastTickWorld == null && this.sawConnectionLossWhileWorldNull) {
+            // The world returned after leaving it without the server connection; a real disconnect+rejoin.
+            // Detected by comparing the world object across ticks instead of listening for WorldEvent(s),
+            // because some servers and mods (proxy reconnects, replaymod, etc.) break those events.
+            this.armResumeOnReconnect();
+            this.sawConnectionLossWhileWorldNull = false;
+        }
+        this.lastTickWorld = world;
+        if (event.getType() != TickEvent.Type.IN) {
+            return;
+        }
+        this.tickCounter++;
+        if (ctx.player() != null) {
+            this.playerWasDead = !ctx.player().isAlive();
+        }
+        if (this.anyTaskProcessActive()) {
+            this.lastTaskActiveTick = this.tickCounter;
+        }
+        this.detectCalcFailureAbort();
+        if (this.pendingResumeCommand == null) {
+            return;
+        }
+        if (this.resumeTicksRemaining < 0) {
+            // first in-world tick after the disconnect that armed this resume
+            this.resumeTicksRemaining = Math.max(0, Baritone.settings().resumeDelayTicks.value);
+            logDirect(String.format(
+                    "Resuming \"%s\" in %.1f seconds. Use %scancel to stop it.",
+                    this.pendingResumeCommand,
+                    this.resumeTicksRemaining / 20.0,
+                    BaritoneAPI.getSettings().prefix.value
+            ), ChatFormatting.GRAY);
+            return;
+        }
+        if (this.resumeTicksRemaining > 0) {
+            this.resumeTicksRemaining--;
+            return;
+        }
+        if (ctx.player() == null || ctx.world() == null) {
+            return; // not actually in a world yet (e.g. sitting in a join queue); keep waiting
+        }
+        if (this.playerWasDead) {
+            return; // onPlayerDeath clears the pending resume; don't act while dead regardless
+        }
+        String serverNow = this.currentServerId();
+        // proxy servers can briefly report no server while the world is already loaded; only reject on a
+        // provable mismatch, never on a null (unknown) identity
+        if (serverNow != null && this.pendingResumeServerId != null
+                && !Objects.equals(this.pendingResumeServerId, serverNow)) {
+            logDirect(String.format(
+                    "Not resuming \"%s\" because a different server or world was joined.",
+                    this.pendingResumeCommand
+            ), ChatFormatting.RED);
+            this.clearPendingResume();
+            return;
+        }
+        if (this.anyTaskProcessActive()) {
+            logDirect(String.format(
+                    "Not resuming \"%s\" because another task is already active.",
+                    this.pendingResumeCommand
+            ), ChatFormatting.RED);
+            this.clearPendingResume();
+            return;
+        }
+        String command = this.pendingResumeCommand;
+        boolean isAutoResume = this.calcFailureResumeAttempts > 0;
+        this.clearPendingResume();
+        if (isAutoResume) {
+            this.executingAutoResume = true;
+        }
+        logDirect(String.format("Resuming: %s", command), ChatFormatting.GRAY);
+        baritone.getCommandManager().execute(command);
+        if (GOAL_ONLY_COMMANDS.contains(command.split("\\s+", 2)[0].toLowerCase(Locale.US))) {
+            baritone.getCommandManager().execute("path");
+        }
+    }
+
+    @Override
+    public void onPathEvent(PathEvent event) {
+        if (event == PathEvent.CALC_FAILED) {
+            this.lastCalcFailureTick = this.tickCounter;
+        }
+    }
+
+    @Override
+    public void onWorldEvent(WorldEvent event) {
+        if (event.getState() == EventState.POST && event.getWorld() == null) {
+            // same arming path as the tick-based detection; both may fire, so this must be idempotent
+            this.armResumeOnReconnect();
+        }
+    }
+
+    /**
+     * Arms a pending resume if a task was interrupted by the world unloading under it. Must be safe to call
+     * multiple times for the same disconnect.
+     */
+    private void armResumeOnReconnect() {
+        if (!Baritone.settings().resumeOnReconnect.value
+                || this.playerWasDead
+                || this.lastTaskCommand == null
+                || this.pendingResumeCommand != null
+                || this.tickCounter - this.lastTaskActiveTick > RECENTLY_ACTIVE_TICKS
+                || this.tickCounter - this.userCancelledAtTick <= RECENTLY_ACTIVE_TICKS) {
+            return;
+        }
+        this.pendingResumeCommand = this.lastTaskCommand;
+        this.pendingResumeServerId = this.lastTaskServerId;
+        this.resumeTicksRemaining = -1; // the countdown starts once we are back in a world
+        this.calcFailureResumeAttempts = 0; // a fresh connection gets a fresh retry budget
+        logDirect(String.format(
+                "Ready to resume \"%s\" after reconnecting.",
+                this.pendingResumeCommand
+        ), ChatFormatting.GRAY);
+    }
+
+    @Override
+    public void onPlayerDeath() {
+        this.clearPendingResume();
+    }
+
+    /**
+     * Arms a resume when the process that was in control gave up by itself right after a path calculation
+     * failure, which is what happens when a task runs into unloaded chunks. A doubling delay and
+     * {@code resumeMaxAttempts} bound the retries so a genuinely impossible task doesn't loop forever.
+     */
+    private void detectCalcFailureAbort() {
+        IBaritoneProcess inControlNow = baritone.getPathingControlManager().mostRecentInControl().orElse(null);
+        if (Baritone.settings().resumeAfterCalcFailure.value
+                && this.tickCounter - this.lastCalcFailureTick <= CALC_FAILURE_WINDOW_TICKS
+                && inControlNow == null
+                && this.inControlPreviousTick != null
+                && !this.inControlPreviousTick.isTemporary()
+                && !this.inControlPreviousTick.isActive()
+                && this.tickCounter - this.userCancelledAtTick >= USER_CANCEL_GRACE_TICKS
+                && this.lastTaskCommand != null
+                && this.calcFailureResumeAttempts < Baritone.settings().resumeMaxAttempts.value) {
+            int delay = Math.max(0, Baritone.settings().resumeDelayTicks.value);
+            for (int i = 0; i < Math.min(this.calcFailureResumeAttempts, 16) && delay < MAX_BACKOFF_TICKS; i++) {
+                delay = (int) Math.min((long) delay * 2, MAX_BACKOFF_TICKS);
+            }
+            this.pendingResumeCommand = this.lastTaskCommand;
+            this.pendingResumeServerId = this.lastTaskServerId;
+            this.resumeTicksRemaining = delay;
+            this.calcFailureResumeAttempts++;
+            logDirect(String.format(
+                    "Task \"%s\" aborted after a path calculation failure. Retrying (attempt %d/%d) in %.1f seconds.",
+                    this.pendingResumeCommand,
+                    this.calcFailureResumeAttempts,
+                    Baritone.settings().resumeMaxAttempts.value,
+                    delay / 20.0
+            ), ChatFormatting.GRAY);
+        }
+        this.inControlPreviousTick = inControlNow;
+    }
+
+    private boolean anyTaskProcessActive() {
+        return baritone.getCustomGoalProcess().isActive()
+                || baritone.getBuilderProcess().isActive()
+                || baritone.getMineProcess().isActive()
+                || baritone.getGetToBlockProcess().isActive()
+                || baritone.getFollowProcess().isActive()
+                || baritone.getExploreProcess().isActive()
+                || baritone.getFarmProcess().isActive()
+                || baritone.getElytraProcess().isActive();
+    }
+
+    /**
+     * @return an identifier of the currently connected server or singleplayer world, or {@code null} if there
+     * is none. Used to make sure a pending resume only fires where the task was running.
+     */
+    private String currentServerId() {
+        if (ctx.minecraft().getSingleplayerServer() != null) {
+            return "singleplayer:" + ctx.minecraft().getSingleplayerServer().getWorldPath(LevelResource.ROOT);
+        }
+        return ctx.minecraft().getCurrentServer() == null ? null : ctx.minecraft().getCurrentServer().ip;
+    }
+
+    public void clearPendingResume() {
+        this.pendingResumeCommand = null;
+        this.pendingResumeServerId = null;
+        this.resumeTicksRemaining = -1;
+    }
+
+    /**
+     * @return the most recent recorded task command, without the prefix, or {@code null} if none was recorded
+     */
+    public String getLastTaskCommand() {
+        return this.lastTaskCommand;
+    }
+
+    /**
+     * @return whether a resume is currently armed and waiting to fire
+     */
+    public boolean isResumePending() {
+        return this.pendingResumeCommand != null;
+    }
+}

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -47,6 +47,7 @@ public final class DefaultCommands {
                 new ComeCommand(baritone),
                 new AxisCommand(baritone),
                 new ForceCancelCommand(baritone),
+                new ResumeLastCommand(baritone),
                 new GcCommand(baritone),
                 new InvertCommand(baritone),
                 new TunnelCommand(baritone),

--- a/src/main/java/baritone/command/defaults/ResumeLastCommand.java
+++ b/src/main/java/baritone/command/defaults/ResumeLastCommand.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.Baritone;
+import baritone.api.IBaritone;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.exception.CommandException;
+import baritone.api.command.exception.CommandInvalidStateException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ResumeLastCommand extends Command {
+
+    public ResumeLastCommand(IBaritone baritone) {
+        super(baritone, "resumelast", "rl");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        args.requireMax(0);
+        String lastTaskCommand = ((Baritone) baritone).getResumeBehavior().getLastTaskCommand();
+        if (lastTaskCommand == null) {
+            throw new CommandInvalidStateException("No task command has been recorded yet");
+        }
+        logDirect(String.format("Re-running: %s", lastTaskCommand));
+        baritone.getCommandManager().execute(lastTaskCommand);
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) {
+        return Stream.empty();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Re-runs the last task command";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "The resumelast command re-runs the most recent task command (tunnel, mine, goto, farm, ...)",
+                "that Baritone recorded. This is useful to manually continue a task after a reconnect or after",
+                "Baritone stopped on its own, for example when it ran into unloaded chunks.",
+                "",
+                "Note that direction and position dependent commands (like tunnel or thisway) are re-derived",
+                "from where you are and which way you are looking when this runs.",
+                "",
+                "Usage:",
+                "> resumelast"
+        );
+    }
+}

--- a/src/main/java/baritone/command/manager/CommandManager.java
+++ b/src/main/java/baritone/command/manager/CommandManager.java
@@ -80,6 +80,11 @@ public class CommandManager implements ICommandManager {
 
     @Override
     public boolean execute(Tuple<String, List<ICommandArgument>> expanded) {
+        // reconstruct the command as it was typed for the resume recorder; the raw rest of the first
+        // argument is the remainder of the original string, so this is byte-faithful
+        String rawCommand = expanded.getA()
+                + (expanded.getB().isEmpty() ? "" : " " + expanded.getB().get(0).getRawRest());
+        this.baritone.getResumeBehavior().recordCandidate(rawCommand);
         ExecutionWrapper execution = this.from(expanded);
         if (execution != null) {
             execution.execute();


### PR DESCRIPTION
Fixes #1007, also addresses #421, #1022, #3926, and the reconnect variants #1544 / #1710 / #1711 / #2852 / #3250 / #3858.

## What this does

Records the most recent task-starting command (`tunnel`, `mine`, `goto`, `farm`, `follow`, `explore`, `come`, `thisway`, `axis`, `surface`, `litematica`, and `build` with absolute coordinates only) and re-executes it `resumeDelayTicks` ticks after rejoining the same server if a task was interrupted by a disconnect. The command line is remembered rather than the process — previous attempts (see 5HT2's comments on #1007) failed saving the process object because it holds stale world references, while the command re-derives everything (position, facing, inventory) from the world at execution time. The server preserves player rotation across a reconnect, so `tunnel` continues in the same direction, which is the behavior #1007 asked for.

`resumelast` (alias `rl`) manually re-runs the last recorded task, covering the build-resume use cases from the duplicate issues.

Opt-in `resumeAfterCalcFailure` retries a task that Baritone aborted on its own after repeated path calculation failures (running into unloaded chunks, #1022/#3926), with doubling backoff bounded by `resumeMaxAttempts`.

## Implementation notes

- **Disconnect detection does not use `WorldEvent`.** On some proxied servers the event does not fire on disconnect — the same reason `WorldProvider` has `detectAndHandleBrokenLoading` ("Some mods break the event. Lol."). Instead the world object and server connection are compared across ticks: world gone + connection gone = disconnect; world gone + connection alive = dimension change and never arms a resume.
- A pending resume is discarded on death, `cancel`/`forcecancel`, setting a new goal, starting another task, or joining a different server. `cancel` keeps the recorded command so `resumelast` still works.
- All four new settings (`resumeOnReconnect`, `resumeDelayTicks`, `resumeAfterCalcFailure`, `resumeMaxAttempts`) default off, so there is no behavior change unless the user enables it.
- `build` is only recorded when given absolute coordinates; re-running a feet-relative build after reconnecting would duplicate the schematic instead of continuing it.

## Testing

Built with `./gradlew build` (fabric). Tested in-game on 1.19.4: task interrupted by disconnect on an anarchy server behind a proxy (the environment where the event-based approach failed) resumes after the configured delay; dimension change does not trigger; death and cancel suppress it; `resumelast` re-runs the recorded command.