### PR TITLE
Fix #resume unpausing the builder when reporting Not paused

### DIFF
--- a/src/main/java/baritone/command/defaults/ExecutionControlCommands.java
+++ b/src/main/java/baritone/command/defaults/ExecutionControlCommands.java
@@ -117,10 +117,10 @@ public class ExecutionControlCommands {
             @Override
             public void execute(String label, IArgConsumer args) throws CommandException {
                 args.requireMax(0);
-                baritone.getBuilderProcess().resume();
-                if (!paused[0]) {
+                if (!paused[0] && !baritone.getBuilderProcess().isPaused()) {
                     throw new CommandInvalidStateException("Not paused");
                 }
+                baritone.getBuilderProcess().resume();
                 paused[0] = false;
                 logDirect("Resumed");
             }


### PR DESCRIPTION
## Changes

Fixes #5101

The `resume` command in `ExecutionControlCommands` had two interacting bugs:

1. `builderProcess.resume()` was called **before** the `Not paused` check, so the error path still unpaused the builder as a side effect.
2. The check only inspected the user-pause flag (`paused[0]`), ignoring `BuilderProcess`'s own sticky pause (`isPaused()`), which is set when the builder gives up on a placement (`Unable to do it. Pausing. resume to resume`) or is paused externally — which is what happens when Litematica's Baritone integration stops a build (reported there as an "Out Of Blocks" stop).

So when the builder was self-paused, `#resume` resumed the task (the "task continues anyway" part of the issue) while still printing `Not paused`. And when genuinely nothing was paused, it unpaused the builder silently.

## Behavior after this change

- `#resume` prints `Not paused` **only** when neither the user pause nor the builder self-pause is set, and no longer has side effects in that case.
- `#resume` now correctly resumes a builder that paused itself (or was paused externally) and prints `Resumed`.

This matches the behavior the issue requested: either `Resumed` or a suppressed `Not paused`, with the task continuing.

## Testing

- `./gradlew compileJava` passes (JDK 17).
- Manual reasoning over the three states: user-paused, builder self-paused, nothing paused. The build has no automated tests covering the command layer; verification steps from the issue (Litematica build hitting "Unable to do it. Pausing.", then `#resume`) now print `Resumed` and continue without the contradictory message.